### PR TITLE
v0.3.1: IDE polish, auto-pairs, build fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-unknown-linux-musl
+
+    - name: Install musl toolchain
+      run: sudo apt-get install -y musl-tools
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -54,12 +59,12 @@ jobs:
     - name: Build release binaries
       run: |
         cargo build --release --bin vimcode
-        cargo build --release --bin vcd --no-default-features
+        cargo build --release --bin vcd --no-default-features --target x86_64-unknown-linux-musl
 
     - name: Strip binaries
       run: |
         strip target/release/vimcode
-        strip target/release/vcd
+        strip target/x86_64-unknown-linux-musl/release/vcd
 
     # ── .deb package ──────────────────────────────────────────────────────────
     - name: Install cargo-deb
@@ -78,7 +83,7 @@ jobs:
     - name: Prepare raw binary artifacts
       run: |
         cp target/release/vimcode vimcode-linux-x86_64
-        cp target/release/vcd vcd-linux-x86_64
+        cp target/x86_64-unknown-linux-musl/release/vcd vcd-linux-x86_64
         echo "BIN_NAME=vimcode-linux-x86_64" >> $GITHUB_ENV
         echo "TUI_BIN_NAME=vcd-linux-x86_64" >> $GITHUB_ENV
 
@@ -106,12 +111,12 @@ jobs:
           ./vimcode-linux-x86_64
           ```
 
-          **Option C — TUI-only binary (no GTK required)**
+          **Option C — TUI-only binary (no GTK required, statically linked)**
           ```
           chmod +x vcd-linux-x86_64
           ./vcd-linux-x86_64
           ```
-          No GTK4 or other GUI libraries needed — works on headless servers.
+          Statically linked with musl — runs on any Linux (Ubuntu 20.04+, CentOS 7+, Alpine, etc.). No GTK4 or other libraries needed.
 
           **Option D — Flatpak** (see attached `vimcode.flatpak` asset)
           ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vimcode"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Vim-like code editor with GTK4 and tree-sitter"
 license = "MIT"

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,6 +5,7 @@
 ---
 
 ## Recently Completed
+- **Session 156**: IDE Polish — indent guides (vertical lines at tabstops, active guide highlight, blank line bridging), bracket pair highlighting (matching `(){}[]` background color), auto-close brackets/quotes (skip-over, pair backspace, smart quote context), 3 new settings + theme colors across all 4 themes, GTK+TUI rendering, 29 tests
 - **Session 155**: Core Commentary Feature — unified comment toggling into `src/core/comment.rs` (46+ language table, two-pass algorithm, override chain), `:Comment`/`:Commentary` commands, `vimcode.set_comment_style()` plugin API, Ctrl+/ fix for GTK+TUI, VSCode Ctrl+Q/F10, 19+31 tests
 - **Session 154**: Keymaps editor in settings panel — `BufferEditor` setting type, scratch buffer with validation, `:Keymaps` command, GTK button + TUI display, 11 tests
 - **Session 153**: Richer Lua Plugin API + VimCode Commentary + User Keymaps — Extended plugin API (cursor write, settings access, state queries, buffer insert/delete, register write, 7 new autocmd events, `set_mode()` refactor, visual/command keymap fallbacks); VimCode Commentary bundled extension (gcc/gc/`:Commentary`, 40+ language comment strings, undo support); plugin `set_lines` undo fix; user-configurable keymaps in settings.json (`"mode keys :command"` format, multi-key sequences, override built-in keys, `{count}` substitution); 22 + 17 + 13 = 52 new tests (2801 total)

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Mar 9, 2026 (Session 155 — Core Commentary Feature) | **Tests:** 2908
+**Last updated:** Mar 9, 2026 (Session 156 — IDE Polish: Indent Guides, Bracket Matching, Auto-Pairs) | **Tests:** 2937
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 154 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,9 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 156 — IDE Polish: Indent Guides, Bracket Matching, Auto-Pairs (2937 tests):**
+Three visual/editing polish features: (1) **Indent guides** — vertical `│` lines at each tabstop in TUI, thin Cairo lines in GTK; controlled by `indent_guides` setting (default on); active guide at cursor scope highlighted brighter; blank lines bridge surrounding indent levels. (2) **Bracket pair highlighting** — when cursor is on `(){}[]`, both brackets get a distinct background (`bracket_match_bg` theme color); `bracket_match` field on Engine updated at end of `handle_key()`; `match_brackets` setting (default on). (3) **Auto-close brackets/quotes** — typing `([{"'\`` in Insert mode inserts matching closer with cursor between; typing closer when next char matches skips over it; Backspace between a pair deletes both; smart context for quotes (only pair after whitespace/brackets/BOL); `auto_pairs` setting (default on). All three features have `:set` toggle support, settings UI entries, and theme colors across all 4 built-in themes. 29 integration tests in `tests/ide_polish.rs`.
 
 **Session 155 — Core Commentary Feature (2908 tests):**
 Unified comment toggling from three separate implementations (Lua plugin, Rust `toggle_comment_range()`, Rust `vscode_toggle_line_comment()`) into a single core module `src/core/comment.rs`. New `CommentStyle`/`CommentStyleOwned` types, `comment_style_for_language()` table covering 46+ languages (including block comments for HTML/CSS/XML), two-pass `compute_toggle_edits()` algorithm, `resolve_comment_style()` override chain (plugin → extension manifest → built-in → fallback `#`). Added `CommentConfig` to `ExtensionManifest` in `extensions.rs`. New `toggle_comment()` method on Engine replaces old `toggle_comment_range()` and `vscode_toggle_line_comment()`. Rewired `gcc`, visual `gc`, and VSCode `Ctrl+/` to use the new core. Added `:Comment` command (`:Commentary` kept as alias). Plugin API: `vimcode.set_comment_style(lang_id, {line, block_open, block_close})`. Fixed Ctrl+/ in GTK (key name `"slash"` not `"/"`) and TUI (crossterm byte 0x1F → `Char('7')` mapping). VSCode mode: added Ctrl+Q quit, F10 menu toggle, menu visible by default. 19 unit tests in `comment.rs`, 31 integration tests in `tests/commentary.rs`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There's a touch of irony here - using a cli tool to write the editor that I've w
 - **First-class Vim mode** — deeply integrated, not a plugin
 - **Cross-platform** — GTK4 desktop UI + full terminal (TUI) backend
 - **CPU rendering** — Cairo/Pango (works in VMs, remote desktops, SSH)
-- **Clean architecture** — platform-agnostic core, 2908+ tests, zero async runtime dependency
+- **Clean architecture** — platform-agnostic core, 2937+ tests, zero async runtime dependency
 
 > **Note:** VimCode does not implement VimScript. Extension and scripting is handled via
 > the built-in Lua 5.4 plugin system. The goal is full Vim *keybinding* and *editing*
@@ -830,6 +830,9 @@ Additional options (set directly in `settings.json`):
 | `updatetime` | `4000` | Milliseconds between swap file writes for dirty buffers (`:set updatetime=N`) |
 | `breadcrumbs` | `true` | Show file path + symbol hierarchy bar below the tab bar (`:set breadcrumbs` / `:set nobreadcrumbs`) |
 | `autohide_panels` | `false` | TUI only: hide sidebar + activity bar at startup; `Ctrl-W h` reveals them, focus returns to editor auto-hides (`:set autohidepanels` / `:set noautohidepanels`) |
+| `indent_guides` | `true` | Show vertical indent guide lines at each tabstop level (`:set indentguides` / `:set noindentguides`) |
+| `match_brackets` | `true` | Highlight matching `(){}[]` bracket pair when cursor is on a bracket (`:set matchbrackets` / `:set nomatchbrackets`) |
+| `auto_pairs` | `true` | Auto-close brackets and quotes in Insert mode; typing closer skips over it; Backspace between pair deletes both (`:set autopairs` / `:set noautopairs`) |
 
 - `:set option?` — query current value (e.g. `:set ts?` → `tabstop=4`)
 - `:set option!` — toggle a boolean option (e.g. `:set wrap!`); `no<option>!` explicitly disables (e.g. `:set nowrap!`)

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1382,6 +1382,10 @@ pub struct Engine {
     /// Cleared by the UI backend after ~200 ms.
     pub yank_highlight: Option<(Cursor, Cursor, bool)>,
 
+    /// Matching bracket position (line, col) when cursor is on a bracket char.
+    /// Updated at the end of `handle_key()`.
+    pub bracket_match: Option<(usize, usize)>,
+
     // --- Insert mode Ctrl+r pending ---
     /// When true, the next keypress in Insert (or Replace) mode inserts a register's content.
     pub insert_ctrl_r_pending: bool,
@@ -1737,6 +1741,7 @@ impl Engine {
             last_ex_command: None,
             last_substitute: None,
             yank_highlight: None,
+            bracket_match: None,
             insert_ctrl_r_pending: false,
             insert_ctrl_g_pending: false,
             insert_ctrl_o_active: false,
@@ -5339,6 +5344,7 @@ impl Engine {
 
         self.ensure_cursor_visible();
         self.sync_scroll_binds();
+        self.update_bracket_match();
 
         // Fire cursor_move plugin hook when the cursor position changed.
         // Excluded from Insert mode: cursor moves caused by typing call git blame
@@ -9634,7 +9640,21 @@ impl Engine {
                     let col = self.view().cursor.col;
                     let char_idx = self.buffer().line_to_char(line) + col;
                     if col > 0 {
-                        self.delete_with_undo(char_idx - 1, char_idx);
+                        // Auto-pair backspace: delete both opener and closer
+                        let prev_char = self.buffer().content.char(char_idx - 1);
+                        let next_char_matches =
+                            if self.settings.auto_pairs && char_idx < self.buffer().len_chars() {
+                                let next = self.buffer().content.char(char_idx);
+                                auto_pair_closer(prev_char) == Some(next)
+                            } else {
+                                false
+                            };
+                        if next_char_matches {
+                            // Delete both the opener (before cursor) and closer (after cursor)
+                            self.delete_with_undo(char_idx - 1, char_idx + 1);
+                        } else {
+                            self.delete_with_undo(char_idx - 1, char_idx);
+                        }
                         self.view_mut().cursor.col -= 1;
                         *changed = true;
                     } else if line > 0 {
@@ -9756,12 +9776,59 @@ impl Engine {
                         let line = self.view().cursor.line;
                         let col = self.view().cursor.col;
                         let char_idx = self.buffer().line_to_char(line) + col;
-                        let mut buf = [0u8; 4];
-                        let s = ch.encode_utf8(&mut buf);
-                        self.insert_with_undo(char_idx, s);
-                        self.insert_text_buffer.push(ch);
-                        self.view_mut().cursor.col += 1;
-                        *changed = true;
+
+                        // Auto-pairs: skip-over closing bracket/quote
+                        let closing_pair = auto_pair_closer(ch);
+                        if self.settings.auto_pairs
+                            && is_closing_pair(ch)
+                            && char_idx < self.buffer().len_chars()
+                            && self.buffer().content.char(char_idx) == ch
+                        {
+                            // Skip over the existing closing char
+                            self.view_mut().cursor.col += 1;
+                            self.insert_text_buffer.push(ch);
+                            *changed = true;
+                        } else if self.settings.auto_pairs && closing_pair.is_some() {
+                            let closer = closing_pair.unwrap();
+                            // Smart context for quotes: only auto-pair if preceded by
+                            // whitespace, bracket, or BOL
+                            let should_pair = if is_quote_char(ch) {
+                                if char_idx == 0 {
+                                    true
+                                } else {
+                                    let prev = self.buffer().content.char(char_idx - 1);
+                                    prev.is_whitespace()
+                                        || matches!(prev, '(' | '[' | '{' | ',' | ';' | ':')
+                                }
+                            } else {
+                                true
+                            };
+                            if should_pair {
+                                let mut buf = [0u8; 4];
+                                let open_s = ch.encode_utf8(&mut buf).to_string();
+                                let mut buf2 = [0u8; 4];
+                                let close_s = closer.encode_utf8(&mut buf2).to_string();
+                                let pair = format!("{}{}", open_s, close_s);
+                                self.insert_with_undo(char_idx, &pair);
+                                self.insert_text_buffer.push(ch);
+                                self.view_mut().cursor.col += 1;
+                                *changed = true;
+                            } else {
+                                let mut buf = [0u8; 4];
+                                let s = ch.encode_utf8(&mut buf);
+                                self.insert_with_undo(char_idx, s);
+                                self.insert_text_buffer.push(ch);
+                                self.view_mut().cursor.col += 1;
+                                *changed = true;
+                            }
+                        } else {
+                            let mut buf = [0u8; 4];
+                            let s = ch.encode_utf8(&mut buf);
+                            self.insert_with_undo(char_idx, s);
+                            self.insert_text_buffer.push(ch);
+                            self.view_mut().cursor.col += 1;
+                            *changed = true;
+                        }
                     }
                     // Trigger signature help after '(' or ','
                     if ch == '(' || ch == ',' {
@@ -17514,6 +17581,45 @@ impl Engine {
         None
     }
 
+    /// Update `self.bracket_match` based on the character under the cursor.
+    /// Called at the end of `handle_key()` when `match_brackets` is enabled.
+    pub fn update_bracket_match(&mut self) {
+        if !self.settings.match_brackets {
+            self.bracket_match = None;
+            return;
+        }
+        let line = self.view().cursor.line;
+        let col = self.view().cursor.col;
+        let line_start = self.buffer().line_to_char(line);
+        let char_pos = line_start + col;
+        if char_pos >= self.buffer().len_chars() {
+            self.bracket_match = None;
+            return;
+        }
+        let current_char = self.buffer().content.char(char_pos);
+        let (is_opening, open_char, close_char) = match current_char {
+            '(' => (true, '(', ')'),
+            ')' => (false, '(', ')'),
+            '{' => (true, '{', '}'),
+            '}' => (false, '{', '}'),
+            '[' => (true, '[', ']'),
+            ']' => (false, '[', ']'),
+            _ => {
+                self.bracket_match = None;
+                return;
+            }
+        };
+        if let Some(match_pos) =
+            self.find_matching_bracket(char_pos, open_char, close_char, is_opening)
+        {
+            let match_line = self.buffer().content.char_to_line(match_pos);
+            let match_line_start = self.buffer().line_to_char(match_line);
+            self.bracket_match = Some((match_line, match_pos - match_line_start));
+        } else {
+            self.bracket_match = None;
+        }
+    }
+
     /// Find the range for a text object.
     /// Returns (start_pos, end_pos) if found, None otherwise.
     fn find_text_object_range(
@@ -23564,10 +23670,10 @@ impl Engine {
             let file = self.active_buffer_state().file_path.clone();
             let line = self.view().cursor.line;
             let col = self.view().cursor.col;
-            let should_push = self
-                .jump_list
-                .last()
-                .is_none_or(|last| last.0 != file || last.1 != line || last.2 != col);
+            #[allow(clippy::unnecessary_map_or)] // is_none_or requires Rust 1.82+
+            let should_push = self.jump_list.last().map_or(true, |last| {
+                last.0 != file || last.1 != line || last.2 != col
+            });
             if should_push {
                 self.jump_list.push((file, line, col));
                 if self.jump_list.len() > 100 {
@@ -24758,6 +24864,31 @@ fn binary_on_path(binary: &str) -> bool {
         path_var
     ));
     false
+}
+
+// ── Auto-pair helpers ────────────────────────────────────────────────────────
+
+/// Return the closing character for an auto-pair opener, or `None`.
+fn auto_pair_closer(ch: char) -> Option<char> {
+    match ch {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        '"' => Some('"'),
+        '\'' => Some('\''),
+        '`' => Some('`'),
+        _ => None,
+    }
+}
+
+/// Return true if `ch` is a closing bracket/quote that can be skipped over.
+fn is_closing_pair(ch: char) -> bool {
+    matches!(ch, ')' | ']' | '}' | '"' | '\'' | '`')
+}
+
+/// Return true if `ch` is a quote character (needs smart context check).
+fn is_quote_char(ch: char) -> bool {
+    matches!(ch, '"' | '\'' | '`')
 }
 
 /// Convert a char index in `s` to a byte offset.
@@ -27077,7 +27208,21 @@ impl Engine {
                         let col = self.view().cursor.col;
                         let char_idx = self.buffer().line_to_char(line) + col;
                         if col > 0 {
-                            self.delete_with_undo(char_idx - 1, char_idx);
+                            // Auto-pair backspace: delete both opener and closer
+                            let prev_char = self.buffer().content.char(char_idx - 1);
+                            let next_char_matches = if self.settings.auto_pairs
+                                && char_idx < self.buffer().len_chars()
+                            {
+                                let next = self.buffer().content.char(char_idx);
+                                auto_pair_closer(prev_char) == Some(next)
+                            } else {
+                                false
+                            };
+                            if next_char_matches {
+                                self.delete_with_undo(char_idx - 1, char_idx + 1);
+                            } else {
+                                self.delete_with_undo(char_idx - 1, char_idx);
+                            }
                             self.view_mut().cursor.col -= 1;
                             changed = true;
                         } else if line > 0 {
@@ -27152,11 +27297,52 @@ impl Engine {
                         let line = self.view().cursor.line;
                         let col = self.view().cursor.col;
                         let char_idx = self.buffer().line_to_char(line) + col;
-                        let mut buf = [0u8; 4];
-                        let s = ch.encode_utf8(&mut buf);
-                        self.insert_with_undo(char_idx, s);
-                        self.view_mut().cursor.col += 1;
-                        changed = true;
+
+                        // Auto-pairs: skip-over closing bracket/quote
+                        let closing_pair = auto_pair_closer(ch);
+                        if self.settings.auto_pairs
+                            && is_closing_pair(ch)
+                            && char_idx < self.buffer().len_chars()
+                            && self.buffer().content.char(char_idx) == ch
+                        {
+                            self.view_mut().cursor.col += 1;
+                            changed = true;
+                        } else if self.settings.auto_pairs && closing_pair.is_some() {
+                            let closer = closing_pair.unwrap();
+                            let should_pair = if is_quote_char(ch) {
+                                if char_idx == 0 {
+                                    true
+                                } else {
+                                    let prev = self.buffer().content.char(char_idx - 1);
+                                    prev.is_whitespace()
+                                        || matches!(prev, '(' | '[' | '{' | ',' | ';' | ':')
+                                }
+                            } else {
+                                true
+                            };
+                            if should_pair {
+                                let mut buf = [0u8; 4];
+                                let open_s = ch.encode_utf8(&mut buf).to_string();
+                                let mut buf2 = [0u8; 4];
+                                let close_s = closer.encode_utf8(&mut buf2).to_string();
+                                let pair = format!("{}{}", open_s, close_s);
+                                self.insert_with_undo(char_idx, &pair);
+                                self.view_mut().cursor.col += 1;
+                                changed = true;
+                            } else {
+                                let mut buf = [0u8; 4];
+                                let s = ch.encode_utf8(&mut buf);
+                                self.insert_with_undo(char_idx, s);
+                                self.view_mut().cursor.col += 1;
+                                changed = true;
+                            }
+                        } else {
+                            let mut buf = [0u8; 4];
+                            let s = ch.encode_utf8(&mut buf);
+                            self.insert_with_undo(char_idx, s);
+                            self.view_mut().cursor.col += 1;
+                            changed = true;
+                        }
                         self.trigger_auto_completion();
                     }
                 }
@@ -27181,6 +27367,7 @@ impl Engine {
 
         self.ensure_cursor_visible();
         self.sync_scroll_binds();
+        self.update_bracket_match();
         EngineAction::None
     }
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -243,6 +243,30 @@ pub struct Settings {
     /// When true, panels appear on demand via Ctrl-W l and hide again when unfocused.
     #[serde(default)]
     pub autohide_panels: bool,
+
+    /// Show indent guide lines at each indentation level.
+    #[serde(default = "default_indent_guides")]
+    pub indent_guides: bool,
+
+    /// Highlight matching brackets when cursor is on one.
+    #[serde(default = "default_match_brackets")]
+    pub match_brackets: bool,
+
+    /// Auto-close brackets and quotes in Insert mode.
+    #[serde(default = "default_auto_pairs")]
+    pub auto_pairs: bool,
+}
+
+fn default_indent_guides() -> bool {
+    true
+}
+
+fn default_match_brackets() -> bool {
+    true
+}
+
+fn default_auto_pairs() -> bool {
+    true
 }
 
 fn default_swap_file() -> bool {
@@ -605,6 +629,9 @@ impl Default for Settings {
             updatetime: default_updatetime(),
             breadcrumbs: default_breadcrumbs(),
             autohide_panels: false,
+            indent_guides: default_indent_guides(),
+            match_brackets: default_match_brackets(),
+            auto_pairs: default_auto_pairs(),
         }
     }
 }
@@ -831,6 +858,9 @@ impl Settings {
             "swapfile" => self.swap_file = enable,
             "breadcrumbs" => self.breadcrumbs = enable,
             "autohidepanels" => self.autohide_panels = enable,
+            "indentguides" => self.indent_guides = enable,
+            "matchbrackets" => self.match_brackets = enable,
+            "autopairs" => self.auto_pairs = enable,
             _ => return Err(format!("Unknown option: {opt}")),
         }
         Ok(())
@@ -1001,6 +1031,21 @@ impl Settings {
             } else {
                 "noautohidepanels".to_string()
             }),
+            "indentguides" => Ok(if self.indent_guides {
+                "indentguides".to_string()
+            } else {
+                "noindentguides".to_string()
+            }),
+            "matchbrackets" => Ok(if self.match_brackets {
+                "matchbrackets".to_string()
+            } else {
+                "nomatchbrackets".to_string()
+            }),
+            "autopairs" => Ok(if self.auto_pairs {
+                "autopairs".to_string()
+            } else {
+                "noautopairs".to_string()
+            }),
             _ => Err(format!("Unknown option: {opt}")),
         }
     }
@@ -1088,6 +1133,9 @@ impl Settings {
             "updatetime" | "ut" => self.updatetime.to_string(),
             "breadcrumbs" => self.breadcrumbs.to_string(),
             "autohide_panels" | "autohidepanels" => self.autohide_panels.to_string(),
+            "indent_guides" | "indentguides" => self.indent_guides.to_string(),
+            "match_brackets" | "matchbrackets" => self.match_brackets.to_string(),
+            "auto_pairs" | "autopairs" => self.auto_pairs.to_string(),
             _ => String::new(),
         }
     }
@@ -1180,6 +1228,9 @@ impl Settings {
             }
             "breadcrumbs" => self.breadcrumbs = value == "true",
             "autohide_panels" | "autohidepanels" => self.autohide_panels = value == "true",
+            "indent_guides" | "indentguides" => self.indent_guides = value == "true",
+            "match_brackets" | "matchbrackets" => self.match_brackets = value == "true",
+            "auto_pairs" | "autopairs" => self.auto_pairs = value == "true",
             _ => return Err(format!("Unknown setting key: {key}")),
         }
         Ok(())
@@ -1528,6 +1579,27 @@ pub static SETTING_DEFS: &[SettingDef] = &[
         label: "Inline Completions",
         description: "Show AI ghost-text completions at the cursor in insert mode (Tab to accept, Alt+]/Alt+[ to cycle alternatives)",
         category: "AI",
+        setting_type: SettingType::Bool,
+    },
+    SettingDef {
+        key: "indent_guides",
+        label: "Indent Guides",
+        description: "Show vertical lines at each indentation level",
+        category: "Editor",
+        setting_type: SettingType::Bool,
+    },
+    SettingDef {
+        key: "match_brackets",
+        label: "Match Brackets",
+        description: "Highlight matching bracket when cursor is on a bracket character",
+        category: "Editor",
+        setting_type: SettingType::Bool,
+    },
+    SettingDef {
+        key: "auto_pairs",
+        label: "Auto Pairs",
+        description: "Auto-close brackets and quotes in Insert mode",
+        category: "Editor",
         setting_type: SettingType::Bool,
     },
     // ── TUI ─────────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -7658,6 +7658,35 @@ fn draw_window(
             pangocairo::show_layout(cr, layout);
         }
 
+        // Indent guides: thin vertical lines at each guide column
+        if !rl.indent_guides.is_empty() {
+            cr.set_line_width(1.0);
+            for &guide_col in &rl.indent_guides {
+                let is_active = rw.active_indent_col == Some(guide_col);
+                let (gr, gg, gb) = if is_active {
+                    theme.indent_guide_active_fg.to_cairo()
+                } else {
+                    theme.indent_guide_fg.to_cairo()
+                };
+                cr.set_source_rgb(gr, gg, gb);
+                let gx = text_x_offset + guide_col as f64 * char_width;
+                cr.move_to(gx, y);
+                cr.line_to(gx, y + line_height);
+                cr.stroke().ok();
+            }
+        }
+
+        // Bracket match highlighting
+        for &(bm_view_line, bm_col) in &rw.bracket_match_positions {
+            if bm_view_line == view_idx {
+                let (br, bg_c, bb) = theme.bracket_match_bg.to_cairo();
+                cr.set_source_rgba(br, bg_c, bb, 0.6);
+                let bx = text_x_offset + bm_col as f64 * char_width;
+                cr.rectangle(bx, y, char_width, line_height);
+                cr.fill().ok();
+            }
+        }
+
         // Diagnostic underlines (wavy squiggles)
         for dm in &rl.diagnostics {
             let diag_color = match dm.severity {
@@ -10727,11 +10756,14 @@ fn pixel_to_click_target(
             .as_ref()
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_default();
-        !engine
-            .dap_breakpoints
-            .get(&key)
-            .is_none_or(|v| v.is_empty())
-            || engine.dap_session_active
+        #[allow(clippy::unnecessary_map_or)] // is_none_or requires Rust 1.82+
+        {
+            !engine
+                .dap_breakpoints
+                .get(&key)
+                .map_or(true, |v| v.is_empty())
+                || engine.dap_session_active
+        }
     };
     let gutter_char_width = render::calculate_gutter_cols(
         engine.settings.line_numbers,

--- a/src/render.rs
+++ b/src/render.rs
@@ -246,6 +246,9 @@ pub struct RenderedLine {
     /// These rows have empty `raw_text`; the full continuation text is in
     /// `ghost_suffix` and backends draw it at the left edge of the content area.
     pub is_ghost_continuation: bool,
+    /// Column positions where indent guide lines should be drawn.
+    /// Empty when `indent_guides` setting is off.
+    pub indent_guides: Vec<usize>,
 }
 
 /// A single diagnostic mark on a rendered line (for inline underlines/squiggles).
@@ -406,6 +409,11 @@ pub struct RenderedWindow {
     pub diagnostic_gutter: std::collections::HashMap<usize, crate::core::lsp::DiagnosticSeverity>,
     /// Transient yank-highlight region (flashes briefly after a yank). `None` if no active highlight.
     pub yank_highlight: Option<SelectionRange>,
+    /// Bracket pair positions to highlight (cursor bracket + matching bracket).
+    /// Each entry is (view_line, col). Up to 2 entries.
+    pub bracket_match_positions: Vec<(usize, usize)>,
+    /// The indent guide column that should be highlighted as "active" (cursor's scope).
+    pub active_indent_col: Option<usize>,
 }
 
 // ─── CommandLineData ──────────────────────────────────────────────────────────
@@ -1603,6 +1611,13 @@ pub struct Theme {
     pub breadcrumb_bg: Color,
     pub breadcrumb_fg: Color,
     pub breadcrumb_active_fg: Color,
+
+    // Indent guides
+    pub indent_guide_fg: Color,
+    pub indent_guide_active_fg: Color,
+
+    // Bracket match highlight
+    pub bracket_match_bg: Color,
 }
 
 impl Theme {
@@ -1744,6 +1759,10 @@ impl Theme {
             breadcrumb_bg: Color::from_hex("#21252b"),
             breadcrumb_fg: Color::from_hex("#7f848e"),
             breadcrumb_active_fg: Color::from_hex("#abb2bf"),
+
+            indent_guide_fg: Color::from_hex("#404040"),
+            indent_guide_active_fg: Color::from_hex("#606060"),
+            bracket_match_bg: Color::from_hex("#3a3d41"),
         }
     }
 
@@ -1851,6 +1870,10 @@ impl Theme {
             breadcrumb_bg: Color::from_hex("#32302f"),
             breadcrumb_fg: Color::from_hex("#a89984"),
             breadcrumb_active_fg: Color::from_hex("#ebdbb2"),
+
+            indent_guide_fg: Color::from_hex("#3c3836"),
+            indent_guide_active_fg: Color::from_hex("#504945"),
+            bracket_match_bg: Color::from_hex("#504945"),
         }
     }
 
@@ -1958,6 +1981,10 @@ impl Theme {
             breadcrumb_bg: Color::from_hex("#1f2335"),
             breadcrumb_fg: Color::from_hex("#565f89"),
             breadcrumb_active_fg: Color::from_hex("#c0caf5"),
+
+            indent_guide_fg: Color::from_hex("#292e42"),
+            indent_guide_active_fg: Color::from_hex("#3b4261"),
+            bracket_match_bg: Color::from_hex("#364a82"),
         }
     }
 
@@ -2065,6 +2092,10 @@ impl Theme {
             breadcrumb_bg: Color::from_hex("#073642"),
             breadcrumb_fg: Color::from_hex("#586e75"),
             breadcrumb_active_fg: Color::from_hex("#93a1a1"),
+
+            indent_guide_fg: Color::from_hex("#073642"),
+            indent_guide_active_fg: Color::from_hex("#0d4a5a"),
+            bracket_match_bg: Color::from_hex("#0d4a5a"),
         }
     }
 
@@ -3702,6 +3733,8 @@ fn build_rendered_window(
         has_breakpoints: false,
         max_col: 0,
         diagnostic_gutter: std::collections::HashMap::new(),
+        bracket_match_positions: Vec::new(),
+        active_indent_col: None,
     };
 
     let window = match engine.windows.get(&window_id) {
@@ -4032,6 +4065,7 @@ fn build_rendered_window(
                         None
                     },
                     is_ghost_continuation: false,
+                    indent_guides: Vec::new(), // filled below
                 });
 
                 // After the cursor segment, insert ghost continuation rows.
@@ -4059,6 +4093,7 @@ fn build_rendered_window(
                             annotation: None,
                             ghost_suffix: Some(cont.clone()),
                             is_ghost_continuation: true,
+                            indent_guides: Vec::new(),
                         });
                     }
                 }
@@ -4091,6 +4126,7 @@ fn build_rendered_window(
                     None
                 },
                 is_ghost_continuation: false,
+                indent_guides: Vec::new(), // filled below
             });
 
             // After the cursor line, insert ghost continuation rows.
@@ -4119,6 +4155,7 @@ fn build_rendered_window(
                         annotation: None,
                         ghost_suffix: Some(cont.clone()),
                         is_ghost_continuation: true,
+                        indent_guides: Vec::new(),
                     });
                 }
             }
@@ -4213,6 +4250,103 @@ fn build_rendered_window(
 
     // diagnostic_gutter is already built in the single-pass pre-indexing above.
 
+    // ── Indent guides ──────────────────────────────────────────────────────
+    let tabstop = engine.settings.tabstop.max(1) as usize;
+    let mut active_indent_col: Option<usize> = None;
+    if engine.settings.indent_guides {
+        // Compute the indent level for each visible line (in columns).
+        let line_indents: Vec<Option<usize>> = lines
+            .iter()
+            .map(|l| {
+                if l.is_ghost_continuation || l.is_wrap_continuation {
+                    return None; // not a real line for indent purposes
+                }
+                let text = &l.raw_text;
+                let mut cols = 0usize;
+                for ch in text.chars() {
+                    match ch {
+                        ' ' => cols += 1,
+                        '\t' => cols += tabstop - (cols % tabstop),
+                        _ => break,
+                    }
+                }
+                // Blank lines (only whitespace/newline) return None so guides bridge
+                let trimmed = text.trim_start();
+                let non_ws = !trimmed.is_empty() && trimmed != "\n" && trimmed != "\r\n";
+                if non_ws {
+                    Some(cols)
+                } else {
+                    None // blank line — will be bridged
+                }
+            })
+            .collect();
+
+        // Determine active guide column from cursor line indent
+        if let Some(cursor_pos) = &cursor {
+            let cursor_view_line = cursor_pos.0.view_line;
+            if cursor_view_line < line_indents.len() {
+                if let Some(indent) = line_indents[cursor_view_line] {
+                    // Active guide is the highest tabstop ≤ cursor indent
+                    if indent >= tabstop {
+                        let guide_col = (indent / tabstop) * tabstop;
+                        // Use the guide one level below if cursor indent is exact multiple
+                        active_indent_col = Some(guide_col - tabstop);
+                    }
+                }
+            }
+        }
+
+        // Assign indent guides per line, bridging blank lines
+        for (i, line) in lines.iter_mut().enumerate() {
+            if line.is_ghost_continuation {
+                continue;
+            }
+            let indent = match line_indents[i] {
+                Some(ind) => ind,
+                None => {
+                    // Blank line: bridge using min indent of surrounding non-blank lines
+                    let above = line_indents[..i].iter().rev().find_map(|x| *x).unwrap_or(0);
+                    let below = line_indents[i + 1..].iter().find_map(|x| *x).unwrap_or(0);
+                    above.min(below)
+                }
+            };
+            let mut guides = Vec::new();
+            let mut col = tabstop;
+            while col <= indent {
+                guides.push(col - tabstop); // guide at the start of each tabstop level
+                col += tabstop;
+            }
+            line.indent_guides = guides;
+        }
+    }
+
+    // ── Bracket match positions ────────────────────────────────────────────
+    let bracket_match_positions = if engine.settings.match_brackets && is_active {
+        if let Some((match_line, match_col)) = engine.bracket_match {
+            let mut positions = Vec::with_capacity(2);
+            // Cursor bracket position
+            let cursor_line_idx = view.cursor.line;
+            let cursor_col_idx = view.cursor.col;
+            for (vi, l) in lines.iter().enumerate() {
+                if l.line_idx == cursor_line_idx
+                    && !l.is_ghost_continuation
+                    && !l.is_wrap_continuation
+                {
+                    positions.push((vi, cursor_col_idx.saturating_sub(l.segment_col_offset)));
+                }
+                if l.line_idx == match_line && !l.is_ghost_continuation && !l.is_wrap_continuation {
+                    positions.push((vi, match_col.saturating_sub(l.segment_col_offset)));
+                }
+            }
+            positions.dedup();
+            positions
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+
     RenderedWindow {
         window_id,
         rect: *rect,
@@ -4231,6 +4365,8 @@ fn build_rendered_window(
         has_breakpoints: has_bp,
         max_col,
         diagnostic_gutter,
+        bracket_match_positions,
+        active_indent_col,
     }
 }
 

--- a/src/tui_main.rs
+++ b/src/tui_main.rs
@@ -6703,6 +6703,32 @@ fn render_window(frame: &mut ratatui::Frame, area: Rect, window: &RenderedWindow
             line_bg,
         );
 
+        // Indent guides: draw │ at guide columns where the cell is a space
+        if !line.indent_guides.is_empty() {
+            let guide_fg = rc(theme.indent_guide_fg);
+            let active_fg = rc(theme.indent_guide_active_fg);
+            for &guide_col in &line.indent_guides {
+                if guide_col < window.scroll_left {
+                    continue;
+                }
+                let vis_col = (guide_col - window.scroll_left) as u16;
+                if vis_col >= text_width {
+                    break;
+                }
+                let cx = text_area_x + vis_col;
+                if cx < area.x + area.width && screen_y < area.y + area.height {
+                    let cell = frame.buffer_mut().get_mut(cx, screen_y);
+                    // Only draw guide if the cell is a space (don't overwrite text)
+                    if cell.symbol() == " " {
+                        let is_active = window.active_indent_col == Some(guide_col);
+                        let fg = if is_active { active_fg } else { guide_fg };
+                        cell.set_char('│');
+                        cell.set_fg(fg);
+                    }
+                }
+            }
+        }
+
         // Ghost continuation lines — draw full line in ghost colour.
         if line.is_ghost_continuation {
             if let Some(ghost) = &line.ghost_suffix {
@@ -6738,6 +6764,25 @@ fn render_window(frame: &mut ratatui::Frame, area: Rect, window: &RenderedWindow
                     let cell = frame.buffer_mut().get_mut(cx, screen_y);
                     cell.set_fg(diag_fg);
                     cell.modifier |= Modifier::UNDERLINED;
+                }
+            }
+        }
+
+        // Bracket match highlighting
+        let bracket_bg = rc(theme.bracket_match_bg);
+        for &(view_line, col) in &window.bracket_match_positions {
+            if view_line == row_idx {
+                if col < window.scroll_left {
+                    continue;
+                }
+                let vis_col = (col - window.scroll_left) as u16;
+                if vis_col >= text_width {
+                    continue;
+                }
+                let cx = text_area_x + vis_col;
+                if cx < area.x + area.width && screen_y < area.y + area.height {
+                    let cell = frame.buffer_mut().get_mut(cx, screen_y);
+                    cell.set_bg(bracket_bg);
                 }
             }
         }
@@ -10182,6 +10227,11 @@ fn rc(c: Color) -> RColor {
 /// string. Returns the total char count if `byte_offset` is past the end.
 fn byte_to_char_idx(text: &str, byte_offset: usize) -> usize {
     let clamped = byte_offset.min(text.len());
-    let safe = text.floor_char_boundary(clamped);
+    // Walk back from clamped to find a char boundary (avoids unstable
+    // `floor_char_boundary` which older Rust toolchains lack).
+    let mut safe = clamped;
+    while safe > 0 && !text.is_char_boundary(safe) {
+        safe -= 1;
+    }
     text[..safe].chars().count()
 }

--- a/tests/ide_polish.rs
+++ b/tests/ide_polish.rs
@@ -1,0 +1,368 @@
+mod common;
+use common::*;
+use vimcode_core::Mode;
+
+/// Ensure engine is in Normal mode (workaround for user's vscode mode setting).
+fn ensure_normal(e: &mut vimcode_core::Engine) {
+    if e.mode != Mode::Normal {
+        press_key(e, "Escape");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Feature 1: Indent Guides
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_indent_guides_default_on() {
+    let e = engine_with("hello\n");
+    assert!(e.settings.indent_guides);
+}
+
+#[test]
+fn test_indent_guides_setting_toggle() {
+    let mut e = engine_with("hello\n");
+    ensure_normal(&mut e);
+    run_cmd(&mut e, "set noindentguides");
+    assert!(!e.settings.indent_guides);
+    run_cmd(&mut e, "set indentguides");
+    assert!(e.settings.indent_guides);
+}
+
+#[test]
+fn test_indent_guides_setting_persists() {
+    let e = engine_with("hello\n");
+    assert_eq!(e.settings.get_value_str("indent_guides"), "true");
+}
+
+#[test]
+fn test_indent_guides_set_value_str() {
+    let mut e = engine_with("hello\n");
+    e.settings.set_value_str("indent_guides", "false").unwrap();
+    assert!(!e.settings.indent_guides);
+    e.settings.set_value_str("indentguides", "true").unwrap();
+    assert!(e.settings.indent_guides);
+}
+
+#[test]
+fn test_indent_guides_query() {
+    let mut e = engine_with("hello\n");
+    let r = e.settings.parse_set_option("indentguides?");
+    assert_eq!(r, Ok("indentguides".to_string()));
+    e.settings.indent_guides = false;
+    let r = e.settings.parse_set_option("indentguides?");
+    assert_eq!(r, Ok("noindentguides".to_string()));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Feature 2: Bracket Pair Highlighting
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_bracket_match_on_open_paren() {
+    let mut e = engine_with("(hello)\n");
+    ensure_normal(&mut e);
+    // Cursor at (0,0) = '('
+    // Trigger update by pressing any key
+    press(&mut e, 'l');
+    press(&mut e, 'h');
+    // Match should point to ')' at col 6
+    assert_eq!(e.bracket_match, Some((0, 6)));
+}
+
+#[test]
+fn test_bracket_match_on_close_paren() {
+    let mut e = engine_with("(hello)\n");
+    ensure_normal(&mut e);
+    // Move to end — ')'
+    for _ in 0..6 {
+        press(&mut e, 'l');
+    }
+    assert_cursor(&e, 0, 6);
+    assert_eq!(e.bracket_match, Some((0, 0)));
+}
+
+#[test]
+fn test_bracket_match_not_on_bracket() {
+    let mut e = engine_with("hello\n");
+    ensure_normal(&mut e);
+    press(&mut e, 'l');
+    assert_eq!(e.bracket_match, None);
+}
+
+#[test]
+fn test_bracket_match_nested() {
+    let mut e = engine_with("((()))\n");
+    ensure_normal(&mut e);
+    // Outer '(' at col 0
+    press(&mut e, 'l');
+    press(&mut e, 'h');
+    assert_eq!(e.bracket_match, Some((0, 5)));
+    // Inner '(' at col 1
+    press(&mut e, 'l');
+    assert_eq!(e.bracket_match, Some((0, 4)));
+    // Innermost '(' at col 2
+    press(&mut e, 'l');
+    assert_eq!(e.bracket_match, Some((0, 3)));
+}
+
+#[test]
+fn test_bracket_match_unbalanced() {
+    let mut e = engine_with("(hello\n");
+    ensure_normal(&mut e);
+    press(&mut e, 'l');
+    press(&mut e, 'h');
+    assert_eq!(e.bracket_match, None);
+}
+
+#[test]
+fn test_bracket_match_disabled() {
+    let mut e = engine_with("(hello)\n");
+    e.settings.match_brackets = false;
+    ensure_normal(&mut e);
+    press(&mut e, 'l');
+    press(&mut e, 'h');
+    assert_eq!(e.bracket_match, None);
+}
+
+#[test]
+fn test_bracket_match_curly() {
+    let mut e = engine_with("{foo}\n");
+    ensure_normal(&mut e);
+    press(&mut e, 'l');
+    press(&mut e, 'h');
+    assert_eq!(e.bracket_match, Some((0, 4)));
+}
+
+#[test]
+fn test_bracket_match_square() {
+    let mut e = engine_with("[bar]\n");
+    ensure_normal(&mut e);
+    press(&mut e, 'l');
+    press(&mut e, 'h');
+    assert_eq!(e.bracket_match, Some((0, 4)));
+}
+
+#[test]
+fn test_bracket_match_setting_toggle() {
+    let mut e = engine_with("hello\n");
+    ensure_normal(&mut e);
+    assert!(e.settings.match_brackets);
+    run_cmd(&mut e, "set nomatchbrackets");
+    assert!(!e.settings.match_brackets);
+    run_cmd(&mut e, "set matchbrackets");
+    assert!(e.settings.match_brackets);
+}
+
+#[test]
+fn test_bracket_match_query() {
+    let mut e = engine_with("hello\n");
+    let r = e.settings.parse_set_option("matchbrackets?");
+    assert_eq!(r, Ok("matchbrackets".to_string()));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Feature 3: Auto-close Brackets/Quotes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_auto_pair_paren() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "\n");
+    press(&mut e, 'i'); // enter insert mode
+    press(&mut e, '(');
+    assert_eq!(buf(&e), "()\n");
+    assert_cursor(&e, 0, 1);
+}
+
+#[test]
+fn test_auto_pair_bracket() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "\n");
+    press(&mut e, 'i');
+    press(&mut e, '[');
+    assert_eq!(buf(&e), "[]\n");
+    assert_cursor(&e, 0, 1);
+}
+
+#[test]
+fn test_auto_pair_curly() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "\n");
+    press(&mut e, 'i');
+    press(&mut e, '{');
+    assert_eq!(buf(&e), "{}\n");
+    assert_cursor(&e, 0, 1);
+}
+
+#[test]
+fn test_auto_pair_skip_over_closing() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "\n");
+    press(&mut e, 'i');
+    press(&mut e, '(');
+    // Buffer: "()", cursor at col 1
+    press(&mut e, ')');
+    // Should skip over ')' rather than inserting another
+    assert_eq!(buf(&e), "()\n");
+    assert_cursor(&e, 0, 2);
+}
+
+#[test]
+fn test_auto_pair_backspace_deletes_both() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "\n");
+    press(&mut e, 'i');
+    press(&mut e, '(');
+    assert_eq!(buf(&e), "()\n");
+    // Backspace should delete both ( and )
+    press_key(&mut e, "BackSpace");
+    assert_eq!(buf(&e), "\n");
+    assert_cursor(&e, 0, 0);
+}
+
+#[test]
+fn test_auto_pair_quote_after_space() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, " \n");
+    // Go to end of line and enter insert
+    press(&mut e, 'A');
+    press(&mut e, '"');
+    assert_eq!(buf(&e), " \"\"\n");
+}
+
+#[test]
+fn test_auto_pair_quote_after_letter_no_pair() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "abc\n");
+    press(&mut e, 'A'); // append at end
+    press(&mut e, '"');
+    // After 'c' → no auto-pair for quotes
+    assert_eq!(buf(&e), "abc\"\n");
+}
+
+#[test]
+fn test_auto_pair_disabled() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    e.settings.auto_pairs = false;
+    set_content(&mut e, "\n");
+    press(&mut e, 'i');
+    press(&mut e, '(');
+    assert_eq!(buf(&e), "(\n");
+}
+
+#[test]
+fn test_auto_pair_setting_toggle() {
+    let mut e = engine_with("hello\n");
+    ensure_normal(&mut e);
+    assert!(e.settings.auto_pairs);
+    run_cmd(&mut e, "set noautopairs");
+    assert!(!e.settings.auto_pairs);
+    run_cmd(&mut e, "set autopairs");
+    assert!(e.settings.auto_pairs);
+}
+
+#[test]
+fn test_auto_pair_multiple_pairs() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "\n");
+    press(&mut e, 'i');
+    press(&mut e, '(');
+    press(&mut e, '[');
+    assert_eq!(buf(&e), "([])\n");
+    assert_cursor(&e, 0, 2);
+}
+
+#[test]
+fn test_auto_pair_normal_mode_unaffected() {
+    let mut e = engine_with("hello\n");
+    ensure_normal(&mut e);
+    assert_eq!(e.mode, Mode::Normal);
+    press(&mut e, 'l');
+    assert_cursor(&e, 0, 1);
+}
+
+#[test]
+fn test_auto_pair_backtick() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, " \n");
+    press(&mut e, 'A');
+    press(&mut e, '`');
+    assert_eq!(buf(&e), " ``\n");
+}
+
+#[test]
+fn test_auto_pair_single_quote_after_bracket() {
+    let mut e = engine_with("");
+    ensure_normal(&mut e);
+    set_content(&mut e, "(\n");
+    press(&mut e, 'l'); // cursor on \n? no, l stays on (
+    press(&mut e, 'A'); // append after (
+    press(&mut e, '\'');
+    assert_eq!(buf(&e), "(''\n");
+}
+
+#[test]
+fn test_auto_pair_query() {
+    let mut e = engine_with("hello\n");
+    let r = e.settings.parse_set_option("autopairs?");
+    assert_eq!(r, Ok("autopairs".to_string()));
+}
+
+// ── VSCode mode auto-pairs ──────────────────────────────────────────────────
+
+#[test]
+fn test_auto_pair_vscode_mode_paren() {
+    let mut e = engine_with("");
+    e.toggle_editor_mode(); // switch to vscode mode (Insert)
+    set_content(&mut e, "\n");
+    e.view_mut().cursor = vimcode_core::Cursor { line: 0, col: 0 };
+    press(&mut e, '(');
+    assert_eq!(buf(&e), "()\n");
+    assert_cursor(&e, 0, 1);
+}
+
+#[test]
+fn test_auto_pair_vscode_mode_skip_over() {
+    let mut e = engine_with("");
+    e.toggle_editor_mode(); // switch to vscode mode (Insert)
+    set_content(&mut e, "\n");
+    e.view_mut().cursor = vimcode_core::Cursor { line: 0, col: 0 };
+    press(&mut e, '(');
+    press(&mut e, ')');
+    assert_eq!(buf(&e), "()\n");
+    assert_cursor(&e, 0, 2);
+}
+
+#[test]
+fn test_auto_pair_vscode_mode_backspace() {
+    let mut e = engine_with("");
+    e.toggle_editor_mode(); // switch to vscode mode (Insert)
+    set_content(&mut e, "\n");
+    e.view_mut().cursor = vimcode_core::Cursor { line: 0, col: 0 };
+    press(&mut e, '(');
+    press_key(&mut e, "BackSpace");
+    assert_eq!(buf(&e), "\n");
+    assert_cursor(&e, 0, 0);
+}
+
+#[test]
+fn test_auto_pair_vscode_mode_quote_smart_context() {
+    let mut e = engine_with("");
+    e.toggle_editor_mode(); // switch to vscode mode (Insert)
+    set_content(&mut e, "a\n");
+    e.view_mut().cursor = vimcode_core::Cursor { line: 0, col: 1 };
+    press(&mut e, '"');
+    // After letter — no auto-pair
+    assert_eq!(buf(&e), "a\"\n");
+}


### PR DESCRIPTION
## Summary
- **Indent guides** — vertical lines at each tabstop, active guide highlight, blank line bridging, TUI + GTK rendering
- **Bracket pair highlighting** — matching `(){}[]` background color when cursor is on a bracket
- **Auto-close brackets/quotes** — insert matching closer, skip-over closing, backspace pair delete, smart quote context; works in both Vim and VSCode modes
- **Build: vcd statically linked with musl** — runs on any Linux (Ubuntu 20.04+, CentOS 7+, Alpine) without glibc version issues
- **Build: Flatpak compat** — replaced `floor_char_boundary` and `is_none_or` (Rust 1.82+) for GNOME SDK 47 Rust 1.80 compatibility
- 3 new settings (`indent_guides`, `match_brackets`, `auto_pairs`), theme colors across all 4 built-in themes
- 33 new tests (including VSCode mode auto-pairs coverage)

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test && cargo build` all pass
- [ ] Flatpak build succeeds in CI
- [ ] `vcd-linux-x86_64` binary runs on Ubuntu 22.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)