### PR TITLE
docs: add Homebrew tap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,17 @@ VimCode requires **GTK4 development libraries** for the GUI backend. The TUI mod
 | Windows (MSYS2) | `pacman -S mingw-w64-x86_64-gtk4 mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc` |
 
 **Platform notes:**
-- **macOS:** GTK4 works via Homebrew; this is not a native AppKit app
+- **macOS:** GTK4 works via Homebrew; this is not a native AppKit app. See [Homebrew install](#homebrew-macos) below
 - **Windows:** Use the MSYS2 MinGW64 shell and set `rustup default stable-x86_64-pc-windows-gnu`
 - **Nerd Font recommended:** VimCode uses Nerd Font icons throughout the UI — the file explorer, activity bar, tab bar, terminal toolbar, and debug panel all rely on Nerd Font glyphs. Install any [Nerd Font](https://www.nerdfonts.com/) (e.g. JetBrainsMono Nerd Font, FiraCode Nerd Font) and set it as your terminal font (TUI) or configure `font_family` in `settings.json` (GTK). Without a Nerd Font, icons will display as missing-glyph boxes.
+
+### Homebrew (macOS)
+
+```bash
+brew tap JDonaghy/vimcode
+brew install vimcode    # GTK4 GUI + TUI (installs both `vimcode` and `vcd`)
+brew install vcd        # TUI only (no GTK4 dependency)
+```
 
 ### Build & run
 


### PR DESCRIPTION
## Summary
- Add Homebrew install section to README with `brew tap JDonaghy/vimcode` instructions
- Two formulas: `vimcode` (GTK4 GUI + TUI) and `vcd` (TUI only, no GTK4 dep)
- Update macOS platform note to link to Homebrew section

Tap repo: https://github.com/JDonaghy/homebrew-vimcode

## Test plan
- [x] Docs-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)