### PR TITLE
Fix 6 Vim conformance deviations (#28-#33)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 15, 2026 (Session 279 — Vim conformance matrix tests, `:set` audit) | **Tests:** 1463 (lib)
+**Last updated:** Apr 15, 2026 (Session 280 — Fix 6 Vim deviations, Neovim conformance harness) | **Tests:** 1463 (lib) + 31 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 278 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,16 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 280 — Fix 6 Vim deviations (#28-#33), Neovim conformance harness:**
+
+1. **Fix #31: `2d2w` count multiplication** — Added `operator_count` field to Engine. When operator is set, count is saved separately; `take_count()` multiplies operator_count × motion_count. `2d2w` now correctly deletes 4 words.
+2. **Fix #32: `<G` outdent** — Was a `send_keys()` test parser bug: `<G` was treated as a special key. Fixed parser to require closing `>`. Engine was already correct.
+3. **Fix #30: `di</da<` angle bracket text objects** — Added `'<' | '>'` match arm to `find_text_object_range()` using existing `find_bracket_object()`.
+4. **Fix #29: `da"/da'` trailing whitespace** — `find_quote_object()` for `modifier == 'a'` now includes trailing whitespace (or leading if no trailing), matching Vim spec.
+5. **Fix #28: `d}/d{` paragraph boundary** — `d{` range is `[target, cursor-1]` (blank line deleted, cursor line preserved). `d}` range is `[cursor, target-1]` (cursor line deleted, blank line preserved). Verified against Neovim headless.
+6. **Fix #33: Cursor position after `c+Esc`** — Added standard Vim cursor-left-on-Esc to insert mode Escape handler.
+7. **Neovim conformance test harness** — `tests/nvim_conformance.rs`: 31 automated tests that run key sequences through both Neovim (headless) and VimCode, comparing buffer content + cursor position. Just add entries to `CASES` array — no manual testing needed. Requires `nvim` on PATH; skips gracefully if missing.
 
 **Session 279 — Vim conformance matrix tests, `:set` option audit:**
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3,7 +3,7 @@
 **Last updated:** Apr 15, 2026 (Session 280 — Fix 6 Vim deviations, Neovim conformance harness) | **Tests:** 1463 (lib) + 31 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
-> Per-session implementation notes through Session 278 are in **SESSION_HISTORY.md**.
+> Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
 
 ---
 
@@ -36,16 +36,4 @@ When implementing a new key/command, add tests covering:
 6. **Fix #33: Cursor position after `c+Esc`** — Added standard Vim cursor-left-on-Esc to insert mode Escape handler.
 7. **Neovim conformance test harness** — `tests/nvim_conformance.rs`: 31 automated tests that run key sequences through both Neovim (headless) and VimCode, comparing buffer content + cursor position. Just add entries to `CASES` array — no manual testing needed. Requires `nvim` on PATH; skips gracefully if missing.
 
-**Session 279 — Vim conformance matrix tests, `:set` option audit:**
-
-1. **Operator × motion matrix tests (Phase 1)** — 29 new parametric tests with 93 total test cases covering all 7 chunks: `d` × 14 motions + 16 text objects, `c` × 8 motions + 6 text objects, `y` × 7 motions + linewise + text objects, `>>` / `<<` × line motions, `gU`/`gu`/`g~` × 16 cases, count variations (3dw, d3w, 3dd), dot-repeat (dw., dd., x., 3x., cw+text., >>., 2dw., 3dd.).
-2. **Test infrastructure** — `send_keys(engine, "d2w")` helper parsing key strings including `<Esc>`, `<CR>`, `<C-x>`, and literal `<`/`>`. `setup_engine(text, line, col)` helper.
-3. **Bug fix: `ge`/`gE` motion** — `move_word_end_backward()` went back two words instead of one. Completely rewrote: go to start of current word → back one → skip whitespace → land at end of previous word. Also fixed `move_bigword_end_backward()`.
-4. **Bug fix: leader key intercepted `df<space>`** — Default leader (space) hijacked any operator+find+space combo. Added `pending_operator`/`pending_find_operator`/`pending_text_object` guards.
-5. **Bug fix: `dw`/`de`/`db` dot-repeat broken** — `apply_operator_with_motion()` never set `last_change`, and `repeat_last_change()` only handled `Motion::Right` (x) and `Motion::DeleteLine` (dd). Added recording + `WordForward`/`WordBackward`/`WordEnd` handlers.
-6. **Bug fix: `send_keys` parsed `<<` as special key** — Fixed by only treating `<` as sequence opener when followed by uppercase letter.
-7. **`:set` option audit (Phase 2)** — 18 new tests: round-trip test (33 settings), behavior tests (expand_tab, shift_width, ignorecase, smartcase, scrolloff, splitbelow, splitright, auto_pairs, hlsearch), ex-command tests (`:set` toggle, `:set key=val`, `:set key?`, error handling).
-8. **6 Vim deviations documented** — d}/d{ paragraph boundary, da"/da' trailing space, di</da< not implemented, 2d2w count multiplication, <G motion, cursor after c+Esc.
-9. **47 new tests** — operator matrix (29), `:set` audit (18). Total: 1463.
-
-> Session 278 and earlier in **SESSION_HISTORY.md**.
+> Session 279 and earlier in **SESSION_HISTORY.md**.

--- a/SESSION_HISTORY.md
+++ b/SESSION_HISTORY.md
@@ -1,7 +1,10 @@
 # VimCode Session History
 
 Detailed per-session implementation notes archived from PROJECT_STATE.md.
-All sessions through 278 archived here. Recent work summary in PROJECT_STATE.md.
+All sessions through 279 archived here. Recent work summary in PROJECT_STATE.md.
+
+**Session 279 — Vim conformance matrix tests, `:set` option audit:**
+Operator × motion matrix tests (Phase 1): 29 new parametric tests with 93 total test cases covering d/c/y/>>/<</ gU/gu/g~ × motions + text objects, count variations, dot-repeat. Test infrastructure: `send_keys(engine, "d2w")` helper. Bug fixes: ge/gE motion (rewrote backward word-end), leader key intercepting df<space>, dw/de/db dot-repeat, send_keys `<<` parsing. `:set` option audit (Phase 2): 18 tests for round-trip, behavior, and ex-command handling. 6 Vim deviations documented as GitHub issues (#28-#33). 47 new tests (total: 1463).
 
 **Session 278 — Find/replace hit regions, colorcolumn, `x`+`.` fix, CLAUDE.md rules:**
 Centralized find/replace hit-test geometry — `FindReplaceClickTarget` enum (13 variants), `FrHitRegion` struct, `compute_find_replace_hit_regions()` in `engine/mod.rs`. All 3 backends use shared hit regions. Shared click dispatch via `Engine::handle_find_replace_click()`. TUI mouse rewrite with hit-region-based dispatch, drag-to-select, double-click word select. GTK click handler fixed (3 geometry mismatches). Win-GUI migrated to shared dispatch. Visual selection preserved during Ctrl+F. Dynamic panel width. `:set colorcolumn` implemented with parsing, derived theme color, 3-backend rendering. `x` count+`.` repeat fixed. CLAUDE.md rules elevated. Crate extraction + Vim conformance roadmap items. 27 new tests.

--- a/SUMMARIES/engine_keys.md
+++ b/SUMMARIES/engine_keys.md
@@ -1,4 +1,4 @@
-# src/core/engine/keys.rs — 7,221 lines
+# src/core/engine/keys.rs — 7,308 lines
 
 All keyboard input handling. Routes keys by mode, processes operators, macros, repeat, user keymaps, mouse events, and clipboard.
 

--- a/SUMMARIES/engine_mod.md
+++ b/SUMMARIES/engine_mod.md
@@ -1,4 +1,4 @@
-# src/core/engine/mod.rs — 3,920 lines
+# src/core/engine/mod.rs — 3,931 lines
 
 Core engine definition. Contains the `Engine` struct (all editor state), enums, types, `new()` constructor, free functions, and `mod` declarations for all submodules.
 

--- a/SUMMARIES/engine_motions.md
+++ b/SUMMARIES/engine_motions.md
@@ -1,4 +1,4 @@
-# src/core/engine/motions.rs — 4,628 lines
+# src/core/engine/motions.rs — 4,842 lines
 
 Cursor movement, text objects, word/paragraph/sentence navigation, bracket matching, completion, code folding, indent/format, and delete operations.
 

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -3325,8 +3325,9 @@ impl Engine {
             }
             Some('{') => {
                 // d{: delete backward to previous paragraph boundary (linewise).
-                // Vim's { is exclusive: the delete range is [target_line, cursor_line - 1],
-                // i.e. the cursor's own line is excluded.
+                // Vim's { is exclusive: the blank line boundary is preserved.
+                // Range: [target_line + 1, cursor_line] when target is blank,
+                //        [target_line, cursor_line] when target is BOF (line 0, not blank).
                 let count = self.take_count();
                 let cursor_line = self.view().cursor.line;
                 for _ in 0..count {
@@ -3334,21 +3335,24 @@ impl Engine {
                 }
                 let target_line = self.view().cursor.line;
                 if target_line < cursor_line {
-                    self.apply_linewise_operator(
-                        operator,
-                        target_line,
-                        cursor_line.saturating_sub(1),
-                        changed,
-                    );
+                    let range_start = if self.is_line_empty(target_line) {
+                        target_line + 1
+                    } else {
+                        target_line
+                    };
+                    if range_start <= cursor_line {
+                        self.apply_linewise_operator(operator, range_start, cursor_line, changed);
+                    }
                 } else if target_line == cursor_line && target_line == 0 {
-                    // Already at top — Vim deletes current line
+                    // Already at top — delete current line
                     self.apply_linewise_operator(operator, cursor_line, cursor_line, changed);
                 }
             }
             Some('}') => {
                 // d}: delete forward to next paragraph boundary (linewise).
-                // Vim's } is exclusive: the delete range is [cursor_line, target_line - 1],
-                // i.e. the target blank line is excluded. Unless target is EOF.
+                // Vim's } is exclusive: the target blank line is excluded.
+                // When cursor is on a blank line, skip it for the range start
+                // (the blank line between paragraphs is a boundary, not content).
                 let count = self.take_count();
                 let cursor_line = self.view().cursor.line;
                 for _ in 0..count {
@@ -3356,16 +3360,22 @@ impl Engine {
                 }
                 let target_line = self.view().cursor.line;
                 let last_line = self.buffer().len_lines().saturating_sub(1);
+                // Exclude target blank line (unless at EOF)
                 let range_end = if target_line > cursor_line
-                    && target_line < last_line
                     && self.is_line_empty(target_line)
+                    && target_line <= last_line
                 {
                     target_line.saturating_sub(1)
                 } else {
                     target_line
                 };
-                if cursor_line <= range_end {
-                    self.apply_linewise_operator(operator, cursor_line, range_end, changed);
+                // Skip blank lines at cursor for range start
+                let mut range_start = cursor_line;
+                while range_start < range_end && self.is_line_empty(range_start) {
+                    range_start += 1;
+                }
+                if range_start <= range_end {
+                    self.apply_linewise_operator(operator, range_start, range_end, changed);
                 }
             }
             Some('(') => {

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -3325,9 +3325,10 @@ impl Engine {
             }
             Some('{') => {
                 // d{: delete backward to previous paragraph boundary (linewise).
-                // Vim's { is exclusive: the blank line boundary is preserved.
-                // Range: [target_line + 1, cursor_line] when target is blank,
-                //        [target_line, cursor_line] when target is BOF (line 0, not blank).
+                // { is exclusive: the destination (backward) is included but cursor
+                // line is excluded.  Range: [target_line, cursor_line - 1].
+                // Neovim example: "aaa\n\nbbb\nccc\nddd" cursor on ddd (line 4):
+                //   d{ → "aaa\nddd" (deletes blank + bbb + ccc, keeps cursor line)
                 let count = self.take_count();
                 let cursor_line = self.view().cursor.line;
                 for _ in 0..count {
@@ -3335,24 +3336,23 @@ impl Engine {
                 }
                 let target_line = self.view().cursor.line;
                 if target_line < cursor_line {
-                    let range_start = if self.is_line_empty(target_line) {
-                        target_line + 1
-                    } else {
-                        target_line
-                    };
-                    if range_start <= cursor_line {
-                        self.apply_linewise_operator(operator, range_start, cursor_line, changed);
-                    }
+                    self.apply_linewise_operator(
+                        operator,
+                        target_line,
+                        cursor_line.saturating_sub(1),
+                        changed,
+                    );
                 } else if target_line == cursor_line && target_line == 0 {
-                    // Already at top — delete current line
                     self.apply_linewise_operator(operator, cursor_line, cursor_line, changed);
                 }
             }
             Some('}') => {
                 // d}: delete forward to next paragraph boundary (linewise).
-                // Vim's } is exclusive: the target blank line is excluded.
-                // When cursor is on a blank line, skip it for the range start
-                // (the blank line between paragraphs is a boundary, not content).
+                // } is exclusive: cursor line is included but the destination
+                // (the blank line } lands on) is excluded.
+                // Range: [cursor_line, target_line - 1] when target is blank.
+                // Neovim example: "line one\n\nline three" cursor on line one:
+                //   d} → "\nline three" (deletes line one, keeps blank line)
                 let count = self.take_count();
                 let cursor_line = self.view().cursor.line;
                 for _ in 0..count {
@@ -3360,7 +3360,7 @@ impl Engine {
                 }
                 let target_line = self.view().cursor.line;
                 let last_line = self.buffer().len_lines().saturating_sub(1);
-                // Exclude target blank line (unless at EOF)
+                // Exclude target blank line, unless } hit EOF (last line)
                 let range_end = if target_line > cursor_line
                     && self.is_line_empty(target_line)
                     && target_line <= last_line
@@ -3369,13 +3369,8 @@ impl Engine {
                 } else {
                     target_line
                 };
-                // Skip blank lines at cursor for range start
-                let mut range_start = cursor_line;
-                while range_start < range_end && self.is_line_empty(range_start) {
-                    range_start += 1;
-                }
-                if range_start <= range_end {
-                    self.apply_linewise_operator(operator, range_start, range_end, changed);
+                if cursor_line <= range_end {
+                    self.apply_linewise_operator(operator, cursor_line, range_end, changed);
                 }
             }
             Some('(') => {

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -1231,7 +1231,8 @@ impl Engine {
             }
             Some('d') => {
                 // 'd' can be both operator (dw) and motion (dd)
-                // Set as pending_operator first
+                // Save count as operator_count so 2d3w = 6w (count multiplication)
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('d');
             }
             Some('D') => {
@@ -1243,6 +1244,7 @@ impl Engine {
             }
             Some('c') => {
                 // 'c' operator (change) - delete then enter insert mode
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('c');
             }
             Some('C') => {
@@ -1429,18 +1431,22 @@ impl Engine {
             }
             Some('>') => {
                 // > operator: set pending for >>
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('>');
             }
             Some('<') => {
                 // < operator: set pending for <<
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('<');
             }
             Some('=') => {
                 // = operator: auto-indent (== indents current line)
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('=');
             }
             Some('!') => {
                 // ! operator: filter through external command
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('!');
             }
             Some('u') => {
@@ -1456,6 +1462,7 @@ impl Engine {
                 self.repeat_last_change(count, changed);
             }
             Some('y') => {
+                self.operator_count = self.count.take();
                 self.pending_operator = Some('y');
             }
             Some('Y') => {
@@ -1575,6 +1582,7 @@ impl Engine {
                 "Escape" => {
                     // Clear count, pending key, and any extra cursors in normal mode
                     self.count = None;
+                    self.operator_count = None;
                     self.pending_key = None;
                     self.view_mut().extra_cursors.clear();
                     // Clear search highlights (like :noh)
@@ -1658,6 +1666,7 @@ impl Engine {
                 Some('g') => {
                     if let Some(op) = self.pending_operator.take() {
                         // dgg/ygg/cgg/zfgg etc: linewise operator to target line
+                        self.operator_count = None;
                         let count = self.count.take();
                         let target_line = count
                             .map(|n| {
@@ -1854,15 +1863,18 @@ impl Engine {
                 }
                 Some('~') => {
                     // g~{motion}: toggle case operator — set pending_operator and await motion
+                    self.operator_count = self.count.take();
                     self.pending_operator = Some('~');
                 }
                 Some('u') => {
                     // gu{motion}: lowercase operator
                     // Check if operator is pending (e.g. c/d + g + u) — handled elsewhere
+                    self.operator_count = self.count.take();
                     self.pending_operator = Some('u');
                 }
                 Some('U') => {
                     // gU{motion}: uppercase operator
+                    self.operator_count = self.count.take();
                     self.pending_operator = Some('U');
                 }
                 Some('n') => {
@@ -2043,10 +2055,12 @@ impl Engine {
                 }
                 Some('q') => {
                     // gq{motion}: format text operator
+                    self.operator_count = self.count.take();
                     self.pending_operator = Some('q');
                 }
                 Some('w') => {
                     // gw{motion}: format text, keep cursor
+                    self.operator_count = self.count.take();
                     self.pending_operator = Some('Q');
                 }
                 Some('R') => {
@@ -2059,6 +2073,7 @@ impl Engine {
                 }
                 Some('?') => {
                     // g?{motion}: ROT13 encode operator
+                    self.operator_count = self.count.take();
                     self.pending_operator = Some('R');
                 }
                 Some('c') => {
@@ -2644,6 +2659,7 @@ impl Engine {
                     Some('D') => self.cmd_fold_delete_recursive(),
                     // Fold: create (zf{motion})
                     Some('f') => {
+                        self.operator_count = self.count.take();
                         self.pending_operator = Some('Z');
                     }
                     Some('F') => {
@@ -2702,6 +2718,7 @@ impl Engine {
                     Some(cursor_line.saturating_sub(count))
                 }
                 Some('G') => {
+                    self.operator_count = None;
                     let count = self.count.take();
                     Some(
                         count
@@ -3289,6 +3306,8 @@ impl Engine {
             }
             Some('G') => {
                 // dG: delete from current line to end (or to line N if count given)
+                // G uses motion count as line number, not multiplied with operator count
+                self.operator_count = None;
                 let count = self.count.take();
                 let current_line = self.view().cursor.line;
                 let target_line = count
@@ -3305,34 +3324,49 @@ impl Engine {
                 self.apply_linewise_operator(operator, start, end, changed);
             }
             Some('{') => {
-                // d{: delete from current line backward to previous blank line (linewise)
+                // d{: delete backward to previous paragraph boundary (linewise).
+                // Vim's { is exclusive: the delete range is [target_line, cursor_line - 1],
+                // i.e. the cursor's own line is excluded.
                 let count = self.take_count();
-                let start_line = self.view().cursor.line;
+                let cursor_line = self.view().cursor.line;
                 for _ in 0..count {
                     self.move_paragraph_backward();
                 }
-                let end_line = self.view().cursor.line;
-                let (s, e) = if end_line <= start_line {
-                    (end_line, start_line)
-                } else {
-                    (start_line, end_line)
-                };
-                self.apply_linewise_operator(operator, s, e, changed);
+                let target_line = self.view().cursor.line;
+                if target_line < cursor_line {
+                    self.apply_linewise_operator(
+                        operator,
+                        target_line,
+                        cursor_line.saturating_sub(1),
+                        changed,
+                    );
+                } else if target_line == cursor_line && target_line == 0 {
+                    // Already at top — Vim deletes current line
+                    self.apply_linewise_operator(operator, cursor_line, cursor_line, changed);
+                }
             }
             Some('}') => {
-                // d}: delete from current line forward to next blank line (linewise)
+                // d}: delete forward to next paragraph boundary (linewise).
+                // Vim's } is exclusive: the delete range is [cursor_line, target_line - 1],
+                // i.e. the target blank line is excluded. Unless target is EOF.
                 let count = self.take_count();
-                let start_line = self.view().cursor.line;
+                let cursor_line = self.view().cursor.line;
                 for _ in 0..count {
                     self.move_paragraph_forward();
                 }
-                let end_line = self.view().cursor.line;
-                let (s, e) = if start_line <= end_line {
-                    (start_line, end_line)
+                let target_line = self.view().cursor.line;
+                let last_line = self.buffer().len_lines().saturating_sub(1);
+                let range_end = if target_line > cursor_line
+                    && target_line < last_line
+                    && self.is_line_empty(target_line)
+                {
+                    target_line.saturating_sub(1)
                 } else {
-                    (end_line, start_line)
+                    target_line
                 };
-                self.apply_linewise_operator(operator, s, e, changed);
+                if cursor_line <= range_end {
+                    self.apply_linewise_operator(operator, cursor_line, range_end, changed);
+                }
             }
             Some('(') => {
                 // d(: delete to previous sentence start (charwise)
@@ -4803,6 +4837,10 @@ impl Engine {
                 let cur = self.view().cursor;
                 self.last_insert_pos = Some((cur.line, cur.col));
                 self.set_mode(Mode::Normal);
+                // Vim moves cursor one left when leaving insert mode (unless at col 0)
+                if self.view().cursor.col > 0 {
+                    self.view_mut().cursor.col -= 1;
+                }
                 self.clamp_cursor_col();
                 // Dismiss signature help when leaving insert mode
                 self.lsp_signature_help = None;

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2093,6 +2093,9 @@ pub struct Engine {
     // --- Count state ---
     /// Accumulated count for commands (e.g., 5j, 3dd). None means no count entered yet.
     pub count: Option<usize>,
+    /// Count prefix before operator (e.g., `2` in `2d3w`). Saved when operator is set,
+    /// then multiplied with motion count in `take_count()`.
+    pub operator_count: Option<usize>,
 
     // --- Character find state ---
     /// Last character find motion: (motion_type, target_char)
@@ -2992,6 +2995,7 @@ impl Engine {
             visual_anchor: None,
             command_from_visual: None,
             count: None,
+            operator_count: None,
             last_find: None,
             pending_operator: None,
             pending_find_operator: None,

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -1629,6 +1629,7 @@ impl Engine {
             '(' | ')' => self.find_bracket_object(modifier, '(', ')', cursor_pos),
             '{' | '}' => self.find_bracket_object(modifier, '{', '}', cursor_pos),
             '[' | ']' => self.find_bracket_object(modifier, '[', ']', cursor_pos),
+            '<' | '>' => self.find_bracket_object(modifier, '<', '>', cursor_pos),
             'p' => self.find_paragraph_object(modifier, cursor_pos),
             's' => self.find_sentence_object(modifier, cursor_pos),
             't' => self.find_tag_text_object(modifier, cursor_pos),
@@ -1762,8 +1763,35 @@ impl Engine {
                 None
             }
         } else {
-            // Around: include quotes
-            Some((open_pos, close_pos + 1))
+            // Around: include quotes + trailing whitespace (or leading if no trailing)
+            let mut end = close_pos + 1;
+            let mut start = open_pos;
+            // Try trailing whitespace first
+            let mut trail = end;
+            while trail < line_end {
+                let ch = self.buffer().content.char(trail);
+                if ch == ' ' || ch == '\t' {
+                    trail += 1;
+                } else {
+                    break;
+                }
+            }
+            if trail > end {
+                end = trail;
+            } else {
+                // No trailing whitespace — try leading whitespace
+                let mut lead = start;
+                while lead > line_start {
+                    let ch = self.buffer().content.char(lead - 1);
+                    if ch == ' ' || ch == '\t' {
+                        lead -= 1;
+                    } else {
+                        break;
+                    }
+                }
+                start = lead;
+            }
+            Some((start, end))
         }
     }
 
@@ -3708,7 +3736,9 @@ impl Engine {
     /// This clears the count field.
     #[allow(dead_code)] // Will be used in Step 2 for motion commands
     pub fn take_count(&mut self) -> usize {
-        self.count.take().unwrap_or(1)
+        let op_count = self.operator_count.take().unwrap_or(1);
+        let motion_count = self.count.take().unwrap_or(1);
+        op_count * motion_count
     }
 
     /// Peeks at the current count without consuming it. Used for UI display.

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -4131,7 +4131,7 @@ fn test_da_quote_double() {
     press_char(&mut engine, 'a');
     press_char(&mut engine, '"');
 
-    assert_eq!(engine.buffer().to_string(), "foo  bar");
+    assert_eq!(engine.buffer().to_string(), "foo bar");
     assert_eq!(engine.view().cursor.col, 4);
 }
 
@@ -19479,14 +19479,15 @@ fn send_keys(engine: &mut Engine, keys: &str) {
     let mut chars = keys.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch == '<' {
-            // Check if this looks like a <SpecialKey> sequence:
-            // peek at the next char — if it's uppercase or part of "C-", parse as special.
-            // Otherwise treat '<' as a literal key.
-            let is_special = chars
+            // Only parse as <SpecialKey> if the remaining string contains a matching '>'.
+            // Collect the rest of the iterator to peek ahead.
+            let rest: String = chars.clone().collect();
+            let has_closing = rest.contains('>');
+            let starts_special = chars
                 .peek()
                 .map(|&c| c.is_ascii_uppercase() || c == 'C')
                 .unwrap_or(false);
-            if is_special {
+            if has_closing && starts_special {
                 let name: String = chars.by_ref().take_while(|&c| c != '>').collect();
                 match name.as_str() {
                     "Esc" => press_special(engine, "Escape"),
@@ -19683,24 +19684,27 @@ fn test_matrix_delete_linewise_motions() {
             0,
             0,
         ),
-        // paragraph motions
-        // NOTE: Neovim d} preserves the blank line ("\nline three"), VimCode deletes it.
-        // TODO: Fix paragraph motion boundary to match Vim — d} should stop AT the blank
-        // line, not past it.
+        // paragraph motions — Vim's } and { are exclusive, so the target line is excluded
         (
             "d}",
             "line one\n\nline three",
             0,
             0,
             "d}",
-            "line three",
+            "\nline three",
             0,
             0,
         ),
-        // NOTE: Neovim d{ from line 3 col 0 gives "line one\nline three" (cursor at
-        // line 1 col 0). VimCode gives "line one" — deletes too much.
-        // TODO: Fix d{ paragraph motion to match Vim.
-        ("d{", "line one\n\nline three", 2, 0, "d{", "line one", 0, 0),
+        (
+            "d{",
+            "line one\n\nline three",
+            2,
+            0,
+            "d{",
+            "line one\nline three",
+            1,
+            0,
+        ),
         // dd
         ("dd_mid", "one\ntwo\nthree", 1, 0, "dd", "one\nthree", 1, 0),
         // d with count on j
@@ -19854,16 +19858,14 @@ fn test_matrix_delete_text_objects() {
             0,
             5,
         ),
-        // NOTE: Neovim da" gives "say now" (col 4). VimCode gives "say  now" (col 4)
-        // — VimCode deletes the quotes+content but not the trailing space.
-        // TODO: Fix a" text object to include trailing whitespace per Vim spec.
+        // da" includes trailing whitespace per Vim spec
         (
             "da_dq",
             "say \"hello world\" now",
             0,
             5,
             "da\"",
-            "say  now",
+            "say now",
             0,
             4,
         ),
@@ -19878,14 +19880,14 @@ fn test_matrix_delete_text_objects() {
             0,
             5,
         ),
-        // NOTE: Same trailing-whitespace issue as da" — see TODO above.
+        // da' includes trailing whitespace per Vim spec
         (
             "da_sq",
             "say 'hello world' now",
             0,
             5,
             "da'",
-            "say  now",
+            "say now",
             0,
             4,
         ),
@@ -19898,10 +19900,9 @@ fn test_matrix_delete_text_objects() {
         // bracket objects
         ("di[", "arr[x + y] end", 0, 4, "di[", "arr[] end", 0, 4),
         ("da[", "arr[x + y] end", 0, 4, "da[", "arr end", 0, 3),
-        // angle bracket objects — NOT YET IMPLEMENTED (missing from find_text_object_range)
-        // TODO: Add < > to find_text_object_range as find_bracket_object('<', '>')
-        // ("di<", "tag<x + y>end", 0, 4, "di<", "tag<>end", 0, 4),
-        // ("da<", "tag<x + y>end", 0, 4, "da<", "tagend", 0, 3),
+        // angle bracket objects
+        ("di<", "tag<x + y>end", 0, 4, "di<", "tag<>end", 0, 4),
+        ("da<", "tag<x + y>end", 0, 4, "da<", "tagend", 0, 3),
         // tag objects
         ("dit", "<div>hello</div>", 0, 5, "dit", "<div></div>", 0, 5),
         ("dat", "<div>hello</div>", 0, 5, "dat", "", 0, 0),
@@ -20028,8 +20029,8 @@ fn test_matrix_change_char_motions() {
             0,
             0,
         ),
-        // NOTE: Neovim c^<Esc> cursor at col 1. VimCode: col 2 (insert position, not -1).
-        ("c^", "  hello world", 0, 5, "c^<Esc>", "  lo world", 0, 2),
+        // Vim: Esc from insert moves cursor one left
+        ("c^", "  hello world", 0, 5, "c^<Esc>", "  lo world", 0, 1),
         ("cw", "hello world foo", 0, 0, "cw<Esc>", " world foo", 0, 0),
         ("cW", "hello.world foo", 0, 0, "cW<Esc>", " foo", 0, 0),
         ("cb", "hello world foo", 0, 6, "cb<Esc>", "world foo", 0, 0),
@@ -20141,7 +20142,7 @@ fn test_matrix_change_linewise_motions() {
 #[test]
 fn test_matrix_change_text_objects() {
     let cases: &[(&str, &str, usize, usize, &str, &str, usize, usize)] = &[
-        // NOTE: Neovim ciw<Esc> cursor at col 5 (one-left of insert). VimCode: col 6.
+        // Vim moves cursor one left when exiting insert mode via Esc
         (
             "ciw",
             "hello world foo",
@@ -20150,9 +20151,8 @@ fn test_matrix_change_text_objects() {
             "ciw<Esc>",
             "hello  foo",
             0,
-            6,
+            5,
         ),
-        // NOTE: Neovim caw<Esc> cursor at col 5. VimCode: col 6.
         (
             "caw",
             "hello world foo",
@@ -20161,10 +20161,8 @@ fn test_matrix_change_text_objects() {
             "caw<Esc>",
             "hello foo",
             0,
-            6,
+            5,
         ),
-        // NOTE: Neovim ci"<Esc> cursor at col 4. VimCode: col 5 (Esc doesn't
-        // move left when between delimiters). Same +1 pattern for all bracket objects.
         (
             "ci_dq",
             "say \"hello world\" now",
@@ -20173,10 +20171,10 @@ fn test_matrix_change_text_objects() {
             "ci\"<Esc>",
             "say \"\" now",
             0,
-            5,
+            4,
         ),
-        ("ci(", "fn(a, b) end", 0, 3, "ci(<Esc>", "fn() end", 0, 3),
-        ("ci{", "if {x + y} end", 0, 4, "ci{<Esc>", "if {} end", 0, 4),
+        ("ci(", "fn(a, b) end", 0, 3, "ci(<Esc>", "fn() end", 0, 2),
+        ("ci{", "if {x + y} end", 0, 4, "ci{<Esc>", "if {} end", 0, 3),
         (
             "cit",
             "<div>hello</div>",
@@ -20185,7 +20183,7 @@ fn test_matrix_change_text_objects() {
             "cit<Esc>",
             "<div></div>",
             0,
-            5,
+            4,
         ),
     ];
 
@@ -20514,9 +20512,14 @@ fn test_matrix_outdent_motions() {
             "<j",
             "hello\nworld\nfoo",
         ),
-        // NOTE: <G (outdent to end of file) doesn't work in VimCode.
-        // >G works fine. TODO: Fix < operator + G motion.
-        // ("<G", "    one\n    two\n    three", 0, 0, "<G", "one\ntwo\nthree"),
+        (
+            "<G",
+            "    one\n    two\n    three",
+            0,
+            0,
+            "<G",
+            "one\ntwo\nthree",
+        ),
     ];
 
     for &(label, buf, cline, ccol, keys, expected_buf) in cases {
@@ -20580,10 +20583,10 @@ fn test_matrix_count_variations() {
     let cases: &[(&str, &str, usize, usize, &str, &str)] = &[
         ("3dw", "one two three four five", 0, 0, "3dw", "four five"),
         ("d3w", "one two three four five", 0, 0, "d3w", "four five"),
-        // NOTE: Neovim 2d2w deletes 4 words (2*2). VimCode's count accumulation
-        // treats "2d2w" as d22w (count becomes 22), deleting everything.
-        // TODO: Fix count handling so operator count and motion count multiply.
-        // ("2d2w", "one two three four five", 0, 0, "2d2w", "five"),
+        // operator_count × motion_count: 2d2w = d4w (deletes 4 words)
+        ("2d2w", "one two three four five", 0, 0, "2d2w", "five"),
+        // 3d2w = d6w (deletes 6 words)
+        ("3d2w", "a b c d e f g h", 0, 0, "3d2w", "g h"),
         ("3dd", "a\nb\nc\nd\ne", 0, 0, "3dd", "d\ne"),
         (
             "2gUw",

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -19684,7 +19684,7 @@ fn test_matrix_delete_linewise_motions() {
             0,
             0,
         ),
-        // paragraph motions — Vim's } and { are exclusive, so the target line is excluded
+        // paragraph motions — Vim's } and { are exclusive: blank line boundary preserved
         (
             "d}",
             "line one\n\nline three",
@@ -19695,14 +19695,28 @@ fn test_matrix_delete_linewise_motions() {
             0,
             0,
         ),
+        // d{ from line after blank: blank line preserved, cursor line + content deleted
         (
             "d{",
             "line one\n\nline three",
             2,
             0,
             "d{",
-            "line one\nline three",
+            "line one\n",
+            0,
+            0,
+        ),
+        // d{ with multiple lines after blank
+        ("d{_multi", "aaa\n\nbbb\nccc", 3, 0, "d{", "aaa\n", 0, 0),
+        // d} from blank line: blank line preserved, paragraph content deleted
+        (
+            "d}_from_blank",
+            "aaa\n\nbbb\nccc\n\nddd",
             1,
+            0,
+            "d}",
+            "aaa\n\n\nddd",
+            2,
             0,
         ),
         // dd
@@ -20429,6 +20443,13 @@ fn test_matrix_yank_with_count() {
     assert_eq!(engine.buffer().to_string(), "one two three four");
     let (content, _) = engine.registers.get(&'"').unwrap();
     assert_eq!(content, "one two ");
+
+    // 3y2w = yank 6 words (operator_count=3 × motion_count=2)
+    let mut engine = setup_engine("a b c d e f g h", 0, 0);
+    send_keys(&mut engine, "3y2w");
+    let (content, is_linewise) = engine.registers.get(&'"').unwrap();
+    assert_eq!(content, "a b c d e f ", "3y2w should yank 6 words");
+    assert!(!is_linewise, "3y2w should be charwise");
 }
 
 #[test]

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -19684,7 +19684,8 @@ fn test_matrix_delete_linewise_motions() {
             0,
             0,
         ),
-        // paragraph motions — Vim's } and { are exclusive: blank line boundary preserved
+        // paragraph motions — { and } are exclusive at the motion destination
+        // d}: cursor line included, target blank line excluded
         (
             "d}",
             "line one\n\nline three",
@@ -19695,28 +19696,39 @@ fn test_matrix_delete_linewise_motions() {
             0,
             0,
         ),
-        // d{ from line after blank: blank line preserved, cursor line + content deleted
+        // d{: destination (blank line) included, cursor line excluded
+        // Neovim: "line one\n\nline three" d{ from line 2 → "line one\nline three"
         (
             "d{",
             "line one\n\nline three",
             2,
             0,
             "d{",
-            "line one\n",
-            0,
+            "line one\nline three",
+            1,
             0,
         ),
-        // d{ with multiple lines after blank
-        ("d{_multi", "aaa\n\nbbb\nccc", 3, 0, "d{", "aaa\n", 0, 0),
-        // d} from blank line: blank line preserved, paragraph content deleted
+        // d{ multi-line: "aaa\n\nbbb\nccc\nddd" d{ from ddd → "aaa\nddd"
+        (
+            "d{_multi",
+            "aaa\n\nbbb\nccc\nddd",
+            4,
+            0,
+            "d{",
+            "aaa\nddd",
+            1,
+            0,
+        ),
+        // d} from blank line: blank line + content deleted, target blank excluded
+        // "aaa\n\nbbb\nccc\n\nddd" d} from line 1 → "aaa\n\nddd"
         (
             "d}_from_blank",
             "aaa\n\nbbb\nccc\n\nddd",
             1,
             0,
             "d}",
-            "aaa\n\n\nddd",
-            2,
+            "aaa\n\nddd",
+            1,
             0,
         ),
         // dd

--- a/tests/nvim_conformance.rs
+++ b/tests/nvim_conformance.rs
@@ -1,0 +1,523 @@
+//! Neovim conformance tests — automatically verify VimCode behavior against Neovim.
+//!
+//! Each test case defines:
+//!   - initial buffer content (lines)
+//!   - cursor position (1-indexed line, 1-indexed col — Neovim convention)
+//!   - key sequence to execute (Vim normal-mode keys)
+//!
+//! The test runs the same scenario through both Neovim (headless) and VimCode,
+//! then asserts that the resulting buffer content and cursor position match.
+//!
+//! To add a new conformance test, just add an entry to the `CASES` array.
+//! No manual testing needed — Neovim is the oracle.
+//!
+//! Requires `nvim` on PATH. Tests are skipped (not failed) if nvim is missing.
+
+mod common;
+
+use common::engine_with;
+use serde::Deserialize;
+use std::io::Write;
+use vimcode_core::Engine;
+
+// ---------------------------------------------------------------------------
+// Neovim oracle
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct NvimResult {
+    buf: Vec<String>,
+    line: usize,
+    col: usize,
+}
+
+/// Run a key sequence in Neovim headless and return (buffer_lines, cursor_line_1, cursor_col_1).
+fn run_in_neovim(
+    lines: &[&str],
+    cursor_line_1: usize,
+    cursor_col_1: usize,
+    keys: &str,
+) -> Option<NvimResult> {
+    // Build a Lua script that sets up buffer, runs keys, writes result
+    let mut lua = String::new();
+    lua.push_str("vim.o.compatible = false\n");
+    lua.push_str("vim.o.shiftwidth = 4\n");
+    lua.push_str("vim.o.expandtab = true\n");
+
+    // Set buffer lines
+    lua.push_str("vim.api.nvim_buf_set_lines(0, 0, -1, false, {");
+    for (i, line) in lines.iter().enumerate() {
+        if i > 0 {
+            lua.push_str(", ");
+        }
+        // Escape backslashes and quotes for Lua string
+        let escaped = line.replace('\\', "\\\\").replace('"', "\\\"");
+        lua.push('"');
+        lua.push_str(&escaped);
+        lua.push('"');
+    }
+    lua.push_str("})\n");
+
+    // Set cursor position (1-indexed)
+    lua.push_str(&format!(
+        "vim.api.nvim_win_set_cursor(0, {{{}, {}}})\n",
+        cursor_line_1,
+        cursor_col_1.saturating_sub(1) // nvim_win_set_cursor col is 0-indexed
+    ));
+
+    // Execute keys via feedkeys with 'nx' flags (noremap, execute immediately)
+    // Escape special characters for Lua
+    let escaped_keys = keys.replace('\\', "\\\\").replace('"', "\\\"");
+    lua.push_str(&format!(
+        "vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(\"{}\", true, false, true), \"nx\", false)\n",
+        escaped_keys
+    ));
+
+    // Capture result
+    let result_path = std::env::temp_dir().join("vimcode_nvim_conformance.json");
+    let result_path_str = result_path.to_string_lossy().replace('\\', "/");
+    lua.push_str(&format!(
+        "local buf = vim.api.nvim_buf_get_lines(0, 0, -1, false)\n\
+         local pos = vim.api.nvim_win_get_cursor(0)\n\
+         local result = vim.fn.json_encode({{buf = buf, line = pos[1], col = pos[2] + 1}})\n\
+         local f = io.open(\"{}\", \"w\")\n\
+         f:write(result)\n\
+         f:close()\n\
+         vim.cmd(\"qa!\")\n",
+        result_path_str
+    ));
+
+    // Write lua script to temp file
+    let script_path = std::env::temp_dir().join("vimcode_nvim_conformance.lua");
+    {
+        let mut f = std::fs::File::create(&script_path).ok()?;
+        f.write_all(lua.as_bytes()).ok()?;
+    }
+
+    // Remove old result file
+    let _ = std::fs::remove_file(&result_path);
+
+    // Run nvim
+    let output = std::process::Command::new("nvim")
+        .arg("--headless")
+        .arg("-u")
+        .arg("NONE")
+        .arg("-l")
+        .arg(script_path.to_string_lossy().as_ref())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        eprintln!("nvim stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return None;
+    }
+
+    // Read result
+    let json = std::fs::read_to_string(&result_path).ok()?;
+    serde_json::from_str(&json).ok()
+}
+
+// ---------------------------------------------------------------------------
+// VimCode runner
+// ---------------------------------------------------------------------------
+
+fn press_char(engine: &mut Engine, ch: char) {
+    engine.handle_key(&ch.to_string(), Some(ch), false);
+}
+
+fn press_special(engine: &mut Engine, name: &str) {
+    engine.handle_key(name, None, false);
+}
+
+fn press_ctrl(engine: &mut Engine, ch: char) {
+    engine.handle_key(&ch.to_string(), Some(ch), true);
+}
+
+/// Parse and send a key sequence to the engine.
+/// Supports <Esc>, <CR>, <C-x>, and literal characters.
+fn send_keys(engine: &mut Engine, keys: &str) {
+    let mut chars = keys.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '<' {
+            let rest: String = chars.clone().collect();
+            let has_closing = rest.contains('>');
+            let starts_special = chars
+                .peek()
+                .map(|&c| c.is_ascii_uppercase() || c == 'C')
+                .unwrap_or(false);
+            if has_closing && starts_special {
+                let name: String = chars.by_ref().take_while(|&c| c != '>').collect();
+                match name.as_str() {
+                    "Esc" => press_special(engine, "Escape"),
+                    "CR" | "Enter" => press_special(engine, "Return"),
+                    "BS" => press_special(engine, "BackSpace"),
+                    "Tab" => press_special(engine, "Tab"),
+                    "Del" | "Delete" => press_special(engine, "Delete"),
+                    "Up" => press_special(engine, "Up"),
+                    "Down" => press_special(engine, "Down"),
+                    "Left" => press_special(engine, "Left"),
+                    "Right" => press_special(engine, "Right"),
+                    n if n.starts_with("C-") => {
+                        let ctrl_char = n.chars().nth(2).unwrap();
+                        press_ctrl(engine, ctrl_char);
+                    }
+                    other => press_special(engine, other),
+                }
+            } else {
+                press_char(engine, '<');
+            }
+        } else {
+            press_char(engine, ch);
+        }
+    }
+}
+
+fn run_in_vimcode(
+    lines: &[&str],
+    cursor_line_1: usize,
+    cursor_col_1: usize,
+    keys: &str,
+) -> (String, usize, usize) {
+    let text = lines.join("\n");
+    let mut engine = engine_with(&text);
+    engine.settings.shift_width = 4;
+    engine.settings.expand_tab = true;
+    // Convert from 1-indexed to 0-indexed
+    engine.view_mut().cursor.line = cursor_line_1.saturating_sub(1);
+    engine.view_mut().cursor.col = cursor_col_1.saturating_sub(1);
+
+    send_keys(&mut engine, keys);
+
+    let buf = engine.buffer().to_string();
+    let line = engine.view().cursor.line + 1; // back to 1-indexed
+    let col = engine.view().cursor.col + 1;
+    (buf, line, col)
+}
+
+// ---------------------------------------------------------------------------
+// Test cases — add new conformance checks here
+// ---------------------------------------------------------------------------
+
+struct Case {
+    /// Short label for the test
+    label: &'static str,
+    /// Initial buffer lines
+    lines: &'static [&'static str],
+    /// Cursor line (1-indexed)
+    cursor_line: usize,
+    /// Cursor col (1-indexed)
+    cursor_col: usize,
+    /// Key sequence to execute
+    keys: &'static str,
+}
+
+const CASES: &[Case] = &[
+    // --- Paragraph motions with operators ---
+    Case {
+        label: "d} basic",
+        lines: &["line one", "", "line three"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "d}",
+    },
+    Case {
+        label: "d{ basic",
+        lines: &["line one", "", "line three"],
+        cursor_line: 3,
+        cursor_col: 1,
+        keys: "d{",
+    },
+    Case {
+        label: "d{ multi-line",
+        lines: &["aaa", "", "bbb", "ccc", "ddd"],
+        cursor_line: 5,
+        cursor_col: 1,
+        keys: "d{",
+    },
+    Case {
+        label: "d{ from first line of para",
+        lines: &["aaa", "", "bbb", "ccc"],
+        cursor_line: 3,
+        cursor_col: 1,
+        keys: "d{",
+    },
+    Case {
+        label: "d} from blank line",
+        lines: &["aaa", "", "bbb", "ccc", "", "ddd"],
+        cursor_line: 2,
+        cursor_col: 1,
+        keys: "d}",
+    },
+    Case {
+        label: "d} to EOF (no trailing blank)",
+        lines: &["aaa", "", "bbb", "ccc"],
+        cursor_line: 3,
+        cursor_col: 1,
+        keys: "d}",
+    },
+    // --- Count multiplication ---
+    Case {
+        label: "2d2w",
+        lines: &["one two three four five"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "2d2w",
+    },
+    Case {
+        label: "3d2w",
+        lines: &["a b c d e f g h"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "3d2w",
+    },
+    Case {
+        label: "d3w",
+        lines: &["one two three four five"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "d3w",
+    },
+    Case {
+        label: "3dw",
+        lines: &["one two three four five"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "3dw",
+    },
+    // --- Angle bracket text objects ---
+    Case {
+        label: "di<",
+        lines: &["tag<x + y>end"],
+        cursor_line: 1,
+        cursor_col: 5,
+        keys: "di<",
+    },
+    Case {
+        label: "da<",
+        lines: &["tag<x + y>end"],
+        cursor_line: 1,
+        cursor_col: 5,
+        keys: "da<",
+    },
+    // --- Quote text objects with whitespace ---
+    Case {
+        label: "da\" trailing space",
+        lines: &["say \"hello world\" now"],
+        cursor_line: 1,
+        cursor_col: 6,
+        keys: "da\"",
+    },
+    Case {
+        label: "da' trailing space",
+        lines: &["say 'hello world' now"],
+        cursor_line: 1,
+        cursor_col: 6,
+        keys: "da'",
+    },
+    Case {
+        label: "da\" no trailing (leading consumed)",
+        lines: &["say \"hello\""],
+        cursor_line: 1,
+        cursor_col: 6,
+        keys: "da\"",
+    },
+    // --- Change + Esc cursor position ---
+    Case {
+        label: "cw<Esc>",
+        lines: &["hello world foo"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "cw<Esc>",
+    },
+    Case {
+        label: "ciw<Esc>",
+        lines: &["hello world foo"],
+        cursor_line: 1,
+        cursor_col: 7,
+        keys: "ciw<Esc>",
+    },
+    Case {
+        label: "ci\"<Esc>",
+        lines: &["say \"hello\" now"],
+        cursor_line: 1,
+        cursor_col: 6,
+        keys: "ci\"<Esc>",
+    },
+    // --- Indent/outdent with motions ---
+    Case {
+        label: "<G outdent",
+        lines: &["    one", "    two", "    three"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "<G",
+    },
+    Case {
+        label: ">j indent",
+        lines: &["one", "two", "three"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: ">j",
+    },
+    // --- Basic motions with operators ---
+    Case {
+        label: "dd",
+        lines: &["one", "two", "three"],
+        cursor_line: 2,
+        cursor_col: 1,
+        keys: "dd",
+    },
+    Case {
+        label: "3dd",
+        lines: &["a", "b", "c", "d", "e"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "3dd",
+    },
+    Case {
+        label: "dj",
+        lines: &["aaa", "bbb", "ccc"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "dj",
+    },
+    Case {
+        label: "dk",
+        lines: &["aaa", "bbb", "ccc"],
+        cursor_line: 2,
+        cursor_col: 1,
+        keys: "dk",
+    },
+    Case {
+        label: "dw",
+        lines: &["hello world foo"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "dw",
+    },
+    Case {
+        label: "de",
+        lines: &["hello world foo"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "de",
+    },
+    Case {
+        label: "db",
+        lines: &["hello world foo"],
+        cursor_line: 1,
+        cursor_col: 7,
+        keys: "db",
+    },
+    Case {
+        label: "d$",
+        lines: &["hello world"],
+        cursor_line: 1,
+        cursor_col: 6,
+        keys: "d$",
+    },
+    Case {
+        label: "d0",
+        lines: &["hello world"],
+        cursor_line: 1,
+        cursor_col: 6,
+        keys: "d0",
+    },
+    Case {
+        label: "yy then p",
+        lines: &["aaa", "bbb"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "yyp",
+    },
+    // --- Visual + delete ---
+    Case {
+        label: "vwd",
+        lines: &["hello world foo"],
+        cursor_line: 1,
+        cursor_col: 1,
+        keys: "vwd",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nvim_conformance() {
+    // Check if nvim is available
+    let nvim_ok = std::process::Command::new("nvim")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if !nvim_ok {
+        eprintln!("SKIP: nvim not found on PATH");
+        return;
+    }
+
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut failures = Vec::new();
+
+    for case in CASES {
+        let nvim = run_in_neovim(case.lines, case.cursor_line, case.cursor_col, case.keys);
+        let nvim = match nvim {
+            Some(r) => r,
+            None => {
+                eprintln!("  SKIP [{}]: nvim execution failed", case.label);
+                continue;
+            }
+        };
+
+        let (vc_buf, vc_line, vc_col) =
+            run_in_vimcode(case.lines, case.cursor_line, case.cursor_col, case.keys);
+
+        let nvim_buf = nvim.buf.join("\n");
+        let buf_match = vc_buf.trim_end_matches('\n') == nvim_buf.trim_end_matches('\n');
+        // Neovim counts a trailing newline as an extra empty line;
+        // ropey does not.  Allow VimCode cursor to be one line earlier
+        // when the buffer ends with '\n' and Neovim's last line is empty.
+        let cursor_match = if vc_line == nvim.line && vc_col == nvim.col {
+            true
+        } else if vc_buf.ends_with('\n')
+            && nvim.buf.last().map(|s| s.is_empty()).unwrap_or(false)
+            && vc_line + 1 == nvim.line
+            && vc_col == nvim.col
+        {
+            true // trailing-newline line-count difference — acceptable
+        } else {
+            false
+        };
+
+        if buf_match && cursor_match {
+            passed += 1;
+        } else {
+            failed += 1;
+            let mut msg = format!("FAIL [{}] keys={:?}\n", case.label, case.keys);
+            msg.push_str(&format!(
+                "  buffer: nvim={:?} vimcode={:?}\n",
+                nvim_buf, vc_buf
+            ));
+            msg.push_str(&format!(
+                "  cursor: nvim=({},{}) vimcode=({},{})\n",
+                nvim.line, nvim.col, vc_line, vc_col
+            ));
+            failures.push(msg);
+        }
+    }
+
+    println!("\n=== Neovim Conformance Results ===");
+    println!("Passed: {passed}");
+    println!("Failed: {failed}");
+    println!("Total:  {}\n", passed + failed);
+
+    if !failures.is_empty() {
+        println!("Failures:");
+        for f in &failures {
+            println!("{f}");
+        }
+        panic!("{failed} conformance test(s) failed");
+    }
+}


### PR DESCRIPTION
## Summary
- **#31**: Fix `2d2w` count multiplication — operator count and motion count now multiply correctly instead of concatenating digits
- **#32**: Fix `<G` outdent — was a `send_keys()` test parser bug treating `<G` as a special key; engine was correct
- **#30**: Implement `di</da<` angle bracket text objects via existing bracket matching logic
- **#29**: Fix `da"/da'` to include trailing whitespace (or leading if none) per Vim spec
- **#28**: Fix `d}/d{` paragraph boundary — motions are exclusive, so target blank line is excluded from delete range
- **#33**: Fix cursor position after `c+Esc` — Vim standard: cursor moves one left when exiting insert mode

Closes #28, closes #29, closes #30, closes #31, closes #32, closes #33

## Test plan
- [x] All 1463 existing tests pass (no regressions)
- [x] Updated test expectations for `da"`, `da'`, `c+Esc` cursor position, `d}`, `d{`
- [x] Added new test cases: `2d2w`, `3d2w`, `<G`, `di<`, `da<`
- [x] `cargo clippy -- -D warnings` clean (both default and win-gui features)
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)