### PR TITLE
fix: 8 Vim deviations (J/gJ cursor, 3rX, C, ib/aB, ci( empty)

### DIFF
--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -1248,10 +1248,14 @@ impl Engine {
                 self.pending_operator = Some('c');
             }
             Some('C') => {
-                // C: delete from cursor to end of line, enter insert mode
+                // C: delete from cursor to end of line, enter insert mode.
+                // Save cursor col before delete — clamp_cursor_col will pull
+                // it left, but for C we need to insert at the original position.
                 let count = self.take_count();
+                let saved_col = self.view().cursor.col;
                 self.start_undo_group();
                 self.delete_to_end_of_line_with_count(count, changed);
+                self.view_mut().cursor.col = saved_col;
                 self.insert_text_buffer.clear();
                 self.mode = Mode::Insert;
                 self.count = None;
@@ -6702,13 +6706,11 @@ impl Engine {
                 // Handle other operations
             }
             ChangeOp::Replace => {
-                // Repeat r command
+                // Repeat r command — final_count is the number of chars to replace
                 if let Some(replacement_char) = change.text.chars().next() {
-                    for _ in 0..final_count {
-                        self.start_undo_group();
-                        self.replace_chars(replacement_char, change.count, changed);
-                        self.finish_undo_group();
-                    }
+                    self.start_undo_group();
+                    self.replace_chars(replacement_char, final_count, changed);
+                    self.finish_undo_group();
                 }
             }
             ChangeOp::ToggleCase => {

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -945,12 +945,14 @@ impl Engine {
     pub(crate) fn join_lines_no_space(&mut self, count: usize, changed: &mut bool) {
         let total_lines = self.buffer().len_lines();
         let start_line = self.view().cursor.line;
-        let joins = count.min(total_lines.saturating_sub(start_line + 1));
+        let joins = if count <= 1 { 1 } else { count - 1 };
+        let joins = joins.min(total_lines.saturating_sub(start_line + 1));
         if joins == 0 {
             return;
         }
 
         self.start_undo_group();
+        let mut join_col = 0usize;
         for _ in 0..joins {
             let cur_line = self.view().cursor.line;
             let next_line = cur_line + 1;
@@ -961,21 +963,14 @@ impl Engine {
             let cur_line_len = self.buffer().line_len_chars(cur_line);
             let cur_line_start = self.buffer().line_to_char(cur_line);
             let newline_pos = cur_line_start + cur_line_len - 1;
+            join_col = newline_pos - cur_line_start;
 
-            // Count leading whitespace on next line
-            let next_line_content: String = self.buffer().content.line(next_line).chars().collect();
-            let leading_ws = next_line_content
-                .chars()
-                .take_while(|c| *c == ' ' || *c == '\t')
-                .count();
-
-            // Delete newline + all leading whitespace of next line (no space inserted)
-            let next_line_start = self.buffer().line_to_char(next_line);
-            let del_end = next_line_start + leading_ws;
-            self.delete_with_undo(newline_pos, del_end);
+            // gJ does NOT strip leading whitespace — just remove the newline
+            self.delete_with_undo(newline_pos, newline_pos + 1);
         }
         self.finish_undo_group();
 
+        self.view_mut().cursor.col = join_col;
         self.clamp_cursor_col();
         *changed = true;
     }
@@ -1626,8 +1621,8 @@ impl Engine {
             'W' => self.find_bigword_object(modifier, cursor_pos),
             '"' => self.find_quote_object(modifier, '"', cursor_pos),
             '\'' => self.find_quote_object(modifier, '\'', cursor_pos),
-            '(' | ')' => self.find_bracket_object(modifier, '(', ')', cursor_pos),
-            '{' | '}' => self.find_bracket_object(modifier, '{', '}', cursor_pos),
+            '(' | ')' | 'b' => self.find_bracket_object(modifier, '(', ')', cursor_pos),
+            '{' | '}' | 'B' => self.find_bracket_object(modifier, '{', '}', cursor_pos),
             '[' | ']' => self.find_bracket_object(modifier, '[', ']', cursor_pos),
             '<' | '>' => self.find_bracket_object(modifier, '<', '>', cursor_pos),
             'p' => self.find_paragraph_object(modifier, cursor_pos),
@@ -2523,6 +2518,18 @@ impl Engine {
 
         let (start_pos, end_pos) = range;
         if start_pos >= end_pos {
+            // Empty inner range (e.g. ci( on "()"). For 'c' operator,
+            // still enter insert mode at the position between the delimiters.
+            if operator == 'c' {
+                let line = self.buffer().content.char_to_line(start_pos);
+                let line_start = self.buffer().line_to_char(line);
+                self.view_mut().cursor.line = line;
+                self.view_mut().cursor.col = start_pos - line_start;
+                self.mode = Mode::Insert;
+                self.start_undo_group();
+                self.insert_text_buffer.clear();
+                *changed = true;
+            }
             return;
         }
 
@@ -3797,8 +3804,8 @@ impl Engine {
             self.delete_with_undo(char_idx, char_idx + to_replace);
             self.insert_with_undo(char_idx, &replacement_str);
 
-            // Keep cursor at the start position (Vim behavior)
-            self.view_mut().cursor.col = col;
+            // Cursor on last replaced char (Neovim behavior)
+            self.view_mut().cursor.col = col + to_replace - 1;
             self.clamp_cursor_col();
             *changed = true;
         }
@@ -4518,13 +4525,15 @@ impl Engine {
         let total_lines = self.buffer().len_lines();
         let start_line = self.view().cursor.line;
 
-        // We join (count) times; each join merges current line with next
-        let joins = count.min(total_lines.saturating_sub(start_line + 1));
+        // Vim: J joins 2 lines (1 join), 3J joins 3 lines (2 joins).
+        let joins = if count <= 1 { 1 } else { count - 1 };
+        let joins = joins.min(total_lines.saturating_sub(start_line + 1));
         if joins == 0 {
             return;
         }
 
         self.start_undo_group();
+        let mut join_col = 0usize; // track the join point for cursor placement
         for _ in 0..joins {
             let cur_line = self.view().cursor.line;
             let next_line = cur_line + 1;
@@ -4553,22 +4562,25 @@ impl Engine {
             let del_end = next_line_start + leading_ws;
             self.delete_with_undo(newline_pos, del_end);
 
-            // Insert a space unless the next non-ws char is ')' or next line was empty/only ws
-            // Also don't add space if the current line ends with a space
+            // Insert a space unless the next non-ws char is ')' or next line was empty/only ws.
+            // Also don't add space if the current line already ends with whitespace.
             let should_add_space = !matches!(next_non_ws, None | Some(')') | Some(']') | Some('}'));
-            // Check if current line ends with space (after the newline was removed)
-            let cur_end_char =
-                self.buffer().line_to_char(cur_line) + self.buffer().line_len_chars(cur_line);
-            let ends_with_space = cur_end_char > self.buffer().line_to_char(cur_line)
-                && self.buffer().content.char(cur_end_char - 1) == ' ';
+            let ends_with_ws = newline_pos > cur_line_start
+                && self.buffer().content.char(newline_pos - 1).is_whitespace();
 
-            if should_add_space && !ends_with_space {
+            if should_add_space && !ends_with_ws {
                 self.insert_with_undo(newline_pos, " ");
+                // Cursor at the inserted space
+                join_col = newline_pos - cur_line_start;
+            } else {
+                // No space inserted — cursor at last char before where next line starts
+                join_col = (newline_pos - cur_line_start).saturating_sub(1);
             }
         }
         self.finish_undo_group();
 
-        // Cursor stays at start of original line
+        // Cursor at the join point (where the space was inserted)
+        self.view_mut().cursor.col = join_col;
         self.clamp_cursor_col();
         *changed = true;
     }

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -1991,8 +1991,8 @@ fn test_replace_char_with_count() {
     press_char(&mut engine, 'x');
 
     assert_eq!(engine.buffer().to_string(), "xxxlo");
-    // Cursor should stay at starting position
-    assert_eq!(engine.view().cursor.col, 0);
+    // Cursor on last replaced char (Neovim behavior)
+    assert_eq!(engine.view().cursor.col, 2);
 }
 
 #[test]
@@ -21995,14 +21995,12 @@ fn test_nvim_2di_paren_no_double_nest() {
 // ── Phase 4 Batch 2: Miscellaneous edge cases ──────────────────────────
 
 #[test]
-#[ignore = "vim deviation: J cursor position wrong (col 0 instead of join point)"]
 fn test_nvim_J_join_two_lines() {
     // Neovim: cursor at col 3 (the space). VimCode: col 0.
     nvim_case("aaa\nbbb\n", 0, 0, "J", "aaa bbb\n", 0, 3);
 }
 
 #[test]
-#[ignore = "vim deviation: 3J joins 4 lines instead of 3"]
 fn test_nvim_3J_join_three_lines() {
     // Neovim: 3J joins 3 lines (current + 2). VimCode joins 4.
     nvim_case(
@@ -22032,7 +22030,6 @@ fn test_nvim_r_replace_char() {
 }
 
 #[test]
-#[ignore = "vim deviation: 3r cursor at col 0 instead of col 2"]
 fn test_nvim_3r_replace_chars() {
     // Neovim: cursor at col 2 (last replaced char). VimCode: col 0.
     nvim_case("hello\n", 0, 0, "3rX", "XXXlo\n", 0, 2);
@@ -22341,7 +22338,6 @@ fn test_nvim_ctrl_a_with_count() {
 // ── Phase 4 Batch 4: Change operations ──────────────────────────────────
 
 #[test]
-#[ignore = "vim deviation: C (change to EOL) starts one char too early"]
 fn test_nvim_c_dollar_change_to_eol() {
     // C at col 6 should change "world" to "XX" → "hello XX".
     // VimCode: changes from col 5, giving "helloXX ".
@@ -22786,7 +22782,6 @@ fn test_nvim_y_big_yank_line() {
 }
 
 #[test]
-#[ignore = "vim deviation: gJ cursor position wrong (col 0 instead of join point)"]
 fn test_nvim_gj_join_no_space() {
     // gJ joins without space. Neovim: cursor at col 3 (join point). VimCode: col 0.
     nvim_case("aaa\nbbb\n", 0, 0, "gJ", "aaabbb\n", 0, 3);
@@ -22870,7 +22865,6 @@ fn test_nvim_di_paren_empty() {
 }
 
 #[test]
-#[ignore = "vim deviation: ci( on empty parens is no-op instead of entering insert"]
 fn test_nvim_ci_paren_empty() {
     // ci( on "()" should enter insert between parens. VimCode: no-op.
     let mut engine = Engine::new();
@@ -22895,14 +22889,12 @@ fn test_nvim_di_quote_empty() {
 // ── Phase 4 Batch 6: J edge cases ───────────────────────────────────────
 
 #[test]
-#[ignore = "vim deviation: J cursor position wrong (see #73)"]
 fn test_nvim_j_join_strips_indent() {
     // J strips leading whitespace from second line. Cursor at join point.
     nvim_case("aaa\n   bbb\n", 0, 0, "J", "aaa bbb\n", 0, 3);
 }
 
 #[test]
-#[ignore = "vim deviation: J adds extra space when line already has trailing space"]
 fn test_nvim_j_join_trailing_space() {
     // J on line with trailing spaces: Neovim doesn't add another space.
     // VimCode adds one, giving "aaa    bbb" instead of "aaa   bbb".
@@ -23059,14 +23051,12 @@ fn test_nvim_y2w_then_check() {
 }
 
 #[test]
-#[ignore = "vim deviation: ib/aB text object aliases not recognized"]
 fn test_nvim_dib_same_as_di_paren() {
     // ib is alias for i(, aB is alias for a{. VimCode: not recognized.
     nvim_case("(hello)\n", 0, 1, "dib", "()\n", 0, 1);
 }
 
 #[test]
-#[ignore = "vim deviation: ib/aB text object aliases not recognized"]
 fn test_nvim_dab_same_as_da_brace() {
     nvim_case("x{hello}y\n", 0, 2, "daB", "xy\n", 0, 1);
 }


### PR DESCRIPTION
## Summary

Fixes 8 Vim deviations discovered by Phase 4 Neovim test mining:

- **#73**: J cursor at join point + 3J count fix (was joining N+1 lines)
- **#74**: 3rX cursor on last replaced char (was col 0)
- **#81**: C (change to EOL) preserves cursor position before insert
- **#83**: gJ cursor at join point (was col 0)
- **#84**: ci( on empty parens enters insert mode between brackets
- **#86**: J no longer adds extra space when line has trailing whitespace
- **#87**: ib/aB text object aliases recognized (ib=i(, aB=a{)

Also fixed replace char dot-repeat to not multiply count.

## Test plan

- [x] 1689 lib tests pass (10 previously-ignored tests now passing)
- [x] All integration tests pass (29 + 91 + 45)
- [x] Clippy clean

Closes #73, #74, #81, #83, #84, #86, #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)