### PR TITLE
fix: 9 Vim conformance bugs (Phase 4 deviations)

### DIFF
--- a/src/core/engine/execute.rs
+++ b/src/core/engine/execute.rs
@@ -17,6 +17,13 @@ impl Engine {
         let normalized = normalize_ex_command(cmd);
         let cmd: &str = &normalized;
 
+        // Handle :{range}{cmd} — commands with line number prefixes (e.g. :2d, :3,5d)
+        if cmd.as_bytes().first().is_some_and(|b| b.is_ascii_digit()) {
+            if let Some(action) = self.try_execute_ranged_command(cmd) {
+                return action;
+            }
+        }
+
         // Handle :term / :terminal — open integrated terminal
         if cmd == "terminal" {
             return EngineAction::OpenTerminal;
@@ -3076,5 +3083,85 @@ impl Engine {
             }
         }
         None
+    }
+
+    /// Try to parse and execute a ranged ex command like `:2d`, `:3,5d`, `:10y`.
+    /// Returns `Some(action)` if it handled the command, `None` otherwise.
+    fn try_execute_ranged_command(&mut self, cmd: &str) -> Option<EngineAction> {
+        // Parse leading range: N or N,M
+        let bytes = cmd.as_bytes();
+        let mut i = 0;
+
+        // Parse first number
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == 0 {
+            return None;
+        }
+        let first_num: usize = cmd[..i].parse().ok()?;
+
+        let (start_line, end_line, rest) = if i < bytes.len() && bytes[i] == b',' {
+            // Range: N,M
+            let comma = i;
+            i += 1;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            let second_num: usize = cmd[comma + 1..i].parse().ok()?;
+            (first_num, second_num, &cmd[i..])
+        } else {
+            // Single line: N
+            (first_num, first_num, &cmd[i..])
+        };
+
+        let rest = rest.trim();
+        let max_line = self.buffer().len_lines();
+        let start = start_line.min(max_line);
+        let end = end_line.min(max_line);
+
+        match rest {
+            "d" | "delete" => {
+                // :Nd or :N,Md — delete lines (1-indexed)
+                if start == 0 || end == 0 || start > end {
+                    self.message = "Invalid range".to_string();
+                    return Some(EngineAction::None);
+                }
+                let start_0 = start - 1;
+                let end_0 = (end - 1).min(self.buffer().len_lines().saturating_sub(1));
+                let count = end_0 - start_0 + 1;
+                self.view_mut().cursor.line = start_0;
+                self.view_mut().cursor.col = 0;
+                let mut changed = false;
+                self.start_undo_group();
+                self.delete_lines(count, &mut changed);
+                self.finish_undo_group();
+                Some(EngineAction::None)
+            }
+            "y" | "yank" => {
+                // :Ny or :N,My — yank lines (1-indexed)
+                if start == 0 || end == 0 || start > end {
+                    self.message = "Invalid range".to_string();
+                    return Some(EngineAction::None);
+                }
+                let start_0 = start - 1;
+                let end_0 = (end - 1).min(self.buffer().len_lines().saturating_sub(1));
+                let saved = self.view().cursor;
+                self.view_mut().cursor.line = start_0;
+                let count = end_0 - start_0 + 1;
+                self.yank_lines(count);
+                self.view_mut().cursor = saved;
+                Some(EngineAction::None)
+            }
+            _ if rest.is_empty() && first_num > 0 => {
+                // :N alone — go to line N (1-indexed)
+                let target = (first_num - 1).min(self.buffer().len_lines().saturating_sub(1));
+                self.view_mut().cursor.line = target;
+                self.view_mut().cursor.col = 0;
+                self.clamp_cursor_col();
+                Some(EngineAction::None)
+            }
+            _ => None, // Unknown ranged command — fall through
+        }
     }
 }

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -901,6 +901,7 @@ impl Engine {
             }
             Some('o') => {
                 let count = self.take_count();
+                self.insert_open_count = count;
                 self.start_undo_group();
                 let line = self.view().cursor.line;
                 let indent = self.smart_indent_for_newline(line);
@@ -927,13 +928,8 @@ impl Engine {
                 } else {
                     line_end
                 };
-                // Insert newlines (with indent on the first new line for count==1).
-                // For count > 1 only the first new line gets the indent; the rest are blank.
-                let text = if count == 1 {
-                    format!("\n{}", indent)
-                } else {
-                    format!("\n{}{}", indent, "\n".repeat(count - 1))
-                };
+                // Open one new line (count is handled on Escape via insert_open_count)
+                let text = format!("\n{}", indent);
                 self.insert_with_undo(insert_pos, &text);
                 self.insert_text_buffer.clear();
                 self.view_mut().cursor.line += 1;
@@ -944,6 +940,7 @@ impl Engine {
             }
             Some('O') => {
                 let count = self.take_count();
+                self.insert_open_count = count;
                 self.start_undo_group();
                 let line = self.view().cursor.line;
                 let indent = if self.settings.auto_indent {
@@ -953,12 +950,8 @@ impl Engine {
                 };
                 let indent_len = indent.len();
                 let line_start = self.buffer().line_to_char(line);
-                // Insert indent + newlines above current line.
-                let text = if count == 1 {
-                    format!("{}\n", indent)
-                } else {
-                    format!("{}\n{}", indent, "\n".repeat(count - 1))
-                };
+                // Open one new line above (count is handled on Escape via insert_open_count)
+                let text = format!("{}\n", indent);
                 self.insert_with_undo(line_start, &text);
                 self.insert_text_buffer.clear();
                 self.view_mut().cursor.col = indent_len;
@@ -1528,8 +1521,15 @@ impl Engine {
                 self.visual_anchor = Some(self.view().cursor);
             }
             Some('V') => {
+                let count = self.take_count();
                 self.set_mode(Mode::VisualLine);
                 self.visual_anchor = Some(self.view().cursor);
+                // Count extends selection: 2V selects 2 lines (current + 1 below)
+                if count > 1 {
+                    let target = (self.view().cursor.line + count - 1)
+                        .min(self.buffer().len_lines().saturating_sub(1));
+                    self.view_mut().cursor.line = target;
+                }
             }
             Some('%') => {
                 let pre_line = self.view().cursor.line;
@@ -2330,8 +2330,15 @@ impl Engine {
             }
             '"' => {
                 // Register selection: "x sets selected_register for next operation
+                // Uppercase A-Z appends to lowercase register
                 if let Some(ch) = unicode {
-                    if ch.is_ascii_lowercase() || ch == '"' || ch == '+' || ch == '*' {
+                    if ch.is_ascii_lowercase()
+                        || ch.is_ascii_uppercase()
+                        || ch == '"'
+                        || ch == '+'
+                        || ch == '*'
+                        || ch.is_ascii_digit()
+                    {
                         self.selected_register = Some(ch);
                     }
                 }
@@ -2443,6 +2450,34 @@ impl Engine {
                 }
             }
             '\'' => {
+                // d'{mark} / y'{mark} / c'{mark}: linewise operator to mark
+                if let Some(op) = self.pending_operator.take() {
+                    if let Some(ch) = unicode {
+                        let target_line = if ch.is_ascii_lowercase() {
+                            let buffer_id = self.active_window().buffer_id;
+                            self.marks
+                                .get(&buffer_id)
+                                .and_then(|m| m.get(&ch))
+                                .map(|c| c.line)
+                        } else if ch.is_ascii_uppercase() {
+                            self.global_marks.get(&ch).map(|&(_, line, _)| line)
+                        } else {
+                            None
+                        };
+                        if let Some(target) = target_line {
+                            let current = self.view().cursor.line;
+                            let (start, end) = if current <= target {
+                                (current, target)
+                            } else {
+                                (target, current)
+                            };
+                            self.apply_linewise_operator(op, start, end, changed);
+                        } else {
+                            self.message = format!("Mark '{}' not set", ch);
+                        }
+                    }
+                    return EngineAction::None;
+                }
                 // Jump to mark line: '{a-z|A-Z|'|.|<|>}
                 if let Some(ch) = unicode {
                     match ch {
@@ -3550,6 +3585,11 @@ impl Engine {
                 // Deferred: need one more keystroke for the target char
                 self.pending_find_operator = Some((operator, unicode.unwrap()));
             }
+            Some('\'') => {
+                // d'{mark}: linewise delete to mark — wait for mark char
+                self.pending_key = Some('\'');
+                self.pending_operator = Some(operator);
+            }
             _ => {
                 // Invalid motion - cancel operator
                 self.count = None;
@@ -3896,18 +3936,26 @@ impl Engine {
         target: char,
         changed: &mut bool,
     ) {
+        let count = self.take_count();
         let start_col = self.view().cursor.col;
         let line = self.view().cursor.line;
         let line_start = self.buffer().line_to_char(line);
 
-        // Execute the find motion
-        self.find_char(find_type, target);
+        // Execute the find motion (repeat for count)
+        let mut found = false;
+        for _ in 0..count {
+            if self.find_char(find_type, target) {
+                found = true;
+            } else {
+                break;
+            }
+        }
         self.last_find = Some((find_type, target));
 
-        let end_col = self.view().cursor.col;
-        if end_col == start_col {
-            return; // find_char didn't move — no match found
+        if !found {
+            return; // find_char found no match
         }
+        let end_col = self.view().cursor.col;
 
         // Calculate range
         let (range_start, range_end) = if find_type == 'f' || find_type == 't' {
@@ -4946,6 +4994,28 @@ impl Engine {
                         self.finish_undo_group();
                     }
                 }
+                // Repeat o/O insert for count > 1: duplicate typed text on new lines
+                if self.insert_open_count > 1 && !self.insert_text_buffer.is_empty() {
+                    let text = self.insert_text_buffer.clone();
+                    let repeat = self.insert_open_count - 1;
+                    self.start_undo_group();
+                    for _ in 0..repeat {
+                        let line = self.view().cursor.line;
+                        let line_start = self.buffer().line_to_char(line);
+                        let line_len = self.buffer().line_len_chars(line);
+                        // Insert before the trailing newline
+                        let insert_pos = line_start + line_len;
+                        let has_nl =
+                            line_len > 0 && self.buffer().content.char(insert_pos - 1) == '\n';
+                        let insert_pos = if has_nl { insert_pos - 1 } else { insert_pos };
+                        let new_line = format!("\n{}", text);
+                        self.insert_with_undo(insert_pos, &new_line);
+                        self.view_mut().cursor.line += 1;
+                        self.view_mut().cursor.col = text.chars().count();
+                    }
+                    self.finish_undo_group();
+                }
+                self.insert_open_count = 0;
                 // Track cursor pos for gi (insert at last insert position)
                 let cur = self.view().cursor;
                 self.last_insert_pos = Some((cur.line, cur.col));
@@ -5908,6 +5978,7 @@ impl Engine {
         if key_name == "Escape" {
             self.mode = Mode::Normal;
             self.visual_anchor = None;
+            self.visual_dollar = false;
             self.count = None; // Clear count on mode exit
             return EngineAction::None;
         }
@@ -6260,9 +6331,10 @@ impl Engine {
         // Handle multi-key sequences (gg, {, }, text objects, register selection)
         if let Some(pending) = self.pending_key.take() {
             if pending == '"' {
-                // Register selection: "x
+                // Register selection: "x (uppercase A-Z appends to lowercase)
                 if let Some(ch) = unicode {
                     if ch.is_ascii_lowercase()
+                        || ch.is_ascii_uppercase()
                         || ch.is_ascii_digit()
                         || ch == '"'
                         || ch == '+'
@@ -6371,6 +6443,36 @@ impl Engine {
                     }
                 }
                 return EngineAction::None;
+            } else if pending == 'g' && unicode == Some('u') {
+                // gu in visual mode: lowercase selection
+                self.count = None;
+                self.lowercase_visual_selection(changed);
+                return EngineAction::None;
+            } else if pending == 'g' && unicode == Some('U') {
+                // gU in visual mode: uppercase selection
+                self.count = None;
+                self.uppercase_visual_selection(changed);
+                return EngineAction::None;
+            } else if pending == 'g' && unicode == Some('~') {
+                // g~ in visual mode: toggle case of selection
+                self.count = None;
+                self.transform_visual_selection(
+                    |s| {
+                        s.chars()
+                            .map(|c| {
+                                if c.is_uppercase() {
+                                    c.to_lowercase().next().unwrap_or(c)
+                                } else if c.is_lowercase() {
+                                    c.to_uppercase().next().unwrap_or(c)
+                                } else {
+                                    c
+                                }
+                            })
+                            .collect()
+                    },
+                    changed,
+                );
+                return EngineAction::None;
             }
         }
 
@@ -6418,13 +6520,18 @@ impl Engine {
                     self.move_word_end();
                 }
             }
-            Some('0') => self.view_mut().cursor.col = 0,
+            Some('0') => {
+                self.view_mut().cursor.col = 0;
+                self.visual_dollar = false;
+            }
             Some('$') => {
                 let line = self.view().cursor.line;
                 self.view_mut().cursor.col = self.get_max_cursor_col(line);
+                self.visual_dollar = true;
             }
             Some('g') => {
                 self.pending_key = Some('g');
+                self.visual_dollar = false;
             }
             Some('G') => {
                 let last_line = self.buffer().len_lines().saturating_sub(1);

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2085,6 +2085,10 @@ pub struct Engine {
     // --- Visual mode state ---
     /// Visual mode anchor point (where visual selection started).
     pub visual_anchor: Option<Cursor>,
+    /// Set when `$` is used in visual mode — the selection extends through the
+    /// end of the line (including newline), matching Vim's curswant=MAXCOL.
+    /// Cleared when any other motion is used or visual mode exits.
+    pub visual_dollar: bool,
     /// When Command mode is entered from Visual mode, stores the original
     /// visual mode variant so the selection remains visible and `'<,'>` range
     /// resolves correctly.  Cleared on command execution or Escape.
@@ -2692,6 +2696,9 @@ pub struct Engine {
     /// Stores visual block insert/append info: (start_line, end_line, col, is_append).
     /// On Escape from Insert, apply insert_text_buffer to all block lines.
     pub visual_block_insert_info: Option<(usize, usize, usize, bool)>,
+    /// Count for o/O repeat: when >1, Escape from insert repeats the typed text
+    /// on additional new lines (Vim behavior for 3oXX<Esc>).
+    pub insert_open_count: usize,
     /// Force motion mode: 'v' = charwise, 'V' = linewise.
     /// Set by pressing v/V/CTRL-V while an operator is pending (e.g., dVj).
     pub force_motion_mode: Option<char>,
@@ -2993,6 +3000,7 @@ impl Engine {
             selected_register: None,
             marks: HashMap::new(),
             visual_anchor: None,
+            visual_dollar: false,
             command_from_visual: None,
             count: None,
             operator_count: None,
@@ -3227,6 +3235,7 @@ impl Engine {
             insert_ctrl_o_active: false,
             insert_ctrl_v_pending: false,
             visual_block_insert_info: None,
+            insert_open_count: 0,
             force_motion_mode: None,
             extension_state: ExtensionState::load(),
             prompted_extensions: HashSet::new(),

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -1375,7 +1375,7 @@ impl Engine {
     /// Find a character on the current line.
     /// motion_type: 'f' (forward inclusive), 'F' (backward inclusive),
     ///              't' (forward till/exclusive), 'T' (backward till/exclusive)
-    pub(crate) fn find_char(&mut self, motion_type: char, target: char) {
+    pub(crate) fn find_char(&mut self, motion_type: char, target: char) -> bool {
         let line = self.view().cursor.line;
         let col = self.view().cursor.col;
         let line_start = self.buffer().line_to_char(line);
@@ -1388,7 +1388,7 @@ impl Engine {
                     let ch = self.buffer().content.char(line_start + i);
                     if ch == target && ch != '\n' {
                         self.view_mut().cursor.col = i;
-                        return;
+                        return true;
                     }
                 }
             }
@@ -1399,7 +1399,7 @@ impl Engine {
                         let ch = self.buffer().content.char(line_start + i);
                         if ch == target {
                             self.view_mut().cursor.col = i;
-                            return;
+                            return true;
                         }
                     }
                 }
@@ -1412,7 +1412,7 @@ impl Engine {
                         if i > 0 {
                             self.view_mut().cursor.col = i - 1;
                         }
-                        return;
+                        return true;
                     }
                 }
             }
@@ -1423,7 +1423,7 @@ impl Engine {
                         let ch = self.buffer().content.char(line_start + i);
                         if ch == target {
                             self.view_mut().cursor.col = i + 1;
-                            return;
+                            return true;
                         }
                     }
                 }
@@ -1431,6 +1431,7 @@ impl Engine {
             _ => {}
         }
         // Character not found - cursor doesn't move (Vim behavior)
+        false
     }
 
     /// Repeat the last character find motion.
@@ -1836,7 +1837,23 @@ impl Engine {
         if modifier == 'i' {
             // Inner: exclude brackets
             if open_pos < close_pos {
-                Some((open_pos + 1, close_pos))
+                let open_line = self.buffer().content.char_to_line(open_pos);
+                let close_line = self.buffer().content.char_to_line(close_pos);
+                if open_line != close_line {
+                    // Multiline: Vim makes inner bracket objects linewise —
+                    // delete from start of line after open bracket to start of
+                    // line with close bracket.
+                    let start = self.buffer().line_to_char(open_line + 1);
+                    let end = self.buffer().line_to_char(close_line);
+                    if start <= end {
+                        Some((start, end))
+                    } else {
+                        // Empty interior (brackets on adjacent lines)
+                        Some((start, start))
+                    }
+                } else {
+                    Some((open_pos + 1, close_pos))
+                }
             } else {
                 None
             }
@@ -3521,6 +3538,24 @@ impl Engine {
     /// Sets a register's content. `is_linewise` affects paste behavior.
     /// For `+` and `*` registers, also writes to the system clipboard.
     pub(crate) fn set_register(&mut self, reg: char, content: String, is_linewise: bool) {
+        // Uppercase register (A-Z): append to lowercase register
+        if reg.is_ascii_uppercase() {
+            let lower = reg.to_ascii_lowercase();
+            let (existing, existing_lw) = self.registers.get(&lower).cloned().unwrap_or_default();
+            let combined_lw = existing_lw || is_linewise;
+            let combined = if existing.is_empty() {
+                content.clone()
+            } else if existing_lw {
+                // Linewise: just concatenate (existing already ends with \n)
+                format!("{}{}", existing, content)
+            } else {
+                format!("{}\n{}", existing, content)
+            };
+            self.registers
+                .insert(lower, (combined.clone(), combined_lw));
+            self.registers.insert('"', (combined, combined_lw));
+            return;
+        }
         self.registers.insert(reg, (content.clone(), is_linewise));
         // Also copy to unnamed register if using a named register
         if reg != '"' {

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -3133,12 +3133,12 @@ fn test_count_cleared_on_mode_changes() {
     assert_eq!(engine.peek_count(), Some(5)); // Count preserved
     press_special(&mut engine, "Escape"); // Escape clears count
 
-    // Test visual line mode PRESERVES count (for use with motions)
+    // Test visual line mode CONSUMES count (3V selects 3 lines)
     press_char(&mut engine, '3');
     assert_eq!(engine.peek_count(), Some(3));
     press_char(&mut engine, 'V');
-    assert_eq!(engine.peek_count(), Some(3)); // Count preserved
-    press_special(&mut engine, "Escape"); // Escape clears count
+    assert_eq!(engine.peek_count(), None); // Count consumed by V
+    press_special(&mut engine, "Escape"); // Escape exits visual
 
     // Test command mode clears count
     press_char(&mut engine, '7');
@@ -21823,10 +21823,15 @@ fn test_nvim_vlld_char_visual() {
 }
 
 #[test]
-#[ignore = "vim deviation: v$d leaves empty first line instead of joining"]
 fn test_nvim_v_dollar_d() {
-    // v$d should delete "abc\n" leaving "def\n". VimCode leaves "\ndef\n".
+    // v$d includes the newline (Vim curswant=MAXCOL behavior)
     nvim_case("abc\ndef\n", 0, 0, "v$d", "def\n", 0, 0);
+}
+
+#[test]
+fn test_nvim_lv_dollar_d() {
+    // lv$d from col 1 — also includes newline, joins with next line
+    nvim_case("abc\ndef\n", 0, 0, "lv$d", "adef\n", 0, 1);
 }
 
 #[test]
@@ -21856,9 +21861,8 @@ fn test_nvim_vey_yank() {
 }
 
 #[test]
-#[ignore = "vim deviation: count before V does not extend visual line selection"]
 fn test_nvim_visual_line_yank_count() {
-    // 2Vy should yank 2 lines. VimCode only yanks 1 (count ignored before V).
+    // 2Vy yanks 2 lines (count extends visual line selection)
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
     engine.update_syntax();
@@ -21869,9 +21873,13 @@ fn test_nvim_visual_line_yank_count() {
 }
 
 #[test]
-#[ignore = "vim deviation: visual selection + gu does not lowercase"]
 fn test_nvim_visual_gu_lowercase() {
     nvim_case("HELLO WORLD\n", 0, 0, "vegu", "hello WORLD\n", 0, 0);
+}
+
+#[test]
+fn test_nvim_visual_gu_uppercase() {
+    nvim_case("hello world\n", 0, 0, "vegU", "HELLO world\n", 0, 0);
 }
 
 #[test]
@@ -22280,7 +22288,6 @@ fn test_nvim_backtick_mark_exact() {
 }
 
 #[test]
-#[ignore = "vim deviation: d'mark (delete to mark) not implemented"]
 fn test_nvim_delete_to_mark() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\nbbb\nccc\nddd\n");
@@ -22423,10 +22430,8 @@ fn test_nvim_named_register_paste() {
 }
 
 #[test]
-#[ignore = "vim deviation: uppercase register append (\"Ayy) not implemented"]
 fn test_nvim_append_register() {
     // "ayy then j"Ayy should append to register a → "aaa\nbbb\n"
-    // VimCode: uppercase register does not append, just overwrites.
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\nbbb\n");
     engine.update_syntax();
@@ -22790,9 +22795,8 @@ fn test_nvim_gj_join_no_space() {
 // ── Phase 4 Batch 5: Ex commands ────────────────────────────────────────
 
 #[test]
-#[ignore = "vim deviation: :2d (ex delete with line number) not implemented"]
 fn test_nvim_ex_delete_line() {
-    // :2d should delete line 2. VimCode: no-op.
+    // :2d deletes line 2
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
     engine.update_syntax();
@@ -22942,9 +22946,8 @@ fn test_nvim_yaw_includes_space() {
 }
 
 #[test]
-#[ignore = "vim deviation: di{ on multiline braces collapses to single line"]
 fn test_nvim_di_brace_multiline() {
-    // di{ on multiline should leave "if {\n}\n". VimCode: "if {}\n" (single line).
+    // di{ on multiline: linewise inner deletion preserves brace lines
     nvim_case("if {\n  body\n}\n", 1, 0, "di{", "if {\n}\n", 1, 0);
 }
 
@@ -23262,7 +23265,6 @@ fn test_nvim_ciw_middle_of_word() {
 }
 
 #[test]
-#[ignore = "vim deviation: count with f in operator mode (d2f.) off by one"]
 fn test_nvim_d2f_delete_to_second_match() {
     nvim_case("a.b.c.d\n", 0, 0, "d2f.", "c.d\n", 0, 0);
 }
@@ -23321,9 +23323,8 @@ fn test_nvim_d_big_on_last_line() {
 }
 
 #[test]
-#[ignore = "vim deviation: count with o (3o) does not repeat line insertion"]
 fn test_nvim_o_with_count() {
-    // 3o should insert "XX" on 3 new lines below. VimCode: inserts only 1.
+    // 3o inserts typed text on 3 new lines below
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\nbbb\n");
     engine.update_syntax();
@@ -23458,15 +23459,15 @@ fn test_nvim_yb_yank_backward() {
 }
 
 #[test]
-#[ignore = "vim deviation: d0 off by one (keeps char at cursor col)"]
 fn test_nvim_d0_at_middle() {
-    nvim_case("hello world\n", 0, 5, "d0", "world\n", 0, 0);
+    // Verified: Neovim 0.12.1 — d0 is exclusive, cursor char NOT included
+    nvim_case("hello world\n", 0, 5, "d0", " world\n", 0, 0);
 }
 
 #[test]
-#[ignore = "vim deviation: d^ off by one (keeps char at cursor col)"]
 fn test_nvim_d_caret_with_indent() {
-    nvim_case("    hello\n", 0, 6, "d^", "    lo\n", 0, 4);
+    // Verified: Neovim 0.12.1 — d^ is exclusive, cursor char NOT included
+    nvim_case("    hello\n", 0, 6, "d^", "    llo\n", 0, 4);
 }
 
 #[test]
@@ -23481,7 +23482,6 @@ fn test_nvim_2fw() {
 }
 
 #[test]
-#[ignore = "vim deviation: dt. does not delete (t motion in operator mode)"]
 fn test_nvim_dt_then_semicolon() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a.b.c.d\n");

--- a/src/core/engine/visual.rs
+++ b/src/core/engine/visual.rs
@@ -57,10 +57,15 @@ impl Engine {
             Mode::Visual => {
                 // Character mode: extract from start to end (inclusive)
                 let start_char = self.buffer().line_to_char(start.line) + start.col;
-                let end_char = self.buffer().line_to_char(end.line) + end.col;
+                let mut end_char_inclusive = self.buffer().line_to_char(end.line) + end.col + 1;
 
-                // Include the character at the end position (Vim-like inclusive)
-                let end_char_inclusive = (end_char + 1).min(self.buffer().len_chars());
+                // When $ was used, extend through the newline (Vim curswant=MAXCOL)
+                if self.visual_dollar {
+                    let line_len = self.buffer().line_len_chars(end.line);
+                    end_char_inclusive = self.buffer().line_to_char(end.line) + line_len;
+                }
+
+                let end_char_inclusive = end_char_inclusive.min(self.buffer().len_chars());
 
                 let text = self
                     .buffer()
@@ -141,6 +146,7 @@ impl Engine {
         // Exit visual mode
         self.mode = Mode::Normal;
         self.visual_anchor = None;
+        self.visual_dollar = false;
     }
 
     pub fn delete_visual_selection(&mut self, changed: &mut bool) {
@@ -174,7 +180,13 @@ impl Engine {
                 Mode::Visual => {
                     // Delete characters
                     let start_char = self.buffer().line_to_char(start.line) + start.col;
-                    let end_char = self.buffer().line_to_char(end.line) + end.col + 1;
+                    let mut end_char = self.buffer().line_to_char(end.line) + end.col + 1;
+
+                    // When $ was used, extend through the newline (Vim curswant=MAXCOL)
+                    if self.visual_dollar {
+                        let line_len = self.buffer().line_len_chars(end.line);
+                        end_char = self.buffer().line_to_char(end.line) + line_len;
+                    }
 
                     self.delete_with_undo(start_char, end_char.min(self.buffer().len_chars()));
 
@@ -220,6 +232,7 @@ impl Engine {
         // Exit visual mode
         self.mode = Mode::Normal;
         self.visual_anchor = None;
+        self.visual_dollar = false;
     }
 
     /// Paste over visual selection: replace selected text with register content.
@@ -403,6 +416,7 @@ impl Engine {
         // Exit visual mode
         self.mode = Mode::Normal;
         self.visual_anchor = None;
+        self.visual_dollar = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix 9 Vim conformance bugs found during Phase 4 Neovim test mining
- Closes #75, #76, #77, #79, #80, #82, #85, #89, #90 (and #88 as invalid)
- Un-ignores 12 previously-ignored tests; 1703 tests pass, 0 fail

## Changes
- **v$d newline** (#75): Added `visual_dollar` flag (Vim's curswant=MAXCOL) — charwise visual selection with `$` now extends through the trailing newline
- **Visual gu/gU/g~** (#76): Added case operators to visual mode's pending `g` key handler
- **Count before V** (#77): `3V` now extends visual line selection by count
- **d'mark** (#79): `'` recognized as operator motion — linewise delete/yank/change to marks
- **Uppercase register append** (#80): `"Ayy` appends to register `a` instead of overwriting
- **:Nd range commands** (#82): `:2d`, `:3,5d`, `:N` go-to-line parsed in `try_execute_ranged_command()`
- **di{ multiline** (#85): Inner bracket text objects use linewise deletion when brackets span multiple lines
- **d2f./dt.** (#89): Count support in operator find-char; `find_char()` returns bool to fix `dt.` edge case where target is adjacent
- **3o/3O repeat** (#90): `insert_open_count` field replays inserted text on Escape

## Test plan
- [x] All 1703 lib tests pass (`cargo test --no-default-features --lib`)
- [x] Clippy clean (`cargo clippy --no-default-features -- -D warnings`)
- [x] Key behaviors verified against Neovim 0.12.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)