### PR TITLE
fix: suppress auto-indent during insert-mode paste

### DIFF
--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -5290,31 +5290,11 @@ impl Engine {
         let col = self.view().cursor.col;
         let char_idx = self.buffer().line_to_char(line) + col;
 
-        // Handle auto-indent: split on newlines and add indent after each.
-        let indent = if self.settings.auto_indent {
-            self.get_line_indent_str(line)
-        } else {
-            String::new()
-        };
-
         // Build the final string to insert.
-        // Replace \r\n and \r with \n, then auto-indent after each newline.
-        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-        let to_insert = if indent.is_empty() {
-            normalized
-        } else {
-            // Add indent after every newline except at the very end.
-            let mut result = String::with_capacity(normalized.len() * 2);
-            let parts: Vec<&str> = normalized.split('\n').collect();
-            for (i, part) in parts.iter().enumerate() {
-                if i > 0 {
-                    result.push('\n');
-                    result.push_str(&indent);
-                }
-                result.push_str(part);
-            }
-            result
-        };
+        // Replace \r\n and \r with \n. Do NOT auto-indent — pasted text
+        // already carries its own whitespace; adding indent causes a
+        // cumulative staircase effect (see #65).
+        let to_insert = text.replace("\r\n", "\n").replace('\r', "\n");
 
         self.insert_with_undo(char_idx, &to_insert);
         self.insert_text_buffer.push_str(&to_insert);

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -23498,3 +23498,49 @@ fn test_nvim_ct_change_till() {
     engine.feed_keys("ct(XX<Esc>");
     assert_eq!(engine.buffer().to_string(), "XX(def\n");
 }
+
+// ── Issue #65: Ctrl-V paste in insert mode must not add cumulative indent ──
+
+#[test]
+fn test_insert_paste_preserves_original_indentation() {
+    // Pasting multi-line text in insert mode should preserve the original
+    // indentation verbatim, not re-indent each line relative to the cursor.
+    let mut engine = Engine::new();
+    engine.settings.auto_indent = true;
+    engine.buffer_mut().insert(0, "\n");
+    engine.update_syntax();
+
+    // Enter insert mode at line 0
+    engine.feed_keys("i");
+    assert_eq!(engine.mode, Mode::Insert);
+
+    // Simulate pasting indented text via paste_in_insert_mode
+    engine.paste_in_insert_mode("aaa\n    bbb\n    ccc\n    ddd");
+
+    // The indentation must be preserved exactly — no staircase effect.
+    assert_eq!(
+        engine.buffer().to_string(),
+        "aaa\n    bbb\n    ccc\n    ddd\n"
+    );
+}
+
+#[test]
+fn test_insert_paste_into_indented_context_no_staircase() {
+    // Even when cursor is on an indented line, paste must not add extra indent.
+    let mut engine = Engine::new();
+    engine.settings.auto_indent = true;
+    engine.buffer_mut().insert(0, "    existing\n");
+    engine.update_syntax();
+
+    // Position cursor at end of the indented line, enter insert mode
+    engine.feed_keys("A");
+    assert_eq!(engine.mode, Mode::Insert);
+
+    // Paste multi-line text — should not inherit the "    " indent
+    engine.paste_in_insert_mode("\nalpha\n    beta\n    gamma");
+
+    assert_eq!(
+        engine.buffer().to_string(),
+        "    existing\nalpha\n    beta\n    gamma\n"
+    );
+}


### PR DESCRIPTION
## Summary
- Removed auto-indent logic from `paste_in_insert_mode()` — pasted text already carries its own whitespace, so adding the current line's indent caused a cumulative staircase effect
- Added 2 regression tests covering paste into empty and indented contexts

## Test plan
- [x] `test_insert_paste_preserves_original_indentation` — pastes indented block, verifies no staircase
- [x] `test_insert_paste_into_indented_context_no_staircase` — pastes from an indented line, verifies no extra indent added
- [x] Full test suite: 1705 passed, 0 failed

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)