### PR TITLE
fix: 7 Vim deviations + 56 new conformance tests (Phase 4 batches 10-11)

### DIFF
--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -1293,9 +1293,17 @@ impl Engine {
             }
             Some('S') => {
                 // S: substitute line (delete entire line content, enter insert mode)
+                // With auto_indent, preserve the leading whitespace (Vim behavior).
                 let count = self.take_count();
                 let start_line = self.view().cursor.line;
                 let _end_line = (start_line + count).min(self.buffer().len_lines());
+
+                // Capture indent before deletion
+                let indent = if self.settings.auto_indent {
+                    self.get_line_indent_str(start_line)
+                } else {
+                    String::new()
+                };
 
                 self.start_undo_group();
 
@@ -1334,7 +1342,13 @@ impl Engine {
                     }
                 }
 
-                self.view_mut().cursor.col = 0;
+                // Re-insert preserved indent
+                if !indent.is_empty() {
+                    let line_start = self.buffer().line_to_char(start_line);
+                    self.insert_with_undo(line_start, &indent);
+                }
+
+                self.view_mut().cursor.col = indent.len();
                 self.insert_text_buffer.clear();
                 self.mode = Mode::Insert;
                 self.count = None;
@@ -2398,8 +2412,12 @@ impl Engine {
                 }
             }
             'r' => {
-                // Replace character: r followed by a character replaces char under cursor
-                if let Some(replacement) = unicode {
+                // Replace character: r followed by a character replaces char under cursor.
+                // Special case: Return/Enter replaces with newline (splits line).
+                let replacement = unicode.or_else(|| {
+                    if key_name == "Return" { Some('\n') } else { None }
+                });
+                if let Some(replacement) = replacement {
                     let count = self.take_count();
                     self.start_undo_group();
                     self.replace_chars(replacement, count, changed);

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -2503,8 +2503,9 @@ impl Engine {
                             // '' jump to position before last jump
                             if let Some((line, _)) = self.last_jump_pos {
                                 let max_line = self.buffer().len_lines().saturating_sub(1);
-                                self.view_mut().cursor.line = line.min(max_line);
-                                self.view_mut().cursor.col = 0;
+                                let target = line.min(max_line);
+                                self.view_mut().cursor.line = target;
+                                self.view_mut().cursor.col = self.first_non_blank_col(target);
                                 self.clamp_cursor_col();
                             } else {
                                 self.message = "No previous jump position".to_string();
@@ -2514,8 +2515,9 @@ impl Engine {
                             // '. jump to last edit position
                             if let Some((line, _)) = self.last_edit_pos {
                                 let max_line = self.buffer().len_lines().saturating_sub(1);
-                                self.view_mut().cursor.line = line.min(max_line);
-                                self.view_mut().cursor.col = 0;
+                                let target = line.min(max_line);
+                                self.view_mut().cursor.line = target;
+                                self.view_mut().cursor.col = self.first_non_blank_col(target);
                                 self.clamp_cursor_col();
                             } else {
                                 self.message = "No previous edit position".to_string();
@@ -2525,8 +2527,9 @@ impl Engine {
                             // '< jump to start of last visual selection
                             if let Some((line, _)) = self.visual_mark_start {
                                 let max_line = self.buffer().len_lines().saturating_sub(1);
-                                self.view_mut().cursor.line = line.min(max_line);
-                                self.view_mut().cursor.col = 0;
+                                let target = line.min(max_line);
+                                self.view_mut().cursor.line = target;
+                                self.view_mut().cursor.col = self.first_non_blank_col(target);
                                 self.clamp_cursor_col();
                             } else {
                                 self.message = "No previous visual selection".to_string();
@@ -2536,8 +2539,9 @@ impl Engine {
                             // '> jump to end of last visual selection
                             if let Some((line, _)) = self.visual_mark_end {
                                 let max_line = self.buffer().len_lines().saturating_sub(1);
-                                self.view_mut().cursor.line = line.min(max_line);
-                                self.view_mut().cursor.col = 0;
+                                let target = line.min(max_line);
+                                self.view_mut().cursor.line = target;
+                                self.view_mut().cursor.col = self.first_non_blank_col(target);
                                 self.clamp_cursor_col();
                             } else {
                                 self.message = "No previous visual selection".to_string();
@@ -2547,8 +2551,9 @@ impl Engine {
                             let buffer_id = self.active_window().buffer_id;
                             if let Some(buffer_marks) = self.marks.get(&buffer_id) {
                                 if let Some(mark_cursor) = buffer_marks.get(&ch) {
-                                    self.view_mut().cursor.line = mark_cursor.line;
-                                    self.view_mut().cursor.col = 0;
+                                    let target = mark_cursor.line;
+                                    self.view_mut().cursor.line = target;
+                                    self.view_mut().cursor.col = self.first_non_blank_col(target);
                                     self.clamp_cursor_col();
                                 } else {
                                     self.message = format!("Mark '{}' not set", ch);
@@ -2560,8 +2565,9 @@ impl Engine {
                         _ if ch.is_ascii_uppercase() => {
                             if let Some(&(_, line, _)) = self.global_marks.get(&ch) {
                                 let max_line = self.buffer().len_lines().saturating_sub(1);
-                                self.view_mut().cursor.line = line.min(max_line);
-                                self.view_mut().cursor.col = 0;
+                                let target = line.min(max_line);
+                                self.view_mut().cursor.line = target;
+                                self.view_mut().cursor.col = self.first_non_blank_col(target);
                                 self.clamp_cursor_col();
                             } else {
                                 self.message = format!("Mark '{}' not set", ch);
@@ -7633,6 +7639,26 @@ impl Engine {
             } else {
                 self.handle_key(&ch.to_string(), Some(ch), false);
             }
+            // Drain macro playback queue (populated by @q etc.)
+            self.drain_macro_queue();
+        }
+    }
+
+    /// Drain the macro playback queue, executing each queued keystroke.
+    fn drain_macro_queue(&mut self) {
+        // Guard against infinite recursion from self-referencing macros
+        let max_iterations = 100_000;
+        let mut iterations = 0;
+        while !self.macro_playback_queue.is_empty() && iterations < max_iterations {
+            if let Some((key_name, unicode, ctrl, consumed)) = self.decode_macro_sequence() {
+                for _ in 0..consumed {
+                    self.macro_playback_queue.pop_front();
+                }
+                self.handle_key(&key_name, unicode, ctrl);
+            } else {
+                self.macro_playback_queue.pop_front();
+            }
+            iterations += 1;
         }
     }
 }

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -1677,14 +1677,25 @@ impl Engine {
             end += 1;
         }
 
-        // For 'aw', include trailing whitespace
+        // For 'aw', include trailing whitespace; if none, include leading whitespace
         if modifier == 'a' {
+            let end_before = end;
             while end < total_chars {
                 let ch = self.buffer().content.char(end);
                 if !ch.is_whitespace() || ch == '\n' {
                     break;
                 }
                 end += 1;
+            }
+            // No trailing whitespace consumed — try leading instead
+            if end == end_before {
+                while start > 0 {
+                    let ch = self.buffer().content.char(start - 1);
+                    if !ch.is_whitespace() || ch == '\n' {
+                        break;
+                    }
+                    start -= 1;
+                }
             }
         }
 

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -23960,3 +23960,226 @@ fn test_nvim_g_comma_changelist_forward() {
     assert!(pos_fwd.1 >= pos_back.1 || pos_fwd.0 > pos_back.0,
         "g, should move cursor forward in changelist");
 }
+
+// ── Phase 4 Batch 11: Marks, Registers, Join edge cases, Insert keys ──────
+
+// -- Mark operations --
+
+#[test]
+fn test_nvim_mark_overwrite() {
+    // Setting a mark twice overwrites the old position
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
+    engine.update_syntax();
+    engine.feed_keys("ma");       // mark 'a' at line 0
+    engine.feed_keys("jjma");     // overwrite mark 'a' at line 2
+    engine.feed_keys("gg'a");     // jump to mark 'a'
+    assert_eq!(engine.view().cursor.line, 2);
+}
+
+#[test]
+fn test_nvim_mark_unset_error() {
+    // Jumping to an unset mark shows an error message
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "test\n");
+    engine.update_syntax();
+    engine.feed_keys("'z");
+    assert!(!engine.message.is_empty(), "should show error for unset mark");
+}
+
+#[test]
+fn test_nvim_mark_tick_first_nonblank() {
+    // ' (tick) jumps to mark's line at first non-blank character
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa\n    bbb\nccc\n");
+    engine.update_syntax();
+    engine.feed_keys("jllma");   // mark 'a' at line 1, col 6
+    engine.feed_keys("gg'a");     // tick-jump to mark 'a'
+    assert_eq!(engine.view().cursor.line, 1);
+    assert_eq!(engine.view().cursor.col, 4); // first non-blank
+}
+
+#[test]
+fn test_nvim_mark_backtick_exact_col() {
+    // ` (backtick) jumps to exact line and column
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello world\nfoo bar baz\n");
+    engine.update_syntax();
+    engine.feed_keys("jllllmb");  // mark 'b' at line 1, col 4
+    engine.feed_keys("gg`b");     // backtick-jump to mark 'b'
+    assert_eq!(engine.view().cursor.line, 1);
+    assert_eq!(engine.view().cursor.col, 4);
+}
+
+// -- Register operations --
+
+#[test]
+fn test_nvim_x_fills_unnamed_register() {
+    // x puts deleted char into unnamed register
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "ABC\n");
+    engine.update_syntax();
+    engine.feed_keys("x");
+    let (text, is_linewise) = engine.registers.get(&'"').cloned().unwrap_or_default();
+    assert_eq!(text, "A");
+    assert!(!is_linewise);
+}
+
+#[test]
+fn test_nvim_dd_fills_unnamed_linewise() {
+    // dd puts deleted line into unnamed register as linewise
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "first\nsecond\nthird\n");
+    engine.update_syntax();
+    engine.feed_keys("jdd");
+    let (text, is_linewise) = engine.registers.get(&'"').cloned().unwrap_or_default();
+    assert_eq!(text, "second\n");
+    assert!(is_linewise);
+}
+
+#[test]
+fn test_nvim_dd_fills_register_1() {
+    // dd puts deleted line into numbered register 1
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "one\ntwo\n");
+    engine.update_syntax();
+    engine.feed_keys("dd");
+    let (text, _) = engine.registers.get(&'1').cloned().unwrap_or_default();
+    assert_eq!(text, "one\n");
+}
+
+#[test]
+fn test_nvim_yank_register_0_preserved() {
+    // Register 0 holds last yank, not affected by deletes
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "alpha\nbeta\ngamma\n");
+    engine.update_syntax();
+    engine.feed_keys("yy");   // yank "alpha\n" to register 0
+    engine.feed_keys("jdd");  // delete "beta\n" to unnamed and register 1
+    let (reg0, _) = engine.registers.get(&'0').cloned().unwrap_or_default();
+    assert_eq!(reg0, "alpha\n");
+    // Unnamed register should now have the deleted text
+    let (unnamed, _) = engine.registers.get(&'"').cloned().unwrap_or_default();
+    assert_eq!(unnamed, "beta\n");
+}
+
+#[test]
+fn test_nvim_macro_record_and_play() {
+    // Record a macro into register q, then play it back
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "\n\n");
+    engine.update_syntax();
+    engine.feed_keys("qqiHello<Esc>q"); // record: insert "Hello"
+    engine.feed_keys("j@q");             // play on next line
+    assert_eq!(engine.buffer().to_string(), "Hello\nHello\n");
+}
+
+#[test]
+fn test_nvim_macro_with_count() {
+    // 3@q plays macro 3 times
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "x\n");
+    engine.update_syntax();
+    engine.feed_keys("qqA!<Esc>q"); // record: append "!"
+    engine.feed_keys("3@q");        // play 3 more times
+    assert_eq!(engine.buffer().to_string(), "x!!!!\n");
+}
+
+// -- Join edge cases --
+
+#[test]
+fn test_nvim_J_last_line_noop() {
+    // J on the last line does nothing
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "only line\n");
+    engine.update_syntax();
+    engine.feed_keys("J");
+    assert_eq!(engine.buffer().to_string(), "only line\n");
+}
+
+#[test]
+fn test_nvim_J_with_empty_next_line() {
+    // J joining with an empty next line
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello\n\nworld\n");
+    engine.update_syntax();
+    engine.feed_keys("J");
+    // Vim joins "hello" with empty line, producing "hello " (trailing space)
+    // then "world" remains on the next line
+    assert_eq!(engine.buffer().to_string(), "hello \nworld\n");
+}
+
+#[test]
+fn test_nvim_gJ_preserves_leading_whitespace() {
+    // gJ joins without adding space, preserving second line's leading whitespace
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "abc\n  def\n");
+    engine.update_syntax();
+    engine.feed_keys("gJ");
+    assert_eq!(engine.buffer().to_string(), "abc  def\n");
+}
+
+#[test]
+fn test_nvim_4J_join_four_lines() {
+    // 4J joins four lines into one
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "one\ntwo\nthree\nfour\nfive\n");
+    engine.update_syntax();
+    engine.feed_keys("4J");
+    assert_eq!(engine.buffer().to_string(), "one two three four\nfive\n");
+}
+
+#[test]
+#[ignore = "vim deviation: J in visual line mode does not join selected lines"]
+fn test_nvim_visual_J_three_lines() {
+    // Visual select 3 lines then J joins them
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aa\nbb\ncc\ndd\n");
+    engine.update_syntax();
+    engine.feed_keys("VjjJ");
+    assert_eq!(engine.buffer().to_string(), "aa bb cc\ndd\n");
+}
+
+#[test]
+#[ignore = "vim deviation: :%join range not supported yet"]
+fn test_nvim_percent_join_command() {
+    // :%join joins all lines
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":%join<CR>");
+    assert_eq!(engine.buffer().to_string(), "a b c d\n");
+}
+
+// -- Insert mode editing keys --
+
+#[test]
+fn test_nvim_insert_ctrl_w_delete_word_back() {
+    // Ctrl-W in insert mode deletes word backward
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "\n");
+    engine.update_syntax();
+    engine.feed_keys("ihello world<C-w><Esc>");
+    assert_eq!(engine.buffer().to_string(), "hello \n");
+}
+
+#[test]
+#[ignore = "vim deviation: Ctrl-U deletes to line start instead of insert start"]
+fn test_nvim_insert_ctrl_u_after_append() {
+    // Ctrl-U in insert mode should only delete text typed since entering insert mode
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "prefix\n");
+    engine.update_syntax();
+    engine.feed_keys("Asuffix<C-u><Esc>");
+    assert_eq!(engine.buffer().to_string(), "prefix\n");
+}
+
+#[test]
+fn test_nvim_insert_ctrl_w_at_line_start() {
+    // Ctrl-W at start of inserted text is a no-op
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello\n");
+    engine.update_syntax();
+    engine.feed_keys("i<C-w><Esc>");
+    assert_eq!(engine.buffer().to_string(), "hello\n");
+}

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -2402,6 +2402,8 @@ fn test_visual_change() {
 
 #[test]
 fn test_visual_line_change() {
+    // Vc replaces the selected line with an empty line (Vim behavior),
+    // preserving the trailing newline so typed text stays on its own line.
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "line1\nline2\nline3");
     engine.update_syntax();
@@ -2409,7 +2411,7 @@ fn test_visual_line_change() {
     press_char(&mut engine, 'V');
     press_char(&mut engine, 'c');
 
-    assert_eq!(engine.buffer().to_string(), "line2\nline3");
+    assert_eq!(engine.buffer().to_string(), "\nline2\nline3");
     assert_eq!(engine.mode, Mode::Insert);
 }
 
@@ -23543,4 +23545,418 @@ fn test_insert_paste_into_indented_context_no_staircase() {
         engine.buffer().to_string(),
         "    existing\nalpha\n    beta\n    gamma\n"
     );
+}
+
+// ── Phase 4 Batch 10: Undo/Redo, Put, Change, Text Objects ────────────────
+
+// -- Undo / Redo --
+
+#[test]
+fn test_nvim_undo_redo_noop_messages() {
+    // Undo/redo on unmodified buffer should be no-ops
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello\n");
+    engine.update_syntax();
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "hello\n");
+    engine.feed_keys("<C-r>");
+    assert_eq!(engine.buffer().to_string(), "hello\n");
+}
+
+#[test]
+fn test_nvim_undo_redo_chain() {
+    // Insert lines, undo all, redo all
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "\n");
+    engine.update_syntax();
+    engine.feed_keys("ione<Esc>");
+    assert_eq!(engine.buffer().to_string(), "one\n");
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "\n");
+    engine.feed_keys("<C-r>");
+    assert_eq!(engine.buffer().to_string(), "one\n");
+}
+
+#[test]
+fn test_nvim_undo_multiple_inserts() {
+    // Each insert creates a separate undo entry
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "\n");
+    engine.update_syntax();
+    engine.feed_keys("iaaa<Esc>obbb<Esc>occc<Esc>");
+    assert_eq!(engine.buffer().to_string(), "aaa\nbbb\nccc\n");
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "aaa\nbbb\n");
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "aaa\n");
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "\n");
+    // Redo back
+    engine.feed_keys("<C-r><C-r><C-r>");
+    assert_eq!(engine.buffer().to_string(), "aaa\nbbb\nccc\n");
+}
+
+#[test]
+fn test_nvim_undo_visual_delete() {
+    // Visual delete then undo restores text
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "one two three\n");
+    engine.update_syntax();
+    engine.feed_keys("wved");
+    assert_eq!(engine.buffer().to_string(), "one  three\n");
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "one two three\n");
+}
+
+#[test]
+fn test_nvim_undo_join() {
+    // J then undo
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello\nworld\n");
+    engine.update_syntax();
+    engine.feed_keys("J");
+    assert_eq!(engine.buffer().to_string(), "hello world\n");
+    engine.feed_keys("u");
+    assert_eq!(engine.buffer().to_string(), "hello\nworld\n");
+}
+
+// -- Put / Paste --
+
+#[test]
+fn test_nvim_p_charwise_inline() {
+    // Yank a word, paste after cursor
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "abc def\n");
+    engine.update_syntax();
+    engine.feed_keys("yiwwp");
+    assert_eq!(engine.buffer().to_string(), "abc dabcef\n");
+}
+
+#[test]
+fn test_nvim_P_charwise_inline() {
+    // Yank a word, paste before cursor
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "abc def\n");
+    engine.update_syntax();
+    engine.feed_keys("yiw$P");
+    assert_eq!(engine.buffer().to_string(), "abc deabcf\n");
+}
+
+#[test]
+fn test_nvim_p_linewise_below() {
+    // dd then p pastes below current line
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
+    engine.update_syntax();
+    engine.feed_keys("ddp");
+    assert_eq!(engine.buffer().to_string(), "bbb\naaa\nccc\n");
+}
+
+#[test]
+fn test_nvim_P_linewise_above() {
+    // yy on line 2, P on line 1 pastes above
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
+    engine.update_syntax();
+    engine.feed_keys("jyyggP");
+    assert_eq!(engine.buffer().to_string(), "bbb\naaa\nbbb\nccc\n");
+}
+
+#[test]
+fn test_nvim_2p_linewise() {
+    // 2p pastes linewise content twice
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa\nbbb\n");
+    engine.update_syntax();
+    engine.feed_keys("yy2p");
+    assert_eq!(engine.buffer().to_string(), "aaa\naaa\naaa\nbbb\n");
+}
+
+#[test]
+fn test_nvim_ddp_swap_lines_full() {
+    // Classic ddp swap: delete line, paste below
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "first\nsecond\nthird\n");
+    engine.update_syntax();
+    engine.feed_keys("ddp");
+    assert_eq!(engine.buffer().to_string(), "second\nfirst\nthird\n");
+}
+
+#[test]
+fn test_nvim_xp_transpose_chars() {
+    // Classic xp to swap two characters
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "ab\n");
+    engine.update_syntax();
+    engine.feed_keys("xp");
+    assert_eq!(engine.buffer().to_string(), "ba\n");
+}
+
+// -- Change operations --
+
+#[test]
+fn test_nvim_S_substitute_line() {
+    // S replaces entire line content
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello world\n");
+    engine.update_syntax();
+    engine.feed_keys("Sfoo<Esc>");
+    assert_eq!(engine.buffer().to_string(), "foo\n");
+}
+
+#[test]
+fn test_nvim_S_preserves_indent() {
+    // S on indented line preserves indentation
+    let mut engine = Engine::new();
+    engine.settings.auto_indent = true;
+    engine.buffer_mut().insert(0, "    hello world\n");
+    engine.update_syntax();
+    engine.feed_keys("Sfoo<Esc>");
+    assert_eq!(engine.buffer().to_string(), "    foo\n");
+}
+
+#[test]
+fn test_nvim_cW_change_bigword() {
+    // cW changes a WORD (including punctuation)
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foo.bar baz\n");
+    engine.update_syntax();
+    engine.feed_keys("cWXXX<Esc>");
+    assert_eq!(engine.buffer().to_string(), "XXX baz\n");
+}
+
+#[test]
+fn test_nvim_cw_dot_repeat() {
+    // cw then dot repeat: w after first cw lands on "bbb", dot changes it
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa bbb ccc\n");
+    engine.update_syntax();
+    engine.feed_keys("cwXXX<Esc>w.");
+    assert_eq!(engine.buffer().to_string(), "XXX XXX ccc\n");
+}
+
+#[test]
+fn test_nvim_r_newline_splits_line() {
+    // r<CR> replaces char with newline, splitting the line
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "abcd\n");
+    engine.update_syntax();
+    engine.feed_keys("llr<CR>");
+    assert_eq!(engine.buffer().to_string(), "ab\nd\n");
+}
+
+#[test]
+fn test_nvim_c_dollar_to_eol() {
+    // C changes from cursor to end of line
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "hello world\n");
+    engine.update_syntax();
+    engine.feed_keys("llCXX<Esc>");
+    assert_eq!(engine.buffer().to_string(), "heXX\n");
+}
+
+#[test]
+fn test_nvim_2cw_change_two_words() {
+    // 2cw changes two words
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa bbb ccc\n");
+    engine.update_syntax();
+    engine.feed_keys("2cwXXX<Esc>");
+    assert_eq!(engine.buffer().to_string(), "XXX ccc\n");
+}
+
+#[test]
+fn test_nvim_cb_change_backward_word() {
+    // cb from start of "bbb" changes backward to start of "aaa" (including space)
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa bbb ccc\n");
+    engine.update_syntax();
+    engine.feed_keys("wcbXXX<Esc>");
+    assert_eq!(engine.buffer().to_string(), "XXXbbb ccc\n");
+}
+
+#[test]
+fn test_nvim_visual_line_change() {
+    // V then c replaces the line
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "line1\nline2\nline3\n");
+    engine.update_syntax();
+    engine.feed_keys("jVcnew<Esc>");
+    assert_eq!(engine.buffer().to_string(), "line1\nnew\nline3\n");
+}
+
+#[test]
+fn test_nvim_visual_multiline_change() {
+    // Vjc replaces two lines with one
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
+    engine.update_syntax();
+    engine.feed_keys("Vjcnew<Esc>");
+    assert_eq!(engine.buffer().to_string(), "new\nccc\n");
+}
+
+// -- Text Objects --
+
+#[test]
+fn test_nvim_ci_double_quote_change() {
+    // ci" changes inside double quotes
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "say \"hello\" end\n");
+    engine.update_syntax();
+    engine.feed_keys("fhci\"world<Esc>");
+    assert_eq!(engine.buffer().to_string(), "say \"world\" end\n");
+}
+
+#[test]
+fn test_nvim_da_double_quote_with_space() {
+    // da" deletes quotes and one surrounding space
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "say \"hello\" end\n");
+    engine.update_syntax();
+    engine.feed_keys("fhda\"");
+    assert_eq!(engine.buffer().to_string(), "say end\n");
+}
+
+#[test]
+fn test_nvim_dit_multiline_tag() {
+    // dit deletes inner tag content spanning multiple lines
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "<b>\ninner\n</b>\n");
+    engine.update_syntax();
+    engine.feed_keys("jdit");
+    assert_eq!(engine.buffer().to_string(), "<b></b>\n");
+}
+
+#[test]
+fn test_nvim_dat_removes_tags() {
+    // dat deletes the tag pair and content
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "before<b>text</b>after\n");
+    engine.update_syntax();
+    engine.feed_keys("ftdat");
+    assert_eq!(engine.buffer().to_string(), "beforeafter\n");
+}
+
+#[test]
+fn test_nvim_cit_empty_tag() {
+    // cit on empty tag inserts inside
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "<div></div>\n");
+    engine.update_syntax();
+    engine.feed_keys("citxxx<Esc>");
+    assert_eq!(engine.buffer().to_string(), "<div>xxx</div>\n");
+}
+
+#[test]
+fn test_nvim_yi_angle_bracket() {
+    // yi< yanks inside angle brackets
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "#include <foo.h>\n");
+    engine.update_syntax();
+    engine.feed_keys("ffyi<");
+    let (reg_text, _) = engine.registers.get(&'"').cloned().unwrap_or_default();
+    assert_eq!(reg_text, "foo.h");
+}
+
+#[test]
+fn test_nvim_ya_angle_bracket() {
+    // ya> yanks around angle brackets (including brackets)
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "#include <foo.h>\n");
+    engine.update_syntax();
+    engine.feed_keys("ffya>");
+    let (reg_text, _) = engine.registers.get(&'"').cloned().unwrap_or_default();
+    assert_eq!(reg_text, "<foo.h>");
+}
+
+#[test]
+fn test_nvim_diw_at_start() {
+    // diw at start of word deletes whole word
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foobar,eins,foobar\n");
+    engine.update_syntax();
+    engine.feed_keys("diw");
+    assert_eq!(engine.buffer().to_string(), ",eins,foobar\n");
+}
+
+#[test]
+fn test_nvim_daw_at_end() {
+    // daw at end of buffer deletes word + preceding space
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foo bar\n");
+    engine.update_syntax();
+    engine.feed_keys("$daw");
+    assert_eq!(engine.buffer().to_string(), "foo\n");
+}
+
+#[test]
+fn test_nvim_daw_on_whitespace() {
+    // daw on whitespace between words deletes the space + next word
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foo bar baz\n");
+    engine.update_syntax();
+    engine.feed_keys("frdaw");
+    // Cursor is on 'r' (end of "bar"), daw from word deletes "bar" + trailing space or leading space
+    // Actually with cursor on 'r', we're inside "bar", so daw deletes " bar" (leading space + word)
+    // In Vim: daw from middle of "bar" deletes " bar" -> "foo baz"
+    assert_eq!(engine.buffer().to_string(), "foo baz\n");
+}
+
+#[test]
+fn test_nvim_ciB_empty_braces() {
+    // ciB (change inside Block/braces) on empty braces
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "fn() {}\n");
+    engine.update_syntax();
+    engine.feed_keys("f{ciBx<Esc>");
+    assert_eq!(engine.buffer().to_string(), "fn() {x}\n");
+}
+
+#[test]
+fn test_nvim_da_backtick_with_space() {
+    // da` deletes around backtick-quoted text including one adjacent space
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "bla `quote` blah\n");
+    engine.update_syntax();
+    engine.feed_keys("fqda`");
+    assert_eq!(engine.buffer().to_string(), "bla blah\n");
+}
+
+// -- Changelist navigation --
+
+#[test]
+fn test_nvim_g_semicolon_changelist() {
+    // g; navigates backward in the changelist
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa bbb ccc\n");
+    engine.update_syntax();
+    // Make changes at different positions
+    engine.feed_keys("cwXXX<Esc>");   // change "aaa" at col 0
+    engine.feed_keys("wcwYYY<Esc>");  // change "bbb" further right
+    engine.feed_keys("wcwZZZ<Esc>");  // change "ccc" further right
+    assert_eq!(engine.buffer().to_string(), "XXX YYY ZZZ\n");
+    // g; should move backward in changelist
+    let pos_after = engine.view().cursor.col;
+    engine.feed_keys("g;");
+    let pos_back1 = engine.view().cursor.col;
+    // Should have moved to a previous change position
+    assert!(pos_back1 <= pos_after || engine.view().cursor.line < 0 + 1,
+        "g; should move cursor backward in changelist");
+}
+
+#[test]
+fn test_nvim_g_comma_changelist_forward() {
+    // g, navigates forward in the changelist
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "aaa bbb\n");
+    engine.update_syntax();
+    engine.feed_keys("cwXXX<Esc>"); // change at start
+    engine.feed_keys("wcwYYY<Esc>"); // change further right
+    // Go back, then forward
+    engine.feed_keys("g;");
+    let pos_back = (engine.view().cursor.line, engine.view().cursor.col);
+    engine.feed_keys("g,");
+    let pos_fwd = (engine.view().cursor.line, engine.view().cursor.col);
+    assert!(pos_fwd.1 >= pos_back.1 || pos_fwd.0 > pos_back.0,
+        "g, should move cursor forward in changelist");
 }

--- a/src/core/engine/visual.rs
+++ b/src/core/engine/visual.rs
@@ -310,8 +310,53 @@ impl Engine {
     }
 
     pub(crate) fn change_visual_selection(&mut self, changed: &mut bool) {
-        // Change is like delete, but then enter insert mode
-        self.delete_visual_selection(changed);
+        let was_visual_line = self.mode == Mode::VisualLine;
+
+        if was_visual_line {
+            // In visual-line mode, "c" replaces the selected lines with an
+            // empty line and enters insert mode on it (Vim behavior).  We
+            // delete the line *contents* of all selected lines and collapse
+            // them into a single empty line, preserving the trailing newline
+            // so text typed afterwards stays on its own line.
+            if let Some((text, _)) = self.get_visual_selection_text() {
+                let reg = self.selected_register.unwrap_or('"');
+                self.set_delete_register(reg, text, true);
+                self.selected_register = None;
+            }
+            if let Some((start, end)) = self.get_visual_selection_range() {
+                self.start_undo_group();
+                let start_char = self.buffer().line_to_char(start.line);
+                // Delete up to (but not including) the newline of the last selected line,
+                // unless the last selected line is the very last line in the buffer.
+                let end_char = if end.line + 1 < self.buffer().len_lines() {
+                    // There's a line after the selection — delete through
+                    // end.line's newline but stop before end.line+1's content.
+                    self.buffer().line_to_char(end.line + 1)
+                } else {
+                    self.buffer().len_chars()
+                };
+                // We want to leave a single empty line.  Delete everything
+                // from start_char..end_char, then re-insert a "\n" if we
+                // consumed the trailing newline of the last selected line.
+                let deleted_trailing_nl = end.line + 1 < self.buffer().len_lines();
+                self.delete_with_undo(start_char, end_char);
+                if deleted_trailing_nl {
+                    // Re-insert the newline we consumed so the cursor sits
+                    // on its own (empty) line.
+                    self.insert_with_undo(start_char, "\n");
+                }
+                self.finish_undo_group();
+                *changed = true;
+                self.view_mut().cursor.line = start.line;
+                self.view_mut().cursor.col = 0;
+            }
+            // Exit visual mode, enter insert mode
+            self.visual_anchor = None;
+            self.visual_dollar = false;
+        } else {
+            // Charwise / blockwise: delete selection normally
+            self.delete_visual_selection(changed);
+        }
 
         // The delete already finished the undo group and set mode to Normal
         // Now start a new undo group for the insert mode typing


### PR DESCRIPTION
## Summary
- **56 new Neovim-mined conformance tests** across undo/redo, put/paste, change operations, text objects, marks, registers, macros, join edge cases, insert mode keys, and changelist navigation
- **7 Vim deviations fixed:**
  - `Vc`/`Vjc` (visual line change) ate trailing newline instead of replacing with empty line
  - `r<CR>` was a no-op (Return key not mapped to '\n' for replace)
  - `S` (substitute line) didn't preserve indentation with auto_indent
  - `daw` at end of line didn't consume leading whitespace
  - Tick mark jump (`'a`) went to col 0 instead of first non-blank
  - `feed_keys` didn't drain macro playback queue (broke `@q` / `3@q`)
  - Updated `test_visual_line_change` to match correct Vim behavior
- **3 deviations documented as ignored tests:** visual J in line mode, `:%join` range, `Ctrl-U` insert scope

## Test plan
- [x] All 1755 tests pass (56 new, 0 regressions)
- [x] 13 ignored tests (3 new + 10 pre-existing)
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)