### PR TITLE
fix: 3 Vim deviations — visual J, :%join, insert Ctrl-U

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 16, 2026 (Session 282 — Insert paste fix, Phase 4 batches 10-11, 8 deviations fixed) | **Tests:** 1757 (lib) + 270 (nvim conformance)
+**Last updated:** Apr 16, 2026 (Session 283 — Fix 3 Vim deviations: visual J, :%join, insert Ctrl-U) | **Tests:** 1761 (lib) + 270 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,14 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 283 — Fix 3 Vim deviations (#97, #98, #99):**
+
+1. **Fix #97: Visual line J now joins selected lines** — Added `J` handler in visual mode operator dispatch. `VjjJ` correctly joins all selected lines.
+2. **Fix #98: :%join range now supported** — Added `%` range prefix handling in `execute_command()`. Also supports `%d` and `%y`.
+3. **Fix #99: Ctrl-U in insert mode respects insert point** — Added `insert_enter_col` field to track where insert mode was entered. Ctrl-U now deletes only back to that boundary instead of line start.
+4. **Closed #65** (already fixed in session 282, issue left open).
+5. **4 previously-ignored tests now passing** (1757 → 1761 lib tests).
 
 **Session 282 — Insert paste fix (#65), Phase 4 batches 10-11 (#25), 8 deviations fixed:**
 

--- a/README.md
+++ b/README.md
@@ -1026,7 +1026,7 @@ All ex commands support Vim-style abbreviations (e.g., `:j` for `:join`, `:y` fo
 | `:m[ove] {dest}` | Move current line to after line {dest} (0-indexed) |
 | `:t {dest}` / `:co[py] {dest}` | Copy current line to after line {dest} (0-indexed) |
 | `:sort [n] [r] [u] [i]` | Sort lines: `n`=numeric, `r`=reverse, `u`=unique, `i`=ignorecase |
-| `:j[oin]` | Join current line with the next (remove newline) |
+| `:j[oin]` / `:%j[oin]` | Join current line with next / join all lines |
 | `:y[ank] [reg]` | Yank current line into register (default `"`) |
 | `:pu[t] [reg]` | Put register contents after current line |
 | `:>` / `:<` | Indent / dedent current line by one shiftwidth |

--- a/SUMMARIES/engine_execute.md
+++ b/SUMMARIES/engine_execute.md
@@ -1,4 +1,4 @@
-# src/core/engine/execute.rs — 3,008 lines
+# src/core/engine/execute.rs — 3,206 lines
 
 Ex-command dispatcher. Parses and executes all `:` commands entered in command mode.
 

--- a/SUMMARIES/engine_keys.md
+++ b/SUMMARIES/engine_keys.md
@@ -1,4 +1,4 @@
-# src/core/engine/keys.rs — 7,664 lines
+# src/core/engine/keys.rs — 7,695 lines
 
 All keyboard input handling. Routes keys by mode, processes operators, macros, repeat, user keymaps, mouse events, and clipboard.
 

--- a/SUMMARIES/engine_mod.md
+++ b/SUMMARIES/engine_mod.md
@@ -1,4 +1,4 @@
-# src/core/engine/mod.rs — 3,931 lines
+# src/core/engine/mod.rs — 3,943 lines
 
 Core engine definition. Contains the `Engine` struct (all editor state), enums, types, `new()` constructor, free functions, and `mod` declarations for all submodules.
 

--- a/SUMMARIES/engine_tests.md
+++ b/SUMMARIES/engine_tests.md
@@ -1,4 +1,4 @@
-# src/core/engine/tests.rs — 24,185 lines
+# src/core/engine/tests.rs — 24,191 lines
 
 All engine unit and integration tests. ~880 test functions covering every Vim feature, command, motion, text object, and edge case. Includes 270 Neovim-mined conformance tests (`test_nvim_*`).
 

--- a/src/core/engine/execute.rs
+++ b/src/core/engine/execute.rs
@@ -24,6 +24,45 @@ impl Engine {
             }
         }
 
+        // Handle :%{cmd} — whole-buffer range prefix (e.g. :%join, :%d)
+        if let Some(rest) = cmd.strip_prefix('%') {
+            let rest = rest.trim();
+            let rest_normalized = normalize_ex_command(rest);
+            match rest_normalized.as_ref() {
+                "join" => {
+                    let total_lines = self.buffer().len_lines();
+                    if total_lines > 1 {
+                        self.view_mut().cursor.line = 0;
+                        self.view_mut().cursor.col = 0;
+                        let mut changed = false;
+                        self.join_lines(total_lines, &mut changed);
+                    }
+                    return EngineAction::None;
+                }
+                "delete" | "d" => {
+                    let total_lines = self.buffer().len_lines();
+                    self.view_mut().cursor.line = 0;
+                    self.view_mut().cursor.col = 0;
+                    let mut changed = false;
+                    self.start_undo_group();
+                    self.delete_lines(total_lines, &mut changed);
+                    self.finish_undo_group();
+                    return EngineAction::None;
+                }
+                "yank" | "y" => {
+                    let total_lines = self.buffer().len_lines();
+                    let saved = self.view().cursor;
+                    self.view_mut().cursor.line = 0;
+                    self.yank_lines(total_lines);
+                    self.view_mut().cursor = saved;
+                    return EngineAction::None;
+                }
+                _ => {
+                    // Fall through for commands that handle % themselves (s/, norm, etc.)
+                }
+            }
+        }
+
         // Handle :term / :terminal — open integrated terminal
         if cmd == "terminal" {
             return EngineAction::OpenTerminal;

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -276,6 +276,7 @@ impl Engine {
         // Capture cursor position before dispatching (used by cursor_move hook below).
         let pre_cursor_line = self.cursor().line;
         let pre_cursor_col = self.cursor().col;
+        let pre_mode = self.mode;
 
         // Ctrl+F: open find/replace from any mode (Visual captures the selection)
         if ctrl
@@ -350,6 +351,11 @@ impl Engine {
                     }
                 }
             }
+        }
+
+        // Track where insert mode was entered (for Ctrl-U boundary)
+        if !matches!(pre_mode, Mode::Insert) && self.mode == Mode::Insert {
+            self.insert_enter_col = self.view().cursor.col;
         }
 
         if changed {
@@ -2415,7 +2421,11 @@ impl Engine {
                 // Replace character: r followed by a character replaces char under cursor.
                 // Special case: Return/Enter replaces with newline (splits line).
                 let replacement = unicode.or_else(|| {
-                    if key_name == "Return" { Some('\n') } else { None }
+                    if key_name == "Return" {
+                        Some('\n')
+                    } else {
+                        None
+                    }
                 });
                 if let Some(replacement) = replacement {
                     let count = self.take_count();
@@ -4679,15 +4689,17 @@ impl Engine {
             return;
         }
 
-        // Ctrl+U: delete from cursor to start of line
+        // Ctrl+U: delete from cursor back to insert-start column (Vim behavior)
         if ctrl && key_name == "u" {
             let line = self.view().cursor.line;
             let col = self.view().cursor.col;
-            if col > 0 {
+            let del_to = self.insert_enter_col;
+            if col > del_to {
                 let line_start = self.buffer().line_to_char(line);
-                let char_idx = line_start + col;
-                self.delete_with_undo(line_start, char_idx);
-                self.view_mut().cursor.col = 0;
+                let from = line_start + del_to;
+                let to = line_start + col;
+                self.delete_with_undo(from, to);
+                self.view_mut().cursor.col = del_to;
                 *changed = true;
             }
             return;
@@ -6115,6 +6127,25 @@ impl Engine {
                 'U' if self.pending_key.is_none() => {
                     self.count = None; // Clear count (not used for visual operators)
                     self.uppercase_visual_selection(changed);
+                    return EngineAction::None;
+                }
+                'J' if self.pending_key.is_none() => {
+                    // Visual J: join all selected lines
+                    self.count = None;
+                    if let Some((start, end)) = self.get_visual_selection_range() {
+                        let start_line = start.line;
+                        let end_line = end.line;
+                        let line_count = end_line - start_line + 1;
+                        // Exit visual mode first
+                        self.mode = Mode::Normal;
+                        self.visual_anchor = None;
+                        // Move cursor to start of selection, then join
+                        self.view_mut().cursor.line = start_line;
+                        self.view_mut().cursor.col = start.col;
+                        if line_count > 1 {
+                            self.join_lines(line_count, changed);
+                        }
+                    }
                     return EngineAction::None;
                 }
                 '>' => {

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2691,6 +2691,8 @@ pub struct Engine {
     pub insert_ctrl_g_pending: bool,
     /// When true, after one Normal-mode command, auto-return to Insert mode (Ctrl-O).
     pub insert_ctrl_o_active: bool,
+    /// Column where insert mode was entered (for Ctrl-U to delete only typed text).
+    pub insert_enter_col: usize,
     /// When true, next keypress in Insert mode is inserted literally (Ctrl-V).
     pub insert_ctrl_v_pending: bool,
     /// Stores visual block insert/append info: (start_line, end_line, col, is_append).
@@ -3233,6 +3235,7 @@ impl Engine {
             insert_ctrl_r_pending: false,
             insert_ctrl_g_pending: false,
             insert_ctrl_o_active: false,
+            insert_enter_col: 0,
             insert_ctrl_v_pending: false,
             visual_block_insert_info: None,
             insert_open_count: 0,

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -21905,9 +21905,9 @@ fn test_nvim_visual_indent() {
 }
 
 #[test]
-#[ignore = "vim deviation: J in visual line mode does not join selected lines"]
 fn test_nvim_visual_join() {
-    // VjjJ should join the 3 selected lines. VimCode: no-op.
+    // VjjJ should join the 3 selected lines.
+    // Cursor ends at last join point (col 7, between "bbb" and "ccc").
     nvim_case(
         "aaa\nbbb\nccc\nddd\n",
         0,
@@ -21915,7 +21915,7 @@ fn test_nvim_visual_join() {
         "VjjJ",
         "aaa bbb ccc\nddd\n",
         0,
-        0,
+        7,
     );
 }
 
@@ -22521,12 +22521,12 @@ fn test_nvim_insert_ctrl_w_delete_word() {
 
 #[test]
 fn test_nvim_insert_ctrl_u_delete_to_start() {
-    // Ctrl-U in insert mode deletes to start of line
+    // Ctrl-U in insert mode deletes back to insert point, not line start
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "hello\n");
     engine.update_syntax();
     engine.feed_keys("A world<C-u><Esc>");
-    assert_eq!(engine.buffer().to_string(), "\n");
+    assert_eq!(engine.buffer().to_string(), "hello\n");
 }
 
 // ── Phase 4 Batch 4: Edge cases ─────────────────────────────────────────
@@ -23931,17 +23931,19 @@ fn test_nvim_g_semicolon_changelist() {
     engine.buffer_mut().insert(0, "aaa bbb ccc\n");
     engine.update_syntax();
     // Make changes at different positions
-    engine.feed_keys("cwXXX<Esc>");   // change "aaa" at col 0
-    engine.feed_keys("wcwYYY<Esc>");  // change "bbb" further right
-    engine.feed_keys("wcwZZZ<Esc>");  // change "ccc" further right
+    engine.feed_keys("cwXXX<Esc>"); // change "aaa" at col 0
+    engine.feed_keys("wcwYYY<Esc>"); // change "bbb" further right
+    engine.feed_keys("wcwZZZ<Esc>"); // change "ccc" further right
     assert_eq!(engine.buffer().to_string(), "XXX YYY ZZZ\n");
     // g; should move backward in changelist
     let pos_after = engine.view().cursor.col;
     engine.feed_keys("g;");
     let pos_back1 = engine.view().cursor.col;
     // Should have moved to a previous change position
-    assert!(pos_back1 <= pos_after || engine.view().cursor.line < 0 + 1,
-        "g; should move cursor backward in changelist");
+    assert!(
+        pos_back1 <= pos_after || engine.view().cursor.line < 0 + 1,
+        "g; should move cursor backward in changelist"
+    );
 }
 
 #[test]
@@ -23952,13 +23954,15 @@ fn test_nvim_g_comma_changelist_forward() {
     engine.update_syntax();
     engine.feed_keys("cwXXX<Esc>"); // change at start
     engine.feed_keys("wcwYYY<Esc>"); // change further right
-    // Go back, then forward
+                                     // Go back, then forward
     engine.feed_keys("g;");
     let pos_back = (engine.view().cursor.line, engine.view().cursor.col);
     engine.feed_keys("g,");
     let pos_fwd = (engine.view().cursor.line, engine.view().cursor.col);
-    assert!(pos_fwd.1 >= pos_back.1 || pos_fwd.0 > pos_back.0,
-        "g, should move cursor forward in changelist");
+    assert!(
+        pos_fwd.1 >= pos_back.1 || pos_fwd.0 > pos_back.0,
+        "g, should move cursor forward in changelist"
+    );
 }
 
 // ── Phase 4 Batch 11: Marks, Registers, Join edge cases, Insert keys ──────
@@ -23971,9 +23975,9 @@ fn test_nvim_mark_overwrite() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\nbbb\nccc\n");
     engine.update_syntax();
-    engine.feed_keys("ma");       // mark 'a' at line 0
-    engine.feed_keys("jjma");     // overwrite mark 'a' at line 2
-    engine.feed_keys("gg'a");     // jump to mark 'a'
+    engine.feed_keys("ma"); // mark 'a' at line 0
+    engine.feed_keys("jjma"); // overwrite mark 'a' at line 2
+    engine.feed_keys("gg'a"); // jump to mark 'a'
     assert_eq!(engine.view().cursor.line, 2);
 }
 
@@ -23984,7 +23988,10 @@ fn test_nvim_mark_unset_error() {
     engine.buffer_mut().insert(0, "test\n");
     engine.update_syntax();
     engine.feed_keys("'z");
-    assert!(!engine.message.is_empty(), "should show error for unset mark");
+    assert!(
+        !engine.message.is_empty(),
+        "should show error for unset mark"
+    );
 }
 
 #[test]
@@ -23993,8 +24000,8 @@ fn test_nvim_mark_tick_first_nonblank() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "aaa\n    bbb\nccc\n");
     engine.update_syntax();
-    engine.feed_keys("jllma");   // mark 'a' at line 1, col 6
-    engine.feed_keys("gg'a");     // tick-jump to mark 'a'
+    engine.feed_keys("jllma"); // mark 'a' at line 1, col 6
+    engine.feed_keys("gg'a"); // tick-jump to mark 'a'
     assert_eq!(engine.view().cursor.line, 1);
     assert_eq!(engine.view().cursor.col, 4); // first non-blank
 }
@@ -24005,8 +24012,8 @@ fn test_nvim_mark_backtick_exact_col() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "hello world\nfoo bar baz\n");
     engine.update_syntax();
-    engine.feed_keys("jllllmb");  // mark 'b' at line 1, col 4
-    engine.feed_keys("gg`b");     // backtick-jump to mark 'b'
+    engine.feed_keys("jllllmb"); // mark 'b' at line 1, col 4
+    engine.feed_keys("gg`b"); // backtick-jump to mark 'b'
     assert_eq!(engine.view().cursor.line, 1);
     assert_eq!(engine.view().cursor.col, 4);
 }
@@ -24054,8 +24061,8 @@ fn test_nvim_yank_register_0_preserved() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "alpha\nbeta\ngamma\n");
     engine.update_syntax();
-    engine.feed_keys("yy");   // yank "alpha\n" to register 0
-    engine.feed_keys("jdd");  // delete "beta\n" to unnamed and register 1
+    engine.feed_keys("yy"); // yank "alpha\n" to register 0
+    engine.feed_keys("jdd"); // delete "beta\n" to unnamed and register 1
     let (reg0, _) = engine.registers.get(&'0').cloned().unwrap_or_default();
     assert_eq!(reg0, "alpha\n");
     // Unnamed register should now have the deleted text
@@ -24070,7 +24077,7 @@ fn test_nvim_macro_record_and_play() {
     engine.buffer_mut().insert(0, "\n\n");
     engine.update_syntax();
     engine.feed_keys("qqiHello<Esc>q"); // record: insert "Hello"
-    engine.feed_keys("j@q");             // play on next line
+    engine.feed_keys("j@q"); // play on next line
     assert_eq!(engine.buffer().to_string(), "Hello\nHello\n");
 }
 
@@ -24081,7 +24088,7 @@ fn test_nvim_macro_with_count() {
     engine.buffer_mut().insert(0, "x\n");
     engine.update_syntax();
     engine.feed_keys("qqA!<Esc>q"); // record: append "!"
-    engine.feed_keys("3@q");        // play 3 more times
+    engine.feed_keys("3@q"); // play 3 more times
     assert_eq!(engine.buffer().to_string(), "x!!!!\n");
 }
 
@@ -24123,14 +24130,15 @@ fn test_nvim_gJ_preserves_leading_whitespace() {
 fn test_nvim_4J_join_four_lines() {
     // 4J joins four lines into one
     let mut engine = Engine::new();
-    engine.buffer_mut().insert(0, "one\ntwo\nthree\nfour\nfive\n");
+    engine
+        .buffer_mut()
+        .insert(0, "one\ntwo\nthree\nfour\nfive\n");
     engine.update_syntax();
     engine.feed_keys("4J");
     assert_eq!(engine.buffer().to_string(), "one two three four\nfive\n");
 }
 
 #[test]
-#[ignore = "vim deviation: J in visual line mode does not join selected lines"]
 fn test_nvim_visual_J_three_lines() {
     // Visual select 3 lines then J joins them
     let mut engine = Engine::new();
@@ -24141,7 +24149,6 @@ fn test_nvim_visual_J_three_lines() {
 }
 
 #[test]
-#[ignore = "vim deviation: :%join range not supported yet"]
 fn test_nvim_percent_join_command() {
     // :%join joins all lines
     let mut engine = Engine::new();
@@ -24164,7 +24171,6 @@ fn test_nvim_insert_ctrl_w_delete_word_back() {
 }
 
 #[test]
-#[ignore = "vim deviation: Ctrl-U deletes to line start instead of insert start"]
 fn test_nvim_insert_ctrl_u_after_append() {
     // Ctrl-U in insert mode should only delete text typed since entering insert mode
     let mut engine = Engine::new();


### PR DESCRIPTION
## Summary
- **#97**: Visual line `J` now joins selected lines (added `J` handler in visual mode operator dispatch)
- **#98**: `:%join` range prefix now supported (also `:%d`, `:%y`); added `%` prefix handling in `execute_command`
- **#99**: `Ctrl-U` in insert mode now deletes only back to the insert point, not to line start (new `insert_enter_col` field tracks where insert mode was entered)
- Closed **#65** (already fixed in session 282)
- 4 previously-ignored conformance tests now passing (1757 → 1761 lib tests)

Closes #97
Closes #98
Closes #99

## Test plan
- [x] All 5 affected tests pass (`test_nvim_visual_join`, `test_nvim_visual_J_three_lines`, `test_nvim_percent_join_command`, `test_nvim_insert_ctrl_u_delete_to_start`, `test_nvim_insert_ctrl_u_after_append`)
- [x] Full test suite: 1761 passed, 0 failed, 9 ignored
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)