### PR TITLE
fix: resolve all clippy errors for Rust 1.95 CI

### DIFF
--- a/src/core/buffer_manager.rs
+++ b/src/core/buffer_manager.rs
@@ -595,7 +595,7 @@ impl BufferState {
                     let end = pos + text.chars().count();
                     self.buffer.delete_range(*pos, end);
                     // Position cursor at the deletion point
-                    let safe_pos = (*pos).min(self.buffer.len_chars().saturating_sub(1).max(0));
+                    let safe_pos = (*pos).min(self.buffer.len_chars().saturating_sub(1));
                     let line = if self.buffer.len_chars() == 0 {
                         0
                     } else {

--- a/src/core/engine/execute.rs
+++ b/src/core/engine/execute.rs
@@ -2137,11 +2137,7 @@ impl Engine {
                 let modified = if self.dirty() { " [Modified]" } else { "" };
                 let total = self.buffer().len_lines();
                 let cur_line = self.view().cursor.line + 1;
-                let pct = if total == 0 {
-                    0
-                } else {
-                    (cur_line * 100) / total
-                };
+                let pct = (cur_line * 100).checked_div(total).unwrap_or(0);
                 self.message = format!("\"{name}\"{modified} {total} lines --{pct}%--");
                 EngineAction::None
             }

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -704,11 +704,7 @@ impl Engine {
                     let total = self.buffer().len_lines();
                     let cur_line = self.view().cursor.line + 1;
                     let col = self.view().cursor.col + 1;
-                    let pct = if total == 0 {
-                        0
-                    } else {
-                        (cur_line * 100) / total
-                    };
+                    let pct = (cur_line * 100).checked_div(total).unwrap_or(0);
                     self.message = format!(
                         "\"{name}\"{modified} line {cur_line} of {total} --{pct}%-- col {col}"
                     );

--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -731,7 +731,7 @@ impl Engine {
                     )
                 })
                 .collect();
-            scored.sort_by(|a, b| b.score.cmp(&a.score));
+            scored.sort_by_key(|b| std::cmp::Reverse(b.score));
             scored.truncate(cap);
             *out = scored;
         }

--- a/src/core/engine/plugins.rs
+++ b/src/core/engine/plugins.rs
@@ -310,7 +310,7 @@ impl Engine {
         if !ctx.insert_lines.is_empty() {
             let buf_id = self.active_buffer_id();
             let mut insertions = ctx.insert_lines;
-            insertions.sort_by(|a, b| b.0.cmp(&a.0));
+            insertions.sort_by_key(|b| std::cmp::Reverse(b.0));
             for (line_1, text) in insertions {
                 let line_idx = line_1.saturating_sub(1);
                 if let Some(state) = self.buffer_manager.get_mut(buf_id) {

--- a/src/core/engine/source_control.rs
+++ b/src/core/engine/source_control.rs
@@ -729,7 +729,7 @@ impl Engine {
             .enumerate()
             .filter_map(|(i, b)| Self::fuzzy_score(&b.name, q).map(|s| (i, s)))
             .collect();
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results.sort_by_key(|b| std::cmp::Reverse(b.1));
         results.truncate(50);
         results
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Library shim for integration tests. No UI deps (GTK/Relm4/Cairo) allowed here.
+#![allow(clippy::collapsible_match)]
 pub mod core;
 pub mod icons;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // Relm4 view! macro generates #[name = "..."] bindings that trigger this lint.
 // TreeView/TreeStore are deprecated in GTK4 4.10+ but still functional.
-#![allow(unused_assignments, deprecated)]
+#![allow(unused_assignments, deprecated, clippy::collapsible_match)]
 
 mod core;
 mod gtk;

--- a/src/tui_bin.rs
+++ b/src/tui_bin.rs
@@ -3,7 +3,13 @@
 //! Build with: `cargo build --release --bin vimcode-tui --no-default-features`
 
 // Shared modules contain code used only by the GTK binary — suppress warnings.
-#![allow(dead_code, unused_imports, unused_assignments)]
+#![allow(
+    dead_code,
+    unused_imports,
+    unused_assignments,
+    clippy::collapsible_match,
+    clippy::explicit_counter_loop
+)]
 
 use std::collections::HashSet;
 use std::path::PathBuf;

--- a/src/tui_bin.rs
+++ b/src/tui_bin.rs
@@ -3,13 +3,7 @@
 //! Build with: `cargo build --release --bin vimcode-tui --no-default-features`
 
 // Shared modules contain code used only by the GTK binary — suppress warnings.
-#![allow(
-    dead_code,
-    unused_imports,
-    unused_assignments,
-    clippy::collapsible_match,
-    clippy::explicit_counter_loop
-)]
+#![allow(dead_code, unused_imports, unused_assignments, clippy::collapsible_match)]
 
 use std::collections::HashSet;
 use std::path::PathBuf;

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -573,7 +573,7 @@ fn filter_dir_entries(all: &[PathBuf], query: &str) -> Vec<PathBuf> {
             dir_fuzzy_score(&display, &q).map(|s| (s, p))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|b| std::cmp::Reverse(b.0));
     scored
         .into_iter()
         .take(CAP)

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -7,7 +7,11 @@
 //!
 //! **No GTK/Cairo/Pango imports here.** All editor logic comes from `core`.
 //! All rendering data comes from `render`.
-#![allow(unused_assignments)]
+#![allow(
+    unused_assignments,
+    clippy::collapsible_match,
+    clippy::explicit_counter_loop
+)]
 
 use std::collections::HashSet;
 use std::fs;

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -2948,11 +2948,9 @@ pub(super) fn render_editor_hover_popup(
             let track_h = num_lines as usize;
             let thumb_h = (track_h * track_h / total).max(1);
             let max_scroll = total.saturating_sub(MAX_HEIGHT as usize);
-            let thumb_top = if max_scroll > 0 {
-                scroll * (track_h - thumb_h) / max_scroll
-            } else {
-                0
-            };
+            let thumb_top = (scroll * (track_h - thumb_h))
+                .checked_div(max_scroll)
+                .unwrap_or(0);
             for i in 0..track_h {
                 let ry = y + 1 + i as u16;
                 if ry >= term_area.height {
@@ -3296,7 +3294,7 @@ pub(super) fn render_ai_sidebar(
         (panel_bg, dim_fg)
     };
     let cursor = ai.input_cursor.min(input_chars.len());
-    let cursor_line = if content_w > 0 { cursor / content_w } else { 0 };
+    let cursor_line = cursor.checked_div(content_w).unwrap_or(0);
     let cursor_col = if content_w > 0 {
         cursor % content_w
     } else {

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -2039,11 +2039,9 @@ pub(super) fn render_picker_popup(
         let track_len = visible_rows;
         let thumb_size = ((visible_rows * visible_rows) / total_items).max(1);
         let max_scroll = total_items.saturating_sub(visible_rows);
-        let thumb_offset = if max_scroll > 0 {
-            (picker.scroll_top * (track_len.saturating_sub(thumb_size))) / max_scroll
-        } else {
-            0
-        };
+        let thumb_offset = (picker.scroll_top * (track_len.saturating_sub(thumb_size)))
+            .checked_div(max_scroll)
+            .unwrap_or(0);
         for row_off in 0..track_len {
             let ry = results_start + row_off as u16;
             if ry >= y + height - 1 || ry >= term_area.height {


### PR DESCRIPTION
## Summary
CI has been failing since Rust 1.95 stable (around session 282) added stricter lints. This fixes all 37 errors so CI goes green again.

**Active fixes:**
- \`sort_by\` → \`sort_by_key\` (4 files)
- \`manual_checked_ops\`: rewrote \`if total == 0 { 0 } else { x / total }\` as \`x.checked_div(total).unwrap_or(0)\` (5 sites)
- Removed redundant \`.max(0)\` on \`usize\` in \`buffer_manager.rs\`

**Crate-level allows** for stylistic lints where the current form is clearer:
- \`collapsible_match\`: many match arms with inner \`if\`-checks are more readable than match guards with complex bodies
- \`explicit_counter_loop\`: TUI rendering uses explicit counters where the counter represents semantic coordinates (row/col) distinct from enumeration

## Test plan
- [x] \`cargo clippy --no-default-features -- -D warnings\` clean on Rust 1.95.0
- [x] \`cargo test --no-default-features --lib\`: 1811 passed, 0 failed, 11 ignored
- [x] \`cargo build --no-default-features\`: success
- [x] \`cargo fmt\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)