### PR TITLE
fix: Replace mode Esc steps cursor back by 1 col (#101)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 16, 2026 (Session 285 — Phase 4 batch 13, 25 new conformance tests, 0 deviations) | **Tests:** 1811 (lib) + 327 (nvim conformance)
+**Last updated:** Apr 16, 2026 (Session 286 — Fix #101 Replace mode Esc cursor) | **Tests:** 1813 (lib) + 327 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,11 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 286 — Fix #101 Replace mode Esc cursor position:**
+
+1. **Fix #101: Replace mode cursor stepback on Esc** — `handle_replace_key` Esc handler in `src/core/engine/motions.rs` was missing the cursor-step-back that Insert mode already had. Added the same `col > 0 → col -= 1` logic. Also covers `gR` virtual replace.
+2. **2 previously-ignored tests now passing** (1811 → 1813 lib, 11 → 9 ignored).
 
 **Session 285 — Phase 4 batch 13 (#25), 25 new conformance tests, 0 new deviations:**
 

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -1200,6 +1200,10 @@ impl Engine {
             "Escape" => {
                 self.virtual_replace = false;
                 self.mode = Mode::Normal;
+                // Vim steps cursor one left when leaving Replace mode (unless at col 0)
+                if self.view().cursor.col > 0 {
+                    self.view_mut().cursor.col -= 1;
+                }
                 self.clamp_cursor_col();
             }
             "BackSpace" => {

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -24357,7 +24357,6 @@ fn test_nvim_ctrl_x_count_prefix() {
 // -- Replace mode --
 
 #[test]
-#[ignore = "vim deviation #101: Replace mode cursor lands at col+1 after Esc"]
 fn test_nvim_R_replaces_chars() {
     // R enters replace mode; subsequent chars overwrite
     // Vim: after RXYZ<Esc>, cursor on last replaced char (Z) at col 2. VimCode: col 3.
@@ -24365,7 +24364,6 @@ fn test_nvim_R_replaces_chars() {
 }
 
 #[test]
-#[ignore = "vim deviation #101: Replace mode cursor lands at col+1 after Esc"]
 fn test_nvim_R_past_eol_appends() {
     // R past end-of-line appends rather than overwriting
     nvim_case("ab\n", 0, 0, "RXYZ<Esc>", "XYZ\n", 0, 2);


### PR DESCRIPTION
## Summary
The \`handle_replace_key\` Esc handler was missing the cursor step-back logic that Insert mode already had. Vim moves cursor one position left when leaving Insert/Replace mode (unless at col 0).

- Fixed in \`src/core/engine/motions.rs:1200\` — one-line change mirrors the Insert mode Esc pattern
- Affects both \`R\` (Replace) and \`gR\` (Virtual Replace) since they share the handler
- 2 ignored conformance tests now pass (\`test_nvim_R_replaces_chars\`, \`test_nvim_R_past_eol_appends\`)

Closes #101

## Test plan
- [x] Full suite: **1813 passed, 0 failed, 9 ignored** (up from 1811/11)
- [x] No regressions from the cursor change
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)