### PR TITLE
fix: refresh git branch in status bar on external change (#60)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 16, 2026 (Session 286 — Fix #101 Replace mode Esc cursor) | **Tests:** 1813 (lib) + 327 (nvim conformance)
+**Last updated:** Apr 16, 2026 (Session 287 — Fix #60 Git branch external refresh) | **Tests:** 1815 (lib) + 327 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,11 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 287 — Fix #60 Git branch status bar refresh:**
+
+1. **Fix #60: Status bar now detects external branch changes** — Added `tick_git_branch()` method on Engine that polls `git::current_branch()` at most once per 2 seconds and returns `true` if the branch changed. Wired into all three backends (GTK, TUI, Win-GUI) via their existing tick loops; a detected change triggers a redraw.
+2. **2 new unit tests** (rate-limit + change detection) — 1813 → 1815 lib tests.
 
 **Session 286 — Fix #101 Replace mode Esc cursor position:**
 

--- a/src/core/engine/buffers.rs
+++ b/src/core/engine/buffers.rs
@@ -3109,6 +3109,30 @@ impl Engine {
         }
     }
 
+    /// Re-read the current git branch if enough time has passed since the last
+    /// check. Catches external branch changes (e.g. `git checkout` in a shell).
+    /// Returns `true` if the branch changed (so the caller can redraw).
+    /// Called from the backend's tick function.
+    pub fn tick_git_branch(&mut self) -> bool {
+        let now = std::time::Instant::now();
+        let should_check = match self.last_git_branch_check {
+            None => true,
+            Some(prev) => now.duration_since(prev) >= std::time::Duration::from_secs(2),
+        };
+        if !should_check {
+            return false;
+        }
+        self.last_git_branch_check = Some(now);
+        let dir = self.git_dir();
+        let fresh = crate::core::git::current_branch(&dir);
+        if fresh != self.git_branch {
+            self.git_branch = fresh;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Poll the file watcher for external modifications and show reload dialogs.
     /// Called from the backend's tick function.
     pub fn tick_file_watcher(&mut self) {

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2177,6 +2177,8 @@ pub struct Engine {
     // --- Git integration ---
     /// Current git branch name (None if not in a git repo or git not available).
     pub git_branch: Option<String>,
+    /// When we last polled for an external branch change (for tick_git_branch rate limit).
+    pub last_git_branch_check: Option<std::time::Instant>,
 
     // --- Scroll binding ---
     /// Pairs of windows whose scroll_top should stay in sync (e.g. :Gblame).
@@ -3037,6 +3039,7 @@ impl Engine {
                 let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 git::current_branch(&cwd)
             },
+            last_git_branch_check: None,
             scroll_bind_pairs: Vec::new(),
             completion_candidates: Vec::new(),
             completion_idx: None,

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -24683,3 +24683,36 @@ fn test_nvim_paste_linewise_above() {
     engine.feed_keys("yyP");
     assert_eq!(engine.buffer().to_string(), "foo\nfoo\nbar\n");
 }
+
+// ── Git branch refresh (#60) ───────────────────────────────────────────
+
+#[test]
+fn test_tick_git_branch_rate_limited() {
+    // Two calls back-to-back: second must return false (within the 2s window)
+    // even if the first did work.
+    let mut engine = Engine::new();
+    engine.tick_git_branch();
+    // Force a fake "branch changed" so the second call would otherwise return true.
+    engine.git_branch = Some("pretend-different".to_string());
+    assert!(
+        !engine.tick_git_branch(),
+        "second tick within 2s must be rate-limited"
+    );
+}
+
+#[test]
+fn test_tick_git_branch_detects_change() {
+    // Bypass the rate limit and confirm a branch mismatch is reported.
+    let mut engine = Engine::new();
+    engine.git_branch = Some("stale-value-not-matching-anything".to_string());
+    engine.last_git_branch_check = None; // force a real check
+    // The return value depends on whether tests run inside a git repo.
+    // Our CWD during tests *is* the vimcode repo, so current_branch() returns
+    // Some(real branch) which differs from our stale value — tick returns true.
+    let changed = engine.tick_git_branch();
+    assert!(changed, "stale branch should be detected as changed");
+    assert_ne!(
+        engine.git_branch.as_deref(),
+        Some("stale-value-not-matching-anything")
+    );
+}

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -5690,6 +5690,10 @@ impl App {
         }
         // Tick swap file writes (only does work when updatetime elapsed).
         self.engine.borrow_mut().tick_swap_files();
+        // Poll for external git branch changes (rate-limited to once per 2s inside).
+        if self.engine.borrow_mut().tick_git_branch() {
+            self.draw_needed.set(true);
+        }
         // Auto-dismiss completed notifications after timeout; force redraw for spinner animation.
         {
             let mut engine = self.engine.borrow_mut();

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -1501,6 +1501,10 @@ fn event_loop(
             engine.tick_swap_files();
             // Check for externally modified files.
             engine.tick_file_watcher();
+            // Poll for external git branch changes (rate-limited to once per 2s).
+            if engine.tick_git_branch() {
+                needs_redraw = true;
+            }
             // Auto-dismiss completed notifications after timeout.
             // Force redraw every idle tick when notifications are visible (spinner animation).
             if !engine.notifications.is_empty() {

--- a/src/win_gui/mod.rs
+++ b/src/win_gui/mod.rs
@@ -5811,6 +5811,11 @@ fn on_tick(hwnd: HWND) {
         // File watcher (external modification detection)
         state.engine.tick_file_watcher();
 
+        // Poll for external git branch changes (rate-limited to once per 2s inside).
+        if state.engine.tick_git_branch() {
+            needs_redraw = true;
+        }
+
         // Notification ticker
         state.engine.tick_notifications();
         needs_redraw = true;


### PR DESCRIPTION
## Summary
When the git branch was changed outside VimCode (e.g. \`git checkout\` in a terminal), the status bar kept showing the stale branch. Branch only refreshed on internal git operations (commit, stage, etc).

**Mechanism**
- New \`Engine::tick_git_branch()\` — rate-limited to once per 2 seconds, re-reads \`git::current_branch()\`, compares, updates \`Engine::git_branch\`, returns \`true\` on change.
- Wired into **all three backend tick loops** per the multi-backend rule in CLAUDE.md:
  - \`src/gtk/mod.rs\` — GTK tick
  - \`src/tui_main/mod.rs\` — TUI event loop
  - \`src/win_gui/mod.rs\` — Win-GUI message loop
- A detected change triggers a redraw via the existing \`draw_needed\` / \`needs_redraw\` flags.

## Test plan
- [x] 2 new unit tests: rate-limit, change detection
- [x] Full suite: **1815 passed, 0 failed, 9 ignored** (up from 1813)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt\` applied

### Manual verification (recommended once merged)
1. Open a repo in VimCode
2. In a separate shell, \`git checkout other-branch\`
3. Status bar should reflect the new branch within ~2s

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)