### PR TITLE
feat: fire git_branch_changed plugin event (#107)

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -512,6 +512,7 @@ vimcode.set_comment_style("haskell", {
 | `panel_collapse` | `"panel\|section\|id\|\|index"` | Tree node collapsed via Tab |
 | `panel_double_click` | `"panel\|section\|id\|\|index"` | Double-click on panel item |
 | `panel_context_menu` | `"panel\|section\|id\|\|index"` | Right-click on panel item |
+| `git_branch_changed` | new branch name (or `""`) | External git branch change detected (rate-limited to once per 2s) |
 | `panel_input` | `"panel\|\|\|text\|"` | Panel input field text changed |
 | Custom | shell output | `async_shell()` callback event |
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 16, 2026 (Session 287 — Fix #60 Git branch external refresh) | **Tests:** 1815 (lib) + 327 (nvim conformance)
+**Last updated:** Apr 16, 2026 (Session 288 — #107 git_branch_changed plugin event) | **Tests:** 1817 (lib) + 327 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,13 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 288 — #107 git_branch_changed plugin event (follow-up to #60):**
+
+1. **Fire `git_branch_changed` plugin event** from `tick_git_branch()` when an external branch change is detected. Plugins (e.g. git-insights panel) can now subscribe via `vimcode.on("git_branch_changed", fn)` and refresh their UI instead of going stale.
+2. **No new Lua API surface** — plugins already have `vimcode.git.branch()` to re-query state on the event.
+3. **2 new unit tests**: plugin event fires on change, does NOT fire when branch unchanged (1815 → 1817 lib tests).
+4. **EXTENSIONS.md updated** with the new event.
 
 **Session 287 — Fix #60 Git branch status bar refresh:**
 

--- a/src/core/engine/buffers.rs
+++ b/src/core/engine/buffers.rs
@@ -3126,7 +3126,11 @@ impl Engine {
         let dir = self.git_dir();
         let fresh = crate::core::git::current_branch(&dir);
         if fresh != self.git_branch {
-            self.git_branch = fresh;
+            self.git_branch = fresh.clone();
+            // Notify plugins (e.g. git-insights panel) so they can refresh.
+            // Arg is the new branch name, or empty string if detached/not a repo.
+            let arg = fresh.unwrap_or_default();
+            self.plugin_event("git_branch_changed", &arg);
             true
         } else {
             false

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -24715,3 +24715,64 @@ fn test_tick_git_branch_detects_change() {
         Some("stale-value-not-matching-anything")
     );
 }
+
+#[test]
+fn test_tick_git_branch_fires_plugin_event() {
+    // When tick_git_branch detects a change, plugins subscribed to
+    // git_branch_changed should be invoked with the new branch name.
+    let dir = write_plugin_lua(
+        "test_git_branch_event",
+        r#"vimcode.on("git_branch_changed", function(branch)
+            vimcode.message("branch:" .. branch)
+        end)"#,
+    );
+    let mut engine = Engine::new();
+    match plugin::PluginManager::new() {
+        Ok(mut mgr) => {
+            mgr.load_plugins_dir(&dir, &[]);
+            engine.plugin_manager = Some(mgr);
+        }
+        Err(_) => return,
+    }
+    // Force a change detection on the next tick.
+    engine.git_branch = Some("stale-value-not-matching-anything".to_string());
+    engine.last_git_branch_check = None;
+    let changed = engine.tick_git_branch();
+    assert!(changed, "tick should detect a change");
+    assert!(
+        engine.message.starts_with("branch:"),
+        "plugin should have set a 'branch:' message, got: {:?}",
+        engine.message
+    );
+}
+
+#[test]
+fn test_tick_git_branch_no_event_when_unchanged() {
+    // When tick_git_branch sees no change, plugins must NOT be invoked.
+    let dir = write_plugin_lua(
+        "test_git_branch_noevent",
+        r#"vimcode.on("git_branch_changed", function(branch)
+            vimcode.message("unexpected:" .. branch)
+        end)"#,
+    );
+    let mut engine = Engine::new();
+    match plugin::PluginManager::new() {
+        Ok(mut mgr) => {
+            mgr.load_plugins_dir(&dir, &[]);
+            engine.plugin_manager = Some(mgr);
+        }
+        Err(_) => return,
+    }
+    // Prime the cache: whatever git::current_branch() returns is what we hold.
+    engine.last_git_branch_check = None;
+    engine.tick_git_branch(); // may or may not return true depending on prior state
+    engine.message.clear();
+    // Second tick without rate limit: branch is already up-to-date → no event.
+    engine.last_git_branch_check = None;
+    let changed = engine.tick_git_branch();
+    assert!(!changed, "second tick should see no change");
+    assert_eq!(
+        engine.message, "",
+        "plugin event must not fire when branch unchanged"
+    );
+}


### PR DESCRIPTION
## Summary
Follow-up to #60. When an external branch change is detected, \`tick_git_branch()\` now emits a \`git_branch_changed\` plugin event so plugins (e.g. git-insights panel) can refresh instead of going stale.

**No new Lua API surface** — plugins already have \`vimcode.git.branch()\` to re-query. All we're adding is the trigger.

## Plugin usage

\`\`\`lua
vimcode.on("git_branch_changed", function(new_branch)
    -- new_branch is the new branch name, or "" if detached/not a repo
    -- re-query git state and refresh UI here
end)
\`\`\`

## Test plan
- [x] \`test_tick_git_branch_fires_plugin_event\` — event fires with new branch name on change
- [x] \`test_tick_git_branch_no_event_when_unchanged\` — event does NOT fire when branch is unchanged
- [x] Full suite: **1817 passed, 0 failed, 9 ignored** (up from 1815)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt\` applied
- [x] EXTENSIONS.md event table updated

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)