### PR TITLE
fix: ranged/concat/bang ex-command forms (#112)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 17, 2026 (Session 290 — Phase 4 batch 15, 23 new conformance tests, #112 filed) | **Tests:** 1869 (lib) + 379 (nvim conformance)
+**Last updated:** Apr 17, 2026 (Session 291 — Fix #112 ranged/concat/bang ex-command forms) | **Tests:** 1881 (lib) + 391 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,12 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 291 — Fix #112: ranged/concat/bang ex-command forms, #114 filed:**
+
+1. **Fix #112 — Ranged `:copy`/`:move`, concat `:tN`/`:mN`/`:coN`, `:sort!`** — Added `execute_copy_range()` and `execute_move_range()` helpers with 1-based range semantics matching Vim. Extended `try_execute_ranged_command()` to dispatch `m`/`move`/`t`/`co`/`copy` keywords. Added `split_cmd_and_arg()` helper that matches a command name followed by a valid separator (digit/space/sign/`./$`). Accepted `:sort!` bang as reverse synonym.
+2. **#114 filed** — VimCode's `parse_line_address` treats numeric dest as 0-based, but Vim uses 1-based throughout. Fix requires auditing existing callers; scoped as a separate issue so this PR stays focused.
+3. **12 new unit tests** covering all new forms + regressions (`:0` still goes to line 0, `:sort r` still works).
 
 **Session 290 — Phase 4 batch 15 (#25), 23 new conformance tests, #112 filed:**
 

--- a/SUMMARIES/engine_execute.md
+++ b/SUMMARIES/engine_execute.md
@@ -1,4 +1,4 @@
-# src/core/engine/execute.rs — 3,206 lines
+# src/core/engine/execute.rs — 3,398 lines
 
 Ex-command dispatcher. Parses and executes all `:` commands entered in command mode.
 

--- a/SUMMARIES/engine_tests.md
+++ b/SUMMARIES/engine_tests.md
@@ -1,6 +1,6 @@
-# src/core/engine/tests.rs — 25,371 lines
+# src/core/engine/tests.rs — 25,509 lines
 
-All engine unit and integration tests. ~920 test functions covering every Vim feature, command, motion, text object, and edge case. Includes 379 Neovim-mined conformance tests (`test_nvim_*`).
+All engine unit and integration tests. ~925 test functions covering every Vim feature, command, motion, text object, and edge case. Includes 391 Neovim-mined conformance tests (`test_nvim_*`).
 
 ## Test Helpers
 - `engine_with(text)` — create engine with initial buffer content; resets settings and keymaps for hermeticity

--- a/src/core/engine/execute.rs
+++ b/src/core/engine/execute.rs
@@ -1315,20 +1315,36 @@ impl Engine {
             return self.execute_global_command(rest, true);
         }
 
-        // :sort [flags] — sort lines in buffer
-        if cmd == "sort" || cmd.starts_with("sort ") {
-            let flags = cmd.strip_prefix("sort").unwrap_or("").trim();
-            return self.execute_sort_command(flags);
+        // :sort [flags] — sort lines in buffer.
+        // Accept both ":sort" with space-separated flags and the Vim ":sort!" bang
+        // (synonym for the 'r' reverse flag).
+        if cmd == "sort" || cmd == "sort!" || cmd.starts_with("sort ") || cmd.starts_with("sort!") {
+            // Normalize: strip "sort" and an optional '!', then treat the '!' as
+            // a reverse flag appended to whatever flags remain.
+            let after = cmd.strip_prefix("sort").unwrap_or("");
+            let (bang, after) = if let Some(rest) = after.strip_prefix('!') {
+                (true, rest)
+            } else {
+                (false, after)
+            };
+            let mut flags = after.trim().to_string();
+            if bang && !flags.contains('r') {
+                flags.push('r');
+            }
+            return self.execute_sort_command(&flags);
         }
 
-        // :m[ove] {dest} — move current line to after dest
-        if let Some(dest) = cmd.strip_prefix("move ") {
-            return self.execute_move_command(dest.trim());
+        // :m[ove] {dest} / :t {dest} / :co[py] {dest} — operate on current line.
+        // Accept both the space-separated form (":move 3") and the concatenated
+        // digit-suffix form (":m3", ":t3", ":co3") that Vim supports.
+        if let Some(dest) = split_cmd_and_arg(cmd, "move").or_else(|| split_cmd_and_arg(cmd, "m")) {
+            return self.execute_move_command(dest);
         }
-
-        // :t {dest} / :co[py] {dest} — copy current line to after dest
-        if let Some(dest) = cmd.strip_prefix("copy ").or_else(|| cmd.strip_prefix("t ")) {
-            return self.execute_copy_command(dest.trim());
+        if let Some(dest) = split_cmd_and_arg(cmd, "copy")
+            .or_else(|| split_cmd_and_arg(cmd, "co"))
+            .or_else(|| split_cmd_and_arg(cmd, "t"))
+        {
+            return self.execute_copy_command(dest);
         }
 
         // Handle range filter: N,M!cmd — pipe lines through external command
@@ -2616,6 +2632,134 @@ impl Engine {
         EngineAction::None
     }
 
+    /// :[start,end]m {dest} — move a range of lines to after line {dest}.
+    /// Lines are 0-indexed inclusive. `dest` is an address string.
+    pub(crate) fn execute_move_range(
+        &mut self,
+        src_start: usize,
+        src_end: usize,
+        dest: &str,
+    ) -> EngineAction {
+        let num_lines = self.buffer().len_lines();
+        if src_start > src_end {
+            self.message = "Invalid range".to_string();
+            return EngineAction::Error;
+        }
+        let current = self.view().cursor.line;
+        let dest_line = self.parse_line_address(dest, current, num_lines);
+        // Dest inside source range is a no-op (Vim disallows it; we silently skip).
+        if dest_line >= src_start && dest_line <= src_end {
+            return EngineAction::None;
+        }
+        let line_count = src_end - src_start + 1;
+
+        let block_start = self.buffer().line_to_char(src_start);
+        let block_end = if src_end + 1 < num_lines {
+            self.buffer().line_to_char(src_end + 1)
+        } else {
+            self.buffer().len_chars()
+        };
+        let block_text: String = self
+            .buffer()
+            .content
+            .slice(block_start..block_end)
+            .chars()
+            .collect();
+        let block_text = if block_text.ends_with('\n') {
+            block_text
+        } else {
+            format!("{}\n", block_text)
+        };
+
+        self.start_undo_group();
+        // Delete source first, then compute adjusted dest in the post-deletion buffer.
+        self.delete_with_undo(block_start, block_end);
+        let post_num_lines = self.buffer().len_lines();
+        let dest_is_zero = dest.trim() == "0";
+        let adjusted_dest = if dest_line > src_end {
+            dest_line - line_count
+        } else {
+            dest_line
+        };
+        let insert_pos = if dest_is_zero {
+            0
+        } else if adjusted_dest + 1 >= post_num_lines {
+            self.buffer().len_chars()
+        } else {
+            self.buffer().line_to_char(adjusted_dest + 1)
+        };
+        self.insert_with_undo(insert_pos, &block_text);
+        self.finish_undo_group();
+
+        let new_cursor_line = if dest_is_zero {
+            line_count - 1
+        } else {
+            adjusted_dest + line_count
+        };
+        let max_line = self.buffer().len_lines().saturating_sub(1);
+        self.view_mut().cursor.line = new_cursor_line.min(max_line);
+        self.view_mut().cursor.col = 0;
+        EngineAction::None
+    }
+
+    /// :[start,end]co {dest} / :t {dest} — copy a range of lines to after line {dest}.
+    pub(crate) fn execute_copy_range(
+        &mut self,
+        src_start: usize,
+        src_end: usize,
+        dest: &str,
+    ) -> EngineAction {
+        let num_lines = self.buffer().len_lines();
+        if src_start > src_end {
+            self.message = "Invalid range".to_string();
+            return EngineAction::Error;
+        }
+        let current = self.view().cursor.line;
+        let dest_line = self.parse_line_address(dest, current, num_lines);
+        let line_count = src_end - src_start + 1;
+
+        let block_start = self.buffer().line_to_char(src_start);
+        let block_end = if src_end + 1 < num_lines {
+            self.buffer().line_to_char(src_end + 1)
+        } else {
+            self.buffer().len_chars()
+        };
+        let block_text: String = self
+            .buffer()
+            .content
+            .slice(block_start..block_end)
+            .chars()
+            .collect();
+        let block_text = if block_text.ends_with('\n') {
+            block_text
+        } else {
+            format!("{}\n", block_text)
+        };
+
+        let dest_is_zero = dest.trim() == "0";
+        let insert_pos = if dest_is_zero {
+            0
+        } else if dest_line + 1 >= num_lines {
+            self.buffer().len_chars()
+        } else {
+            self.buffer().line_to_char(dest_line + 1)
+        };
+
+        self.start_undo_group();
+        self.insert_with_undo(insert_pos, &block_text);
+        self.finish_undo_group();
+
+        let new_cursor_line = if dest_is_zero {
+            line_count - 1
+        } else {
+            dest_line + line_count
+        };
+        let max_line = self.buffer().len_lines().saturating_sub(1);
+        self.view_mut().cursor.line = new_cursor_line.min(max_line);
+        self.view_mut().cursor.col = 0;
+        EngineAction::None
+    }
+
     /// :t {dest} / :co[py] {dest} — copy current line to after line {dest}.
     pub(crate) fn execute_copy_command(&mut self, dest: &str) -> EngineAction {
         let current_line = self.view().cursor.line;
@@ -3196,7 +3340,59 @@ impl Engine {
                 self.clamp_cursor_col();
                 Some(EngineAction::None)
             }
-            _ => None, // Unknown ranged command — fall through
+            _ => {
+                // Try :[range]m[ove]{dest} / :[range]co[py]{dest} / :[range]t{dest}.
+                // After range parse, `rest` looks like "m3", "move 3", "co3", "copy 3", "t3".
+                let move_dest =
+                    split_cmd_and_arg(rest, "move").or_else(|| split_cmd_and_arg(rest, "m"));
+                let copy_dest = split_cmd_and_arg(rest, "copy")
+                    .or_else(|| split_cmd_and_arg(rest, "co"))
+                    .or_else(|| split_cmd_and_arg(rest, "t"));
+                if move_dest.is_none() && copy_dest.is_none() {
+                    // Unknown ranged command — fall through to other dispatchers.
+                    return None;
+                }
+                if start == 0 || end == 0 || start > end {
+                    self.message = "Invalid range".to_string();
+                    return Some(EngineAction::None);
+                }
+                let src_start = start - 1;
+                let src_end = (end - 1).min(self.buffer().len_lines().saturating_sub(1));
+                if let Some(dest) = move_dest {
+                    return Some(self.execute_move_range(src_start, src_end, dest));
+                }
+                if let Some(dest) = copy_dest {
+                    return Some(self.execute_copy_range(src_start, src_end, dest));
+                }
+                None
+            }
         }
+    }
+}
+
+/// Matches `rest` against command name `name` followed by a valid argument
+/// separator (space, digit, `+`, `-`, `.`, `$`). Returns the trimmed argument
+/// if matched, else None.
+///
+/// Examples:
+/// - split_cmd_and_arg("t3", "t") → Some("3")
+/// - split_cmd_and_arg("move 5", "move") → Some("5")
+/// - split_cmd_and_arg("term", "t") → None (char 'e' is not a valid separator)
+fn split_cmd_and_arg<'a>(rest: &'a str, name: &str) -> Option<&'a str> {
+    let rest = rest.strip_prefix(name)?;
+    if rest.is_empty() {
+        return None;
+    }
+    let first = rest.chars().next()?;
+    if first == ' '
+        || first.is_ascii_digit()
+        || first == '+'
+        || first == '-'
+        || first == '.'
+        || first == '$'
+    {
+        Some(rest.trim())
+    } else {
+        None
     }
 }

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -25369,3 +25369,141 @@ fn test_nvim_pwd_sets_message() {
         ":pwd should populate the message"
     );
 }
+
+// ── Phase 4 Batch 15.5: #112 ex-command form fixes ────────────────────────
+// Ranged :copy/:move, concatenated :tN/:mN/:coN, and :sort! bang.
+
+// -- Ranged :copy (:N,Mco<dest>) --
+
+#[test]
+fn test_nvim_copy_range_to_after() {
+    // :1,2co3 — range is 1-based (lines 1-2 = indices 0-1), dest "3" is
+    // VimCode-0-based (line 3 = "d"). So we insert "a\nb\n" after "d".
+    // NOTE: Vim uses 1-based dest everywhere; VimCode's parse_line_address
+    // treats numeric dest as 0-based. Tracked as a separate deviation.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":1,2co3<CR>");
+    assert_eq!(engine.buffer().to_string(), "a\nb\nc\nd\na\nb\n");
+}
+
+#[test]
+fn test_nvim_copy_single_line_to_after() {
+    // :2co4 copies line 2 to after line 4
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":2co4<CR>");
+    assert_eq!(engine.buffer().to_string(), "a\nb\nc\nd\nb\n");
+}
+
+// -- Ranged :move --
+
+#[test]
+fn test_nvim_move_single_line_forward() {
+    // :1m3 — range "1" = 1-based line 1 = index 0 ("a"), dest "3" = 0-based
+    // line 3 ("d"). Move "a\n" from top to after "d".
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":1m3<CR>");
+    assert_eq!(engine.buffer().to_string(), "b\nc\nd\na\n");
+}
+
+#[test]
+fn test_nvim_move_line_to_top() {
+    // :3m0 moves line 3 to the top
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":3m0<CR>");
+    assert_eq!(engine.buffer().to_string(), "c\na\nb\nd\n");
+}
+
+#[test]
+fn test_nvim_move_range_forward() {
+    // :1,2m4 moves lines 1-2 to after line 4
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":1,2m4<CR>");
+    assert_eq!(engine.buffer().to_string(), "c\nd\na\nb\n");
+}
+
+// -- Concatenated forms (no space): :tN, :mN, :coN --
+
+#[test]
+fn test_nvim_t_concat_form() {
+    // :t3 copies current line to after line 3 (current = line 0 = "a")
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":t3<CR>");
+    assert_eq!(engine.buffer().to_string(), "a\nb\nc\nd\na\n");
+}
+
+#[test]
+fn test_nvim_m_concat_form() {
+    // :m3 moves current line (0 = "a") to after line 3 → b\nc\nd\na\n
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":m3<CR>");
+    assert_eq!(engine.buffer().to_string(), "b\nc\nd\na\n");
+}
+
+#[test]
+fn test_nvim_co_concat_form() {
+    // :co2 copies current line to after line 2
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\n");
+    engine.update_syntax();
+    engine.feed_keys(":co2<CR>");
+    assert_eq!(engine.buffer().to_string(), "a\nb\nc\na\n");
+}
+
+// -- :sort! bang for reverse --
+
+#[test]
+fn test_nvim_sort_bang_reverses() {
+    // :sort! reverses alphabetical order (synonym for :sort r)
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "alpha\nbravo\ncharlie\n");
+    engine.update_syntax();
+    engine.feed_keys(":sort!<CR>");
+    assert_eq!(engine.buffer().to_string(), "charlie\nbravo\nalpha\n");
+}
+
+#[test]
+fn test_nvim_sort_bang_with_flags() {
+    // :sort! u combines reverse with unique
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\na\nc\nb\n");
+    engine.update_syntax();
+    engine.feed_keys(":sort! u<CR>");
+    assert_eq!(engine.buffer().to_string(), "c\nb\na\n");
+}
+
+// -- Regressions: make sure existing forms still work --
+
+#[test]
+fn test_nvim_colon_zero_still_goes_to_first() {
+    // :0 must still move cursor to line 0 (not be rejected as invalid range)
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\n");
+    engine.update_syntax();
+    engine.view_mut().cursor.line = 2;
+    engine.feed_keys(":0<CR>");
+    assert_eq!(engine.view().cursor.line, 0);
+}
+
+#[test]
+fn test_nvim_sort_with_existing_r_flag_still_works() {
+    // :sort r (old form) should keep working unchanged.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "alpha\nbravo\ncharlie\n");
+    engine.update_syntax();
+    engine.feed_keys(":sort r<CR>");
+    assert_eq!(engine.buffer().to_string(), "charlie\nbravo\nalpha\n");
+}


### PR DESCRIPTION
## Summary
Three ex-command forms that Vim supports but VimCode didn't:

### 1. Ranged \`:copy\` / \`:move\`
- \`:1,2co3\` copies lines 1–2 to after line 3
- \`:3m0\` moves line 3 to the top
- Added new \`execute_copy_range()\` / \`execute_move_range()\` helpers with explicit source-line range support
- Hooked into \`try_execute_ranged_command()\` which already parses \`N\` / \`N,M\` prefixes

### 2. Concatenated forms \`:tN\` / \`:mN\` / \`:coN\`
- \`:t3\`, \`:m3\`, \`:co3\` — no space between command and destination
- New \`split_cmd_and_arg()\` helper matches a command keyword followed by a valid separator (digit, space, sign, \`.\`, \`\$\`)
- Keeps \`:term\`, \`:messages\` etc. routing unchanged (e.g. \`:t\` followed by \`e\` is not parsed as copy)

### 3. \`:sort!\` bang
- Synonym for the existing \`r\` reverse flag
- \`:sort!\` reverses; \`:sort! u\` combines with unique; \`:sort r\` still works

## New deviation surfaced: #114
While implementing, I noticed VimCode's \`parse_line_address()\` treats numeric addresses as 0-based but Vim uses 1-based throughout. This is a pre-existing VimCode-wide deviation. Filed as **#114** and deliberately left out of this PR to keep scope focused. My new ranged code follows VimCode's 0-based convention for dest (consistent with the rest of the codebase) — the tests here encode that behaviour and would flip by one line if #114 is fixed.

## Test plan
- [x] 12 new tests cover all new forms + regressions
- [x] \`:0\` still goes to line 0 (caught a mid-implementation regression)
- [x] \`:sort r\` (old flag form) still works
- [x] Full suite: **1881 passed, 0 failed, 9 ignored** (up from 1869/9)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt\` applied

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)