### PR TITLE
fix: ex-command numeric line addresses are now 1-based (#114)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 17, 2026 (Session 293 — Fix #116 visual block $ virtual-end append) | **Tests:** 1900 (lib) + 410 (nvim conformance)
+**Last updated:** Apr 17, 2026 (Session 294 — Fix #114 1-based ex-command addresses) | **Tests:** 1904 (lib) + 414 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -25,6 +25,12 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 294 — Fix #114: ex-command numeric line addresses are now 1-based:**
+
+1. **Fix #114 — `parse_line_address` now 1-based for bare numbers** — Matches Vim's convention throughout. `":3"` → index 2, `":0"` → index 0 (used by copy/move as "before line 1"). Relative addresses (`+N`, `-N`, `.`, `$`) unchanged — they were already correct.
+2. **Added `dest_is_zero` special case** to `execute_copy_command` (the single-line form) so `:copy 0` inserts at top, matching the existing range-version behaviour.
+3. **6 existing tests updated** to encode 1-based semantics (`:1,2co3`, `:1m3`, `:t3`, `:m3`, `:co2`, `:copy 2`); 4 new tests added covering 1-based specifically and the `:N m 0` / `:copy 0` special case.
 
 **Session 293 — Fix #116 visual block virtual-end append:**
 

--- a/src/core/engine/execute.rs
+++ b/src/core/engine/execute.rs
@@ -2785,8 +2785,12 @@ impl Engine {
             format!("{}\n", line_text)
         };
 
-        // Insert copy after dest_line (after the line at dest_line index)
-        let insert_pos = if dest_line >= num_lines {
+        // Insert copy after dest_line. The special address "0" means "insert
+        // before line 1" — at char 0 — and is NOT a normal "after line N" op.
+        let dest_is_zero = dest.trim() == "0";
+        let insert_pos = if dest_is_zero {
+            0
+        } else if dest_line >= num_lines {
             self.buffer().len_chars()
         } else {
             let after = dest_line.min(num_lines - 1);
@@ -2801,7 +2805,9 @@ impl Engine {
         self.insert_with_undo(insert_pos, &line_text);
         self.finish_undo_group();
 
-        let new_line = if dest_line < current_line {
+        let new_line = if dest_is_zero {
+            0
+        } else if dest_line < current_line {
             current_line + 1
         } else {
             dest_line + 1
@@ -2813,7 +2819,15 @@ impl Engine {
     }
 
     /// Parse a line address string to a 0-based line index.
-    /// Supports: "0", "1"-"N" (1-based absolute), ".", "$", "+N", "-N".
+    ///
+    /// Bare numeric addresses are **1-based** (matches Vim's convention): `"1"`
+    /// → index 0, `"3"` → index 2. The special address `"0"` means "before line 1"
+    /// — callers that use the result as an insert point should treat 0 as "insert
+    /// at the very top". For callers that use the result as a cursor line,
+    /// clamping to 0 is already safe.
+    ///
+    /// Supports: `"0"` (before first line), `"1"`-`"N"` (1-based absolute),
+    /// `"."` (current), `"$"` (last), `"+N"`/`"-N"` (relative to current).
     pub(crate) fn parse_line_address(&self, addr: &str, current: usize, total: usize) -> usize {
         let addr = addr.trim();
         if addr == "." {
@@ -2831,8 +2845,12 @@ impl Engine {
             return current.saturating_sub(n);
         }
         if let Ok(n) = addr.parse::<usize>() {
-            // 0-based absolute line index
-            return n.min(total.saturating_sub(1));
+            // 1-based absolute line index. "0" maps to index 0 and is treated
+            // specially by copy/move callers as "before line 1".
+            if n == 0 {
+                return 0;
+            }
+            return (n - 1).min(total.saturating_sub(1));
         }
         current
     }

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -25091,13 +25091,12 @@ fn test_nvim_range_delete_two_lines() {
 
 #[test]
 fn test_nvim_copy_current_to_after() {
-    // :copy 2 copies current line to after line 2
+    // :copy 2 copies current line (line 1 = "a") to after line 2 ("b").
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a\nb\nc\n");
     engine.update_syntax();
     engine.feed_keys(":copy 2<CR>");
-    // "a" copied after line 2 ("c") → "a\nb\nc\na\n"
-    assert_eq!(engine.buffer().to_string(), "a\nb\nc\na\n");
+    assert_eq!(engine.buffer().to_string(), "a\nb\na\nc\n");
 }
 
 // -- :move (simple form with space) --
@@ -25377,15 +25376,12 @@ fn test_nvim_pwd_sets_message() {
 
 #[test]
 fn test_nvim_copy_range_to_after() {
-    // :1,2co3 — range is 1-based (lines 1-2 = indices 0-1), dest "3" is
-    // VimCode-0-based (line 3 = "d"). So we insert "a\nb\n" after "d".
-    // NOTE: Vim uses 1-based dest everywhere; VimCode's parse_line_address
-    // treats numeric dest as 0-based. Tracked as a separate deviation.
+    // :1,2co3 copies lines 1-2 ("a", "b") to after line 3 ("c").
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
     engine.update_syntax();
     engine.feed_keys(":1,2co3<CR>");
-    assert_eq!(engine.buffer().to_string(), "a\nb\nc\nd\na\nb\n");
+    assert_eq!(engine.buffer().to_string(), "a\nb\nc\na\nb\nd\n");
 }
 
 #[test]
@@ -25402,13 +25398,12 @@ fn test_nvim_copy_single_line_to_after() {
 
 #[test]
 fn test_nvim_move_single_line_forward() {
-    // :1m3 — range "1" = 1-based line 1 = index 0 ("a"), dest "3" = 0-based
-    // line 3 ("d"). Move "a\n" from top to after "d".
+    // :1m3 moves line 1 ("a") to after line 3 ("c").
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
     engine.update_syntax();
     engine.feed_keys(":1m3<CR>");
-    assert_eq!(engine.buffer().to_string(), "b\nc\nd\na\n");
+    assert_eq!(engine.buffer().to_string(), "b\nc\na\nd\n");
 }
 
 #[test]
@@ -25435,32 +25430,32 @@ fn test_nvim_move_range_forward() {
 
 #[test]
 fn test_nvim_t_concat_form() {
-    // :t3 copies current line to after line 3 (current = line 0 = "a")
+    // :t3 copies current line (line 1 = "a") to after line 3 ("c").
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
     engine.update_syntax();
     engine.feed_keys(":t3<CR>");
-    assert_eq!(engine.buffer().to_string(), "a\nb\nc\nd\na\n");
+    assert_eq!(engine.buffer().to_string(), "a\nb\nc\na\nd\n");
 }
 
 #[test]
 fn test_nvim_m_concat_form() {
-    // :m3 moves current line (0 = "a") to after line 3 → b\nc\nd\na\n
+    // :m3 moves current line ("a") to after line 3 ("c").
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
     engine.update_syntax();
     engine.feed_keys(":m3<CR>");
-    assert_eq!(engine.buffer().to_string(), "b\nc\nd\na\n");
+    assert_eq!(engine.buffer().to_string(), "b\nc\na\nd\n");
 }
 
 #[test]
 fn test_nvim_co_concat_form() {
-    // :co2 copies current line to after line 2
+    // :co2 copies current line ("a") to after line 2 ("b").
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "a\nb\nc\n");
     engine.update_syntax();
     engine.feed_keys(":co2<CR>");
-    assert_eq!(engine.buffer().to_string(), "a\nb\nc\na\n");
+    assert_eq!(engine.buffer().to_string(), "a\nb\na\nc\n");
 }
 
 // -- :sort! bang for reverse --
@@ -25506,6 +25501,52 @@ fn test_nvim_sort_with_existing_r_flag_still_works() {
     engine.update_syntax();
     engine.feed_keys(":sort r<CR>");
     assert_eq!(engine.buffer().to_string(), "charlie\nbravo\nalpha\n");
+}
+
+// ── #114 follow-up: 1-based line addresses ─────────────────────────────
+
+#[test]
+fn test_nvim_copy_address_is_1_based() {
+    // :copy 1 copies current line to after line 1 (= "a", the first line).
+    // Under VimCode's old 0-based parse_line_address, this would have put
+    // the copy after "b" instead.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\n");
+    engine.update_syntax();
+    engine.view_mut().cursor.line = 2; // yanking "c"
+    engine.feed_keys(":copy 1<CR>");
+    assert_eq!(engine.buffer().to_string(), "a\nc\nb\nc\n");
+}
+
+#[test]
+fn test_nvim_move_address_is_1_based() {
+    // :3m1 moves line 3 ("c") to after line 1 ("a").
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":3m1<CR>");
+    assert_eq!(engine.buffer().to_string(), "a\nc\nb\nd\n");
+}
+
+#[test]
+fn test_nvim_copy_to_0_inserts_before_first_line() {
+    // :copy 0 (or :co0) inserts the copy at the very top (before line 1).
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\n");
+    engine.update_syntax();
+    engine.view_mut().cursor.line = 2; // yank "c"
+    engine.feed_keys(":copy 0<CR>");
+    assert_eq!(engine.buffer().to_string(), "c\na\nb\nc\n");
+}
+
+#[test]
+fn test_nvim_move_to_0_moves_to_top() {
+    // :3m0 moves line 3 ("c") to the very top.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "a\nb\nc\nd\n");
+    engine.update_syntax();
+    engine.feed_keys(":3m0<CR>");
+    assert_eq!(engine.buffer().to_string(), "c\na\nb\nd\n");
 }
 
 // ── Phase 4 Batch 16: visual block I/A, :retab, :noh, marks, more edges ──


### PR DESCRIPTION
## Summary
Vim uses 1-based line addresses everywhere in ex commands (\`:3\` = the third line). VimCode's \`parse_line_address\` treated bare numbers as 0-based, creating an internal inconsistency: range prefixes (\`:1,2d\`) were already 1-based via \`first_num - 1\`, while destinations (\`:copy 3\`) were 0-based.

## Changes
- **\`parse_line_address\`**: bare \`"N"\` now returns \`(N-1).min(total-1)\`. \`"0"\` stays as a valid address meaning "before line 1" — callers special-case it.
- **\`execute_copy_command\`**: added \`dest_is_zero\` branch so \`:copy 0\` inserts at the very top, matching the already-correct behaviour in \`execute_copy_range\` / \`execute_move_range\`.

## Test updates
**6 existing tests adjusted** to encode Vim's 1-based semantics:
- \`:1,2co3\`, \`:1m3\`, \`:3m0\`, \`:t3\`, \`:m3\`, \`:co2\`, \`:copy 2\`

**4 new tests** prove the 1-based convention and the \`:0\` insert-at-top special case:
- \`:copy 1\` copies current line to after line 1 (= "a")
- \`:3m1\` moves line 3 ("c") to after line 1 ("a")
- \`:copy 0\` inserts copy at the very top
- \`:3m0\` moves line 3 to the very top

## Relative addresses unchanged
\`.\`, \`\$\`, \`+N\`, \`-N\` were already correct and keep working.

## Test plan
- [x] 6 updated tests pass with new 1-based expectations
- [x] 4 new tests pass (1-based + :0 special case)
- [x] Full suite: **1904 passed, 0 failed, 9 ignored** (up from 1900/9)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt\` applied

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)