### PR TITLE
feat: g<Tab> jumps to last-accessed tab

### DIFF
--- a/COVERAGE_PHASE5.md
+++ b/COVERAGE_PHASE5.md
@@ -83,7 +83,7 @@ Total: **58 commands**  ·  ✅ 36  ·  🟡 2  ·  ❌ 14  ·  ⏭️ 6
 | `gF` | ❌ | Edit file + jump to line number ([#120](https://github.com/JDonaghy/vimcode/issues/120)) |
 | `g@` | ❌ | Call `operatorfunc` ([#121](https://github.com/JDonaghy/vimcode/issues/121)) |
 | `g<` | ❌ | Display previous command output |
-| `g<Tab>` | ❌ | Last-accessed tab page ([#122](https://github.com/JDonaghy/vimcode/issues/122)) |
+| `g<Tab>` | ✅ | Last-accessed tab page (fixed in #122) |
 | `gH` | ❌ | Start Select-line mode (Select mode not supported) |
 | `gV` | ❌ | Don't reselect in Select mode (Select mode not supported) |
 | `g]` | ❌ | `:tselect` on tag under cursor |
@@ -101,7 +101,7 @@ Total: **58 commands**  ·  ✅ 36  ·  🟡 2  ·  ❌ 14  ·  ⏭️ 6
 - **`g$` / `g0` / `g^` / `g<End>` / `g<Home>`** — screen-line motions (wrap-aware horizontal) — [#123](https://github.com/JDonaghy/vimcode/issues/123)
 - **`gF`** — edit-file-and-jump-to-line — [#120](https://github.com/JDonaghy/vimcode/issues/120)
 - **`g@`** — user-definable operator (via `operatorfunc`) — [#121](https://github.com/JDonaghy/vimcode/issues/121)
-- **`g<Tab>`** — jump to last-accessed tab — [#122](https://github.com/JDonaghy/vimcode/issues/122)
+- ~~**`g<Tab>`** — jump to last-accessed tab — [#122](https://github.com/JDonaghy/vimcode/issues/122)~~ ✅ implemented
 - **Tag navigation cluster** (`g]`, `g CTRL-]`) — covered by a broader tag-support story (separate issue if we commit to tag support)
 
 **Not worth fixing** (⏭️):

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 17, 2026 (Session 295 — Phase 5 begins, g-prefix audit, 4 gaps filed) | **Tests:** 1904 (lib) + 414 (nvim conformance)
+**Last updated:** Apr 17, 2026 (Session 296 — g<Tab> last-accessed tab, #122) | **Tests:** 1915 (lib) + 414 (nvim conformance)
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The tab context menu offers both: "Split Right/Down" creates a Vim window split 
 
 **Tabs**
 - `:tabnew` — new tab; `:tabclose` — close tab
-- `gt` / `gT` or `g` + `t` / `T` — next/previous tab
+- `gt` / `gT` or `g` + `t` / `T` — next/previous tab; `g<Tab>` — toggle last-accessed tab
 - `Ctrl+Tab` / `Ctrl+Shift+Tab` — MRU tab switcher popup (cycles most-recently-used tabs; Enter confirms, Escape cancels); release modifier to auto-confirm (GTK)
 - `Alt+t` — MRU tab switcher (works in both TUI and GTK; hold Alt and press `t` to cycle; release Alt or wait 500ms to confirm in TUI)
 
@@ -918,6 +918,7 @@ Full editor in the terminal via ratatui + crossterm — feature-parity with the 
 | `q:` | Open command-line history window (Enter executes, `q` closes) |
 | `q/` / `q?` | Open search history window (Enter searches, `q` closes) |
 | `gt` / `gT` | Next / previous tab |
+| `g<Tab>` | Jump to last-accessed tab (toggle) |
 | `Ctrl+Tab` / `Ctrl+Shift+Tab` | MRU tab switcher (forward / backward) |
 | `Alt+t` | MRU tab switcher (TUI + GTK compatible) |
 | `Ctrl+Alt+Left` / `Ctrl+Alt+Right` | Navigate back / forward through tab history |

--- a/VIM_COMPATIBILITY.md
+++ b/VIM_COMPATIBILITY.md
@@ -280,6 +280,7 @@ See [README.md](README.md) for full feature documentation.
 | `gf` | Go to file under cursor | ✅ | |
 | `gF` | Go to file at line | ✅ | |
 | `gt` / `gT` | Next/prev tab | ✅ | |
+| `g<Tab>` | Last-accessed tab | ✅ | Toggle between two most recent tabs |
 | `g~{motion}` | Toggle case | ✅ | |
 | `gu{motion}` | Lowercase | ✅ | |
 | `gU{motion}` | Uppercase | ✅ | |
@@ -304,7 +305,7 @@ See [README.md](README.md) for full feature documentation.
 | `gh` | Editor hover popup (diagnostics, annotations, LSP hover) | ✅ | VimCode-specific (Vim: Select mode) |
 | `gH` / `gV` | Select mode | N/A | No Select mode |
 
-**g-commands: 35/35 (100%)**
+**g-commands: 36/36 (100%)**
 
 ---
 

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -1828,6 +1828,14 @@ impl Engine {
                 Some('T') => {
                     self.prev_tab();
                 }
+                Some('\t') => {
+                    // g<Tab>: jump to last-accessed tab
+                    self.goto_last_accessed_tab();
+                }
+                None if key_name == "Tab" => {
+                    // g<Tab> via feed_keys (unicode is None for special keys)
+                    self.goto_last_accessed_tab();
+                }
                 Some('s') => {
                     return self.cmd_git_stage_hunk();
                 }

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -25803,3 +25803,70 @@ fn test_nvim_set_query_tabstop() {
         engine.message
     );
 }
+
+// --- g<Tab>: jump to last-accessed tab ---
+
+#[test]
+fn test_gtab_jumps_to_last_accessed_tab() {
+    let mut engine = Engine::new();
+    engine.new_tab(None); // tab 1
+    engine.new_tab(None); // tab 2 (active)
+    assert_eq!(engine.active_group().active_tab, 2);
+
+    // Go to tab 0
+    engine.goto_tab(0);
+    assert_eq!(engine.active_group().active_tab, 0);
+
+    // g<Tab> should jump back to tab 2 (last accessed)
+    engine.feed_keys("g<Tab>");
+    assert_eq!(engine.active_group().active_tab, 2);
+}
+
+#[test]
+fn test_gtab_toggles_between_two_tabs() {
+    let mut engine = Engine::new();
+    engine.new_tab(None); // tab 1
+    engine.goto_tab(0);
+    assert_eq!(engine.active_group().active_tab, 0);
+
+    // Switch to tab 1 via gt
+    engine.feed_keys("gt");
+    assert_eq!(engine.active_group().active_tab, 1);
+
+    // g<Tab> should go back to tab 0
+    engine.feed_keys("g<Tab>");
+    assert_eq!(engine.active_group().active_tab, 0);
+
+    // Another g<Tab> should toggle back to tab 1
+    engine.feed_keys("g<Tab>");
+    assert_eq!(engine.active_group().active_tab, 1);
+}
+
+#[test]
+fn test_gtab_noop_with_single_tab() {
+    let mut engine = Engine::new();
+    // Only one tab — g<Tab> should be a no-op
+    engine.feed_keys("g<Tab>");
+    assert_eq!(engine.active_group().active_tab, 0);
+}
+
+#[test]
+fn test_gtab_with_three_tabs() {
+    let mut engine = Engine::new();
+    engine.new_tab(None); // tab 1
+    engine.new_tab(None); // tab 2 (active)
+
+    // Visit tab 0
+    engine.goto_tab(0);
+    // Visit tab 1
+    engine.goto_tab(1);
+    assert_eq!(engine.active_group().active_tab, 1);
+
+    // g<Tab> should go to tab 0 (the last one before tab 1)
+    engine.feed_keys("g<Tab>");
+    assert_eq!(engine.active_group().active_tab, 0);
+
+    // g<Tab> again should go back to tab 1
+    engine.feed_keys("g<Tab>");
+    assert_eq!(engine.active_group().active_tab, 1);
+}

--- a/src/core/engine/windows.rs
+++ b/src/core/engine/windows.rs
@@ -1529,6 +1529,38 @@ impl Engine {
         }
     }
 
+    /// Jump to the last-accessed tab (g<Tab> / :tablast-accessed).
+    /// Uses the MRU list: index 0 is current, index 1 is previous.
+    /// Calling again toggles back (Vim behaviour).
+    pub fn goto_last_accessed_tab(&mut self) {
+        // Prune stale entries
+        self.tab_mru.retain(|&(g, idx)| {
+            self.editor_groups
+                .get(&g)
+                .is_some_and(|grp| idx < grp.tabs.len())
+        });
+        // Ensure current is at index 0
+        let current = (self.active_group, self.active_group().active_tab);
+        if self.tab_mru.first() != Some(&current) {
+            self.tab_mru.retain(|e| *e != current);
+            self.tab_mru.insert(0, current);
+        }
+        if self.tab_mru.len() < 2 {
+            return; // No previous tab to jump to
+        }
+        let (group_id, tab_idx) = self.tab_mru[1];
+        if self.editor_groups.contains_key(&group_id) {
+            self.active_group = group_id;
+            self.active_group_mut().active_tab = tab_idx;
+            self.line_annotations.clear();
+            self.blame_annotations_active = false;
+            self.tab_mru_touch();
+            self.tab_nav_push();
+            self.lsp_ensure_active_buffer();
+            self.ensure_active_tab_visible();
+        }
+    }
+
     /// Open the tab switcher popup, pre-selecting the second MRU entry.
     pub fn open_tab_switcher(&mut self) {
         // Build a clean MRU list: only include entries that still exist


### PR DESCRIPTION
## Summary
- Implements `g<Tab>` (Vim's last-accessed tab toggle) using the existing `tab_mru` list
- New `goto_last_accessed_tab()` method + handler in both unicode and key_name paths
- 4 new tests: basic jump, toggle, single-tab no-op, 3-tab MRU ordering

## Test plan
- [x] `cargo test --no-default-features --lib test_gtab` — 4/4 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Full suite: 1915 passed, 0 failed

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)