### PR TITLE
feat: gF opens file under cursor + jumps to line

### DIFF
--- a/COVERAGE_PHASE5.md
+++ b/COVERAGE_PHASE5.md
@@ -80,7 +80,7 @@ Total: **58 commands**  ·  ✅ 36  ·  🟡 2  ·  ❌ 14  ·  ⏭️ 6
 | `gx` | ✅ | Open URL under cursor (OS handler) |
 | `gs` | ✅ | Sleep N seconds |
 | `gh` | 🟡 | Enters a Select-ish state — *verify separately* |
-| `gF` | ❌ | Edit file + jump to line number ([#120](https://github.com/JDonaghy/vimcode/issues/120)) |
+| `gF` | ✅ | Edit file + jump to line number (fixed in #120) |
 | `g@` | ❌ | Call `operatorfunc` ([#121](https://github.com/JDonaghy/vimcode/issues/121)) |
 | `g<` | ❌ | Display previous command output |
 | `g<Tab>` | ✅ | Last-accessed tab page (fixed in #122) |
@@ -99,7 +99,7 @@ Total: **58 commands**  ·  ✅ 36  ·  🟡 2  ·  ❌ 14  ·  ⏭️ 6
 
 **Headline gaps worth filing as issues:**
 - **`g$` / `g0` / `g^` / `g<End>` / `g<Home>`** — screen-line motions (wrap-aware horizontal) — [#123](https://github.com/JDonaghy/vimcode/issues/123)
-- **`gF`** — edit-file-and-jump-to-line — [#120](https://github.com/JDonaghy/vimcode/issues/120)
+- ~~**`gF`** — edit-file-and-jump-to-line — [#120](https://github.com/JDonaghy/vimcode/issues/120)~~ ✅ implemented
 - **`g@`** — user-definable operator (via `operatorfunc`) — [#121](https://github.com/JDonaghy/vimcode/issues/121)
 - ~~**`g<Tab>`** — jump to last-accessed tab — [#122](https://github.com/JDonaghy/vimcode/issues/122)~~ ✅ implemented
 - **Tag navigation cluster** (`g]`, `g CTRL-]`) — covered by a broader tag-support story (separate issue if we commit to tag support)

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -1809,6 +1809,34 @@ impl Engine {
                         self.message = "No file path under cursor".to_string();
                     }
                 }
+                Some('F') => {
+                    // gF: open file under cursor + jump to line number
+                    if let Some((path, line_num)) = self.file_path_and_line_under_cursor() {
+                        let abs_path = if path.is_absolute() {
+                            path
+                        } else {
+                            self.cwd.join(&path)
+                        };
+                        match self.open_file_with_mode(
+                            &abs_path,
+                            crate::core::engine::OpenMode::Permanent,
+                        ) {
+                            Ok(()) => {
+                                if let Some(n) = line_num {
+                                    let target = n.saturating_sub(1); // 1-based → 0-based
+                                    let max = self.buffer().len_lines().saturating_sub(1);
+                                    self.view_mut().cursor.line = target.min(max);
+                                    let fnb = self.first_non_blank_col(target.min(max));
+                                    self.view_mut().cursor.col = fnb;
+                                    self.scroll_cursor_center();
+                                }
+                            }
+                            Err(e) => self.message = e,
+                        }
+                    } else {
+                        self.message = "No file path under cursor".to_string();
+                    }
+                }
                 Some('t') => {
                     if let Some(n) = self.count {
                         // Ngt → go to tab N (1-based, like Vim)

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -1072,6 +1072,107 @@ impl Engine {
         None
     }
 
+    /// Like `file_path_under_cursor`, but also parses a trailing `:<line>`
+    /// suffix (e.g. `src/main.rs:42`, `foo.txt:10:3`). Returns the resolved
+    /// path and an optional 1-based line number.
+    pub(crate) fn file_path_and_line_under_cursor(
+        &self,
+    ) -> Option<(std::path::PathBuf, Option<usize>)> {
+        let line = self.view().cursor.line;
+        let col = self.view().cursor.col;
+
+        let line_text: String = self.buffer().content.line(line).chars().collect();
+        let chars: Vec<char> = line_text.chars().collect();
+
+        // Path chars: same as file_path_under_cursor but ALLOW ':' so we capture the suffix
+        let is_path_or_colon =
+            |c: char| !c.is_whitespace() && c != '"' && c != '\'' && c != ',' && c != ';';
+
+        let mut start = col;
+        let mut end = col;
+
+        while start > 0 && is_path_or_colon(chars[start - 1]) {
+            start -= 1;
+        }
+        while end < chars.len() && is_path_or_colon(chars[end]) {
+            end += 1;
+        }
+        while end > start && (chars[end - 1] == '\n' || chars[end - 1] == '\r') {
+            end -= 1;
+        }
+        // Strip trailing colon (e.g. "foo.rs:" at end of sentence)
+        while end > start && chars[end - 1] == ':' {
+            end -= 1;
+        }
+
+        if start >= end {
+            return None;
+        }
+
+        let token: String = chars[start..end].iter().collect();
+        if token.is_empty() {
+            return None;
+        }
+
+        // Split off `:line` or `:line:col` suffix — try progressively stripping
+        // colon-delimited numeric suffixes to find a valid file path.
+        let mut path_part = token.as_str();
+        let mut line_num: Option<usize> = None;
+
+        // Try stripping `:col` then `:line` (handles `path:line:col`)
+        for _ in 0..2 {
+            if let Some(colon_pos) = path_part.rfind(':') {
+                let suffix = &path_part[colon_pos + 1..];
+                if let Ok(n) = suffix.parse::<usize>() {
+                    // Remember the first (outermost) number stripped as line, but
+                    // on the second pass it becomes the actual line number.
+                    line_num = Some(n);
+                    path_part = &path_part[..colon_pos];
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if path_part.is_empty() {
+            return None;
+        }
+
+        let path = std::path::PathBuf::from(path_part);
+
+        // Resolve path: workspace root, then current file's dir
+        let resolved = if path.is_absolute() {
+            if path.exists() {
+                Some(path)
+            } else {
+                None
+            }
+        } else {
+            let mut found = None;
+            if let Some(ref root) = self.workspace_root {
+                let abs = root.join(&path);
+                if abs.exists() {
+                    found = Some(abs);
+                }
+            }
+            if found.is_none() {
+                if let Some(file_path) = self.active_buffer_state().file_path.as_ref() {
+                    if let Some(dir) = file_path.parent() {
+                        let abs = dir.join(&path);
+                        if abs.exists() {
+                            found = Some(abs);
+                        }
+                    }
+                }
+            }
+            found
+        };
+
+        resolved.map(|p| (p, line_num))
+    }
+
     // --- g* / g#: partial word search ---
 
     pub(crate) fn search_word_under_cursor_partial(&mut self, forward: bool) {

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -25870,3 +25870,121 @@ fn test_gtab_with_three_tabs() {
     engine.feed_keys("g<Tab>");
     assert_eq!(engine.active_group().active_tab, 1);
 }
+
+// --- gF: open file under cursor + jump to line ---
+
+#[test]
+fn test_gf_open_file_at_line() {
+    use std::io::Write;
+    // Create a temp file with 10 lines
+    let dir = std::env::temp_dir().join("vimcode_test_gf");
+    let _ = std::fs::create_dir_all(&dir);
+    let file = dir.join("target.txt");
+    {
+        let mut f = std::fs::File::create(&file).unwrap();
+        for i in 1..=10 {
+            writeln!(f, "line {i}").unwrap();
+        }
+    }
+
+    let mut engine = Engine::new();
+    engine.cwd = dir.clone();
+    // Buffer contains "target.txt:5"
+    let text = format!("{}:5", file.display());
+    engine.buffer_mut().insert(0, &text);
+    engine.update_syntax();
+
+    // gF should open the file and jump to line 5 (0-based: 4)
+    press_char(&mut engine, 'g');
+    press_char(&mut engine, 'F');
+
+    // Verify we're in the target file at line 4 (0-based)
+    assert_eq!(
+        engine.active_buffer_state().file_path.as_deref(),
+        Some(file.as_path())
+    );
+    assert_eq!(engine.view().cursor.line, 4);
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_gf_open_file_no_line_suffix() {
+    use std::io::Write;
+    let dir = std::env::temp_dir().join("vimcode_test_gf2");
+    let _ = std::fs::create_dir_all(&dir);
+    let file = dir.join("plain.txt");
+    {
+        let mut f = std::fs::File::create(&file).unwrap();
+        writeln!(f, "hello").unwrap();
+    }
+
+    let mut engine = Engine::new();
+    engine.cwd = dir.clone();
+    // Buffer contains just the file path, no :N suffix
+    let text = format!("{}", file.display());
+    engine.buffer_mut().insert(0, &text);
+    engine.update_syntax();
+
+    // gF should still open the file (at line 0, no line suffix)
+    press_char(&mut engine, 'g');
+    press_char(&mut engine, 'F');
+
+    assert_eq!(
+        engine.active_buffer_state().file_path.as_deref(),
+        Some(file.as_path())
+    );
+    assert_eq!(engine.view().cursor.line, 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_gf_open_file_with_line_and_col_suffix() {
+    use std::io::Write;
+    let dir = std::env::temp_dir().join("vimcode_test_gf3");
+    let _ = std::fs::create_dir_all(&dir);
+    let file = dir.join("multi.txt");
+    {
+        let mut f = std::fs::File::create(&file).unwrap();
+        for i in 1..=20 {
+            writeln!(f, "content line {i}").unwrap();
+        }
+    }
+
+    let mut engine = Engine::new();
+    engine.cwd = dir.clone();
+    // Buffer contains "multi.txt:10:3" (line:col format from grep output)
+    let text = format!("{}:10:3", file.display());
+    engine.buffer_mut().insert(0, &text);
+    engine.update_syntax();
+
+    press_char(&mut engine, 'g');
+    press_char(&mut engine, 'F');
+
+    assert_eq!(
+        engine.active_buffer_state().file_path.as_deref(),
+        Some(file.as_path())
+    );
+    // Line 10 → 0-based index 9
+    assert_eq!(engine.view().cursor.line, 9);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_gf_no_file_shows_message() {
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "nonexistent_file_xyz.txt:42");
+    engine.update_syntax();
+
+    press_char(&mut engine, 'g');
+    press_char(&mut engine, 'F');
+
+    assert!(
+        engine.message.contains("No file path"),
+        "expected error message, got: {:?}",
+        engine.message
+    );
+}


### PR DESCRIPTION
## Summary
- Implements `gF` — like `gf` but parses trailing `:line` or `:line:col` suffix and jumps to that line
- New `file_path_and_line_under_cursor()` method extracts path + optional line number
- Supports grep/compiler output formats: `src/main.rs:42`, `foo.txt:10:3`
- 4 new tests covering file+line, file-only, file+line+col, and nonexistent file

## Test plan
- [x] `cargo test --no-default-features --lib test_gf` — 4/4 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Full suite: 1915 passed, 0 failed

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)