### PR TITLE
feat: tab bar hit regions — centralize click geometry

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -1089,6 +1089,41 @@ pub fn compute_find_replace_hit_regions(
     (regions, input_w)
 }
 
+// ── Tab bar hit regions ─────────────────────────────────────────────────────
+
+/// Click target within a group's tab bar.
+/// Backends resolve native coordinates → `TabBarClickTarget`, then call
+/// `Engine::handle_tab_bar_click()` for shared dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TabBarClickTarget {
+    /// Click on a tab (switch to it). Index into the group's tab list.
+    Tab(usize),
+    /// Click on a tab's close button. Index into the group's tab list.
+    CloseTab(usize),
+    /// Split editor right button.
+    SplitRight,
+    /// Split editor down button.
+    SplitDown,
+    /// Action menu button (the "…" overflow menu).
+    ActionMenu,
+    /// Diff toolbar: previous change.
+    DiffPrev,
+    /// Diff toolbar: next change.
+    DiffNext,
+    /// Diff toolbar: toggle inline/side-by-side.
+    DiffToggle,
+}
+
+/// A hit region within a group's tab bar, expressed in character-cell units
+/// relative to the tab bar's left edge.
+#[derive(Debug, Clone)]
+pub struct TabBarHitRegion {
+    /// Column offset from the tab bar left edge.
+    pub col: u16,
+    /// Width of this region in char cells.
+    pub width: u16,
+}
+
 /// Represents a change operation that can be repeated with `.`
 #[derive(Debug, Clone)]
 struct Change {

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -26157,3 +26157,48 @@ end)
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// --- Tab bar hit regions ---
+
+#[test]
+fn test_tab_bar_handle_click_switches_tab() {
+    let mut engine = Engine::new();
+    engine.new_tab(None); // tab 1
+    assert_eq!(engine.active_group().active_tab, 1);
+
+    // Switch to tab 0 via handle_tab_bar_click
+    let group_id = engine.active_group;
+    engine.handle_tab_bar_click(group_id, TabBarClickTarget::Tab(0));
+    assert_eq!(engine.active_group().active_tab, 0);
+}
+
+#[test]
+fn test_tab_bar_handle_click_close_tab() {
+    let mut engine = Engine::new();
+    engine.new_tab(None); // tab 1
+    assert_eq!(engine.active_group().tabs.len(), 2);
+
+    let group_id = engine.active_group;
+    let needs_confirm = engine.handle_tab_bar_click(group_id, TabBarClickTarget::CloseTab(1));
+    assert!(!needs_confirm); // Not dirty
+    assert_eq!(engine.active_group().tabs.len(), 1);
+}
+
+#[test]
+fn test_tab_bar_handle_click_close_dirty_tab_returns_true() {
+    let mut engine = Engine::new();
+    engine.new_tab(None); // tab 1
+                          // Make the buffer dirty
+    engine.buffer_mut().insert(0, "dirty");
+    engine
+        .buffer_manager
+        .get_mut(engine.active_buffer_id())
+        .unwrap()
+        .dirty = true;
+
+    let group_id = engine.active_group;
+    let needs_confirm = engine.handle_tab_bar_click(group_id, TabBarClickTarget::CloseTab(1));
+    assert!(needs_confirm); // Should request confirmation
+                            // Tab should NOT be closed yet
+    assert_eq!(engine.active_group().tabs.len(), 2);
+}

--- a/src/core/engine/windows.rs
+++ b/src/core/engine/windows.rs
@@ -1612,6 +1612,52 @@ impl Engine {
         self.tab_switcher_open = false;
     }
 
+    /// Handle a click on a tab bar hit region.
+    /// `group_id` identifies which group's tab bar was clicked.
+    /// Returns `true` if a close-dirty-tab confirmation is needed.
+    pub fn handle_tab_bar_click(&mut self, group_id: GroupId, target: TabBarClickTarget) -> bool {
+        self.active_group = group_id;
+        match target {
+            TabBarClickTarget::Tab(idx) => {
+                self.goto_tab(idx);
+                self.lsp_ensure_active_buffer();
+            }
+            TabBarClickTarget::CloseTab(idx) => {
+                if let Some(g) = self.editor_groups.get_mut(&group_id) {
+                    g.active_tab = idx;
+                }
+                self.line_annotations.clear();
+                if self.dirty() {
+                    return true; // Caller should show confirmation
+                }
+                self.close_tab();
+            }
+            TabBarClickTarget::SplitRight => {
+                self.open_editor_group(SplitDirection::Vertical);
+            }
+            TabBarClickTarget::SplitDown => {
+                self.open_editor_group(SplitDirection::Horizontal);
+            }
+            TabBarClickTarget::ActionMenu => {
+                // Caller handles this — needs screen coordinates
+            }
+            TabBarClickTarget::DiffPrev => {
+                if self.windows.contains_key(&self.active_window_id()) {
+                    self.jump_prev_hunk();
+                }
+            }
+            TabBarClickTarget::DiffNext => {
+                if self.windows.contains_key(&self.active_window_id()) {
+                    self.jump_next_hunk();
+                }
+            }
+            TabBarClickTarget::DiffToggle => {
+                self.diff_toggle_hide_unchanged();
+            }
+        }
+        false
+    }
+
     /// Get display info for each MRU entry: (filename, path, is_dirty).
     pub fn tab_switcher_items(&self) -> Vec<(String, String, bool)> {
         self.tab_mru

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -422,6 +422,7 @@ impl PluginManager {
     }
 
     /// Check if an operatorfunc has been registered via `vimcode.set_operatorfunc()`.
+    #[allow(dead_code)]
     pub fn has_operatorfunc(&self) -> bool {
         self.lua
             .named_registry_value::<LuaRegistryKey>("__operatorfunc")

--- a/src/render.rs
+++ b/src/render.rs
@@ -422,6 +422,162 @@ pub struct GroupTabBar {
     pub diff_toolbar: Option<DiffToolbarData>,
     /// Index of the first visible tab (scroll offset for overflow tab bars).
     pub tab_scroll_offset: usize,
+    /// Pre-computed click regions for this tab bar, in char-cell units
+    /// relative to the tab bar's left edge (column 0 = left edge of group bounds).
+    pub hit_regions: Vec<(
+        crate::core::engine::TabBarHitRegion,
+        crate::core::engine::TabBarClickTarget,
+    )>,
+}
+
+// ── Tab bar hit region constants (char-cell units) ──────────────────────────
+
+/// Columns used by each tab's close button (the × itself + trailing space).
+pub const TAB_CLOSE_COLS: u16 = 2;
+/// Columns occupied by each split button (1 space + 2-wide glyph).
+const TAB_SPLIT_BTN_COLS: u16 = 3;
+/// Total columns reserved for both split buttons (right + down).
+const TAB_SPLIT_BOTH_COLS: u16 = TAB_SPLIT_BTN_COLS * 2;
+/// Columns for the editor action menu button ("…").
+const TAB_ACTION_BTN_COLS: u16 = 3;
+/// Columns per diff toolbar button (1 space + 1 char + 1 space).
+const DIFF_BTN_COLS: u16 = 3;
+/// Total columns for all three diff toolbar buttons.
+const DIFF_TOOLBAR_BTN_COLS: u16 = DIFF_BTN_COLS * 3;
+
+/// Compute hit regions for a group's tab bar.
+///
+/// Layout (left to right):
+/// `[tab0][tab1]...[tabN]  [diff_toolbar?] [split_btns?] [action_btn]`
+///
+/// All positions are in char-cell columns relative to the tab bar left edge.
+pub fn compute_tab_bar_hit_regions(
+    tabs: &[TabInfo],
+    tab_scroll_offset: usize,
+    bar_width: u16,
+    has_diff_toolbar: bool,
+    diff_label_cols: u16,
+    has_split_buttons: bool,
+) -> Vec<(
+    crate::core::engine::TabBarHitRegion,
+    crate::core::engine::TabBarClickTarget,
+)> {
+    use crate::core::engine::{TabBarClickTarget, TabBarHitRegion};
+
+    let mut regions = Vec::new();
+
+    // ── Right-side buttons (from right edge inward) ─────────────
+
+    // Action menu button at far right
+    let action_start = bar_width.saturating_sub(TAB_ACTION_BTN_COLS);
+    regions.push((
+        TabBarHitRegion {
+            col: action_start,
+            width: TAB_ACTION_BTN_COLS,
+        },
+        TabBarClickTarget::ActionMenu,
+    ));
+
+    // Split buttons (left of action menu)
+    let split_cols = if has_split_buttons {
+        TAB_SPLIT_BOTH_COLS
+    } else {
+        0
+    };
+    let split_end = action_start;
+    let split_start = split_end.saturating_sub(split_cols);
+    if has_split_buttons {
+        regions.push((
+            TabBarHitRegion {
+                col: split_start,
+                width: TAB_SPLIT_BTN_COLS,
+            },
+            TabBarClickTarget::SplitRight,
+        ));
+        regions.push((
+            TabBarHitRegion {
+                col: split_start + TAB_SPLIT_BTN_COLS,
+                width: TAB_SPLIT_BTN_COLS,
+            },
+            TabBarClickTarget::SplitDown,
+        ));
+    }
+
+    // Diff toolbar (left of split buttons)
+    if has_diff_toolbar {
+        let diff_total = DIFF_TOOLBAR_BTN_COLS + diff_label_cols;
+        let diff_end = split_start;
+        let diff_start = diff_end.saturating_sub(diff_total);
+        let btn_start = diff_start + diff_label_cols;
+        regions.push((
+            TabBarHitRegion {
+                col: btn_start,
+                width: DIFF_BTN_COLS,
+            },
+            TabBarClickTarget::DiffPrev,
+        ));
+        regions.push((
+            TabBarHitRegion {
+                col: btn_start + DIFF_BTN_COLS,
+                width: DIFF_BTN_COLS,
+            },
+            TabBarClickTarget::DiffNext,
+        ));
+        regions.push((
+            TabBarHitRegion {
+                col: btn_start + DIFF_BTN_COLS * 2,
+                width: DIFF_BTN_COLS,
+            },
+            TabBarClickTarget::DiffToggle,
+        ));
+    }
+
+    // ── Tab slots (from left edge) ─────────────────────────────
+
+    let mut x: u16 = 0;
+    for (i, tab) in tabs.iter().enumerate().skip(tab_scroll_offset) {
+        let name_width = tab.name.chars().count() as u16;
+        let tab_width = name_width + TAB_CLOSE_COLS;
+        if x + tab_width > bar_width {
+            break; // Overflow — remaining tabs are hidden
+        }
+        // Tab body (click to switch)
+        regions.push((
+            TabBarHitRegion {
+                col: x,
+                width: name_width,
+            },
+            TabBarClickTarget::Tab(i),
+        ));
+        // Close button
+        regions.push((
+            TabBarHitRegion {
+                col: x + name_width,
+                width: TAB_CLOSE_COLS,
+            },
+            TabBarClickTarget::CloseTab(i),
+        ));
+        x += tab_width;
+    }
+
+    regions
+}
+
+/// Resolve a column position (in char cells, relative to the tab bar left edge)
+/// to a `TabBarClickTarget` by walking the hit region list.
+pub fn resolve_tab_bar_click(
+    hit_regions: &[(
+        crate::core::engine::TabBarHitRegion,
+        crate::core::engine::TabBarClickTarget,
+    )],
+    col: u16,
+) -> Option<crate::core::engine::TabBarClickTarget> {
+    for (region, target) in hit_regions {
+        if col >= region.col && col < region.col + region.width {
+            return Some(*target);
+        }
+    }
+    None
 }
 
 /// One segment in the breadcrumb bar (either a path component or a symbol).
@@ -4775,12 +4931,30 @@ pub fn build_screen_layout(
                     .get(&gid)
                     .map(|g| g.tab_scroll_offset)
                     .unwrap_or(0);
+                let bar_width = bounds.width as u16;
+                let has_diff_toolbar = diff_toolbar.is_some();
+                let diff_label_cols = diff_toolbar
+                    .as_ref()
+                    .and_then(|dt| dt.change_label.as_ref())
+                    .map(|l| l.len() as u16 + 1)
+                    .unwrap_or(0);
+                let is_active = gid == engine.active_group;
+                let has_split = is_active || engine.is_in_diff_view();
+                let hit_regions = compute_tab_bar_hit_regions(
+                    &tabs,
+                    tab_scroll_offset,
+                    bar_width,
+                    has_diff_toolbar,
+                    diff_label_cols,
+                    has_split,
+                );
                 GroupTabBar {
                     group_id: gid,
                     tabs,
                     bounds,
                     diff_toolbar,
                     tab_scroll_offset,
+                    hit_regions,
                 }
             })
             .collect();

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2476,115 +2476,47 @@ pub(super) fn handle_mouse(
             if let Some((
                 group_id,
                 local_col,
-                bar_width,
-                group_tabs,
-                diff_toolbar_ref,
-                was_active,
-                scroll_offset,
+                _bar_width,
+                _group_tabs,
+                _diff_toolbar_ref,
+                _was_active,
+                _scroll_offset,
             )) = matched_group
             {
-                engine.active_group = group_id;
-
-                let mut x: u16 = 0;
-                let mut tab_matched = false;
-                // Collect tab hit info from immutable borrow, then apply mutably.
-                let mut hit_info: Option<(usize, bool)> = None;
-                for (i, tab) in group_tabs.iter().enumerate().skip(scroll_offset) {
-                    let name_width = tab.name.chars().count() as u16;
-                    let tab_width = name_width + TAB_CLOSE_COLS;
-                    if local_col >= x && local_col < x + tab_width {
-                        tab_matched = true;
-                        let valid = engine
-                            .editor_groups
-                            .get(&group_id)
-                            .is_some_and(|g| i < g.tabs.len());
-                        if valid {
-                            let is_close = local_col >= x + name_width;
-                            hit_info = Some((i, is_close));
-                        }
-                        break;
-                    }
-                    x += tab_width;
-                }
-                if let Some((tab_idx, is_close)) = hit_info {
-                    engine.active_group = group_id;
-                    if is_close {
-                        if let Some(g) = engine.editor_groups.get_mut(&group_id) {
-                            g.active_tab = tab_idx;
-                        }
-                        engine.line_annotations.clear();
-                        if engine.dirty() {
-                            *close_tab_confirm = true;
-                        } else {
-                            engine.close_tab();
-                        }
-                    } else {
-                        engine.goto_tab(tab_idx);
-                        // Record drag start position for tab drag-and-drop.
-                        *tab_drag_start = Some((col, row));
-                        engine.lsp_ensure_active_buffer();
-                        if let Some(path) = engine.file_path().cloned() {
-                            sidebar.reveal_path(&path, term_height.saturating_sub(4) as usize);
-                        }
-                    }
-                }
-                if !tab_matched {
-                    // Calculate diff toolbar zone (label + 3 buttons).
-                    let diff_total_cols = if let Some(dt) = diff_toolbar_ref {
-                        let label_cols = dt
-                            .change_label
-                            .as_ref()
-                            .map(|l| l.len() as u16 + 1)
-                            .unwrap_or(0);
-                        DIFF_TOOLBAR_BTN_COLS + label_cols
-                    } else {
-                        0
-                    };
-                    // Split buttons exist on active group, or all groups in diff mode.
-                    let had_split = was_active || engine.is_in_diff_view();
-                    let split_cols = if had_split { TAB_SPLIT_BOTH_COLS } else { 0 };
-                    let split_end = bar_width.saturating_sub(TAB_ACTION_BTN_COLS);
-                    let split_start = split_end.saturating_sub(split_cols);
-                    let diff_end = split_start;
-                    let diff_start = diff_end.saturating_sub(diff_total_cols);
-                    // Hit-test diff toolbar buttons FIRST (they sit left of
-                    // split buttons, so check them before split to avoid
-                    // boundary overlap).
-                    if diff_total_cols > 0 && local_col >= diff_start && local_col < diff_end {
-                        // Hit-test diff toolbar buttons (prev, next, fold).
-                        // Layout: [label][prev][next][fold].
-                        let in_diff = local_col - diff_start;
-                        let label_cols = diff_total_cols - DIFF_TOOLBAR_BTN_COLS;
-                        let in_btns = in_diff.saturating_sub(label_cols);
-                        let has_win = engine.windows.contains_key(&engine.active_window_id());
-                        if in_diff < label_cols {
-                            // Clicked on the label — no-op.
-                        } else if in_btns < DIFF_BTN_COLS {
-                            if has_win {
-                                engine.jump_prev_hunk();
+                // Use pre-computed hit regions from the GroupTabBar.
+                let hit_target = split
+                    .group_tab_bars
+                    .iter()
+                    .find(|gtb| gtb.group_id == group_id)
+                    .and_then(|gtb| {
+                        crate::render::resolve_tab_bar_click(&gtb.hit_regions, local_col)
+                    });
+                if let Some(target) = hit_target {
+                    use crate::core::engine::TabBarClickTarget;
+                    match target {
+                        TabBarClickTarget::Tab(_) => {
+                            let needs_confirm = engine.handle_tab_bar_click(group_id, target);
+                            if needs_confirm {
+                                *close_tab_confirm = true;
                             }
-                        } else if in_btns < DIFF_BTN_COLS * 2 {
-                            if has_win {
-                                engine.jump_next_hunk();
+                            *tab_drag_start = Some((col, row));
+                            if let Some(path) = engine.file_path().cloned() {
+                                sidebar.reveal_path(&path, term_height.saturating_sub(4) as usize);
                             }
-                        } else {
-                            engine.diff_toggle_hide_unchanged();
                         }
-                    } else if had_split
-                        && local_col >= split_start
-                        && local_col < split_start + TAB_SPLIT_BOTH_COLS
-                        && bar_width >= TAB_SPLIT_BOTH_COLS
-                    {
-                        // Hit-test split buttons.
-                        let in_split = local_col - split_start;
-                        if in_split >= TAB_SPLIT_BTN_COLS {
-                            engine.open_editor_group(SplitDirection::Horizontal);
-                        } else {
-                            engine.open_editor_group(SplitDirection::Vertical);
+                        TabBarClickTarget::CloseTab(_) => {
+                            let needs_confirm = engine.handle_tab_bar_click(group_id, target);
+                            if needs_confirm {
+                                *close_tab_confirm = true;
+                            }
                         }
-                    } else if local_col >= bar_width.saturating_sub(TAB_ACTION_BTN_COLS) {
-                        // Editor action menu button ("…") at far right.
-                        engine.open_editor_action_menu(group_id, col, row + 1);
+                        TabBarClickTarget::ActionMenu => {
+                            engine.active_group = group_id;
+                            engine.open_editor_action_menu(group_id, col, row + 1);
+                        }
+                        _ => {
+                            engine.handle_tab_bar_click(group_id, target);
+                        }
                     }
                 }
                 return sidebar_width;


### PR DESCRIPTION
## Summary
- Centralizes tab bar click detection into pre-computed hit regions on `GroupTabBar`, following the established `FrHitRegion` pattern
- New types: `TabBarClickTarget` enum, `TabBarHitRegion` struct
- New functions: `compute_tab_bar_hit_regions()`, `resolve_tab_bar_click()`
- New engine method: `handle_tab_bar_click()` — shared dispatch for all backends
- **TUI migrated**: replaced ~100 lines of local geometry with hit region lookup
- GTK migration deferred (requires pixel→char conversion changes in a separate pass)

## Architecture
```
render.rs: compute_tab_bar_hit_regions() → GroupTabBar.hit_regions
                                              ↓
backend (TUI/GTK):  resolve_tab_bar_click(regions, col) → TabBarClickTarget
                                              ↓
engine:  handle_tab_bar_click(group_id, target) → shared dispatch
```

## Test plan
- [x] 3 new tests: tab switch, close tab, close dirty tab confirmation
- [x] `cargo clippy -- -D warnings` — clean
- [x] Full suite: 1933 passed, 0 failed

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)