### PR TITLE
feat: status bar hit regions — centralize click geometry

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -8071,6 +8071,50 @@ pub fn build_window_status_line(
     }
 }
 
+/// Compute hit regions from status line segments.
+/// `bar_width` is the total width in char cells.
+/// Returns `(col, width, action)` tuples for all interactive segments.
+pub fn compute_status_hit_regions(
+    left: &[StatusSegment],
+    right: &[StatusSegment],
+    bar_width: usize,
+) -> Vec<(u16, u16, StatusAction)> {
+    let mut regions = Vec::new();
+    // Left segments: accumulate from col 0
+    let mut col: u16 = 0;
+    for seg in left {
+        let w = seg.text.chars().count() as u16;
+        if let Some(ref action) = seg.action {
+            regions.push((col, w, action.clone()));
+        }
+        col += w;
+    }
+    // Right segments: right-aligned
+    let right_width: usize = right.iter().map(|s| s.text.chars().count()).sum();
+    let mut col = bar_width.saturating_sub(right_width) as u16;
+    for seg in right {
+        let w = seg.text.chars().count() as u16;
+        if let Some(ref action) = seg.action {
+            regions.push((col, w, action.clone()));
+        }
+        col += w;
+    }
+    regions
+}
+
+/// Resolve a column position to a `StatusAction` using pre-computed hit regions.
+pub fn resolve_status_bar_click(
+    hit_regions: &[(u16, u16, StatusAction)],
+    col: u16,
+) -> Option<StatusAction> {
+    for &(start, width, ref action) in hit_regions {
+        if col >= start && col < start + width {
+            return Some(action.clone());
+        }
+    }
+    None
+}
+
 fn build_command_line(engine: &Engine) -> CommandLineData {
     let (text, right_align, show_cursor, cursor_anchor_text) = match engine.mode {
         Mode::Command if engine.history_search_active => {

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2840,33 +2840,10 @@ fn status_segment_hit_test(
     width: usize,
     click_col: usize,
 ) -> Option<crate::render::StatusAction> {
-    // Compute right-side total width
-    let right_width: usize = status
-        .right_segments
-        .iter()
-        .map(|s| s.text.chars().count())
-        .sum();
-    let right_start = width.saturating_sub(right_width);
-
-    // Check left segments
-    let mut col = 0;
-    for seg in &status.left_segments {
-        let seg_len = seg.text.chars().count();
-        if click_col >= col && click_col < col + seg_len {
-            return seg.action.clone();
-        }
-        col += seg_len;
-    }
-
-    // Check right segments
-    let mut col = right_start;
-    for seg in &status.right_segments {
-        let seg_len = seg.text.chars().count();
-        if click_col >= col && click_col < col + seg_len {
-            return seg.action.clone();
-        }
-        col += seg_len;
-    }
-
-    None
+    let regions = crate::render::compute_status_hit_regions(
+        &status.left_segments,
+        &status.right_segments,
+        width,
+    );
+    crate::render::resolve_status_bar_click(&regions, click_col as u16)
 }


### PR DESCRIPTION
## Summary
- Adds `compute_status_hit_regions()` and `resolve_status_bar_click()` in render.rs
- TUI's `status_segment_hit_test()` now delegates to the shared functions
- Same pattern as #40 (tab bar hit regions) — geometry computed once, backends consume

## Test plan
- [x] `cargo clippy -- -D warnings` — clean (full build, all targets)
- [x] Full suite: 1933 passed, 0 failed
- [x] GTK + TUI + vcd binaries compile

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)