### PR TITLE
feat: sidebar activity bar hit regions

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -1089,6 +1089,62 @@ pub fn compute_find_replace_hit_regions(
     (regions, input_w)
 }
 
+// ── Activity bar hit regions ────────────────────────────────────────────────
+
+/// Click target within the activity bar icon column.
+/// Backends resolve row position → `ActivityBarTarget`, then apply
+/// panel-switching logic locally (since sidebar visibility is backend state).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivityBarTarget {
+    /// Hamburger menu (row 0) — toggles menu bar.
+    MenuToggle,
+    /// Built-in panel by name.
+    Panel(SidebarPanel),
+    /// Extension panel by registered name.
+    ExtensionPanel(String),
+    /// Settings (bottom row).
+    Settings,
+}
+
+/// Built-in sidebar panels (shared across backends).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidebarPanel {
+    Explorer,
+    Search,
+    Debug,
+    Git,
+    Extensions,
+    Ai,
+}
+
+/// Resolve an activity bar row (0-indexed from the top of the activity bar)
+/// to a click target. `bar_height` is the total activity bar height in rows.
+/// `ext_panel_names` is the sorted list of registered extension panel names.
+pub fn resolve_activity_bar_click(
+    row: u16,
+    bar_height: u16,
+    ext_panel_names: &[String],
+) -> Option<ActivityBarTarget> {
+    let settings_row = bar_height.saturating_sub(1);
+    match row {
+        0 => Some(ActivityBarTarget::MenuToggle),
+        1 => Some(ActivityBarTarget::Panel(SidebarPanel::Explorer)),
+        2 => Some(ActivityBarTarget::Panel(SidebarPanel::Search)),
+        3 => Some(ActivityBarTarget::Panel(SidebarPanel::Debug)),
+        4 => Some(ActivityBarTarget::Panel(SidebarPanel::Git)),
+        5 => Some(ActivityBarTarget::Panel(SidebarPanel::Extensions)),
+        6 => Some(ActivityBarTarget::Panel(SidebarPanel::Ai)),
+        r if r == settings_row && settings_row >= 7 => Some(ActivityBarTarget::Settings),
+        r if r >= 7 => {
+            let ext_idx = (r - 7) as usize;
+            ext_panel_names
+                .get(ext_idx)
+                .map(|name| ActivityBarTarget::ExtensionPanel(name.clone()))
+        }
+        _ => None,
+    }
+}
+
 // ── Tab bar hit regions ─────────────────────────────────────────────────────
 
 /// Click target within a group's tab bar.

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -26221,3 +26221,56 @@ fn test_ctrl_bracket_right_pushes_jump_location() {
         "jump list should have an entry"
     );
 }
+
+// --- Activity bar hit regions ---
+
+#[test]
+fn test_activity_bar_resolve_builtin_panels() {
+    use crate::core::engine::{resolve_activity_bar_click, ActivityBarTarget, SidebarPanel};
+    let ext_names: Vec<String> = vec![];
+
+    assert_eq!(
+        resolve_activity_bar_click(0, 30, &ext_names),
+        Some(ActivityBarTarget::MenuToggle)
+    );
+    assert_eq!(
+        resolve_activity_bar_click(1, 30, &ext_names),
+        Some(ActivityBarTarget::Panel(SidebarPanel::Explorer))
+    );
+    assert_eq!(
+        resolve_activity_bar_click(4, 30, &ext_names),
+        Some(ActivityBarTarget::Panel(SidebarPanel::Git))
+    );
+    assert_eq!(
+        resolve_activity_bar_click(6, 30, &ext_names),
+        Some(ActivityBarTarget::Panel(SidebarPanel::Ai))
+    );
+    // Settings at bottom row
+    assert_eq!(
+        resolve_activity_bar_click(29, 30, &ext_names),
+        Some(ActivityBarTarget::Settings)
+    );
+    // Empty gap between panels and settings
+    assert_eq!(resolve_activity_bar_click(10, 30, &ext_names), None);
+}
+
+#[test]
+fn test_activity_bar_resolve_extension_panels() {
+    use crate::core::engine::{resolve_activity_bar_click, ActivityBarTarget};
+    let ext_names = vec!["git-insights".to_string(), "todo-panel".to_string()];
+
+    // Row 7 = first extension panel
+    assert_eq!(
+        resolve_activity_bar_click(7, 30, &ext_names),
+        Some(ActivityBarTarget::ExtensionPanel(
+            "git-insights".to_string()
+        ))
+    );
+    // Row 8 = second extension panel
+    assert_eq!(
+        resolve_activity_bar_click(8, 30, &ext_names),
+        Some(ActivityBarTarget::ExtensionPanel("todo-panel".to_string()))
+    );
+    // Row 9 with only 2 extensions = None (gap)
+    assert_eq!(resolve_activity_bar_click(9, 30, &ext_names), None);
+}

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -1853,35 +1853,23 @@ pub(super) fn handle_mouse(
     if col < ab_width {
         // Activity bar spans full height below the menu bar row (matching GTK layout).
         let menu_rows: u16 = if engine.menu_bar_visible { 1 } else { 0 };
-        // Activity bar starts at row `menu_rows` in absolute terminal coordinates.
         if row < menu_rows {
-            return sidebar_width; // click in menu bar area, ignore
-        }
-        let bar_row = row - menu_rows; // row relative to activity bar start
-        let bar_height = term_height.saturating_sub(menu_rows);
-        let settings_row = bar_height.saturating_sub(1);
-        // Row 0: hamburger (menu bar toggle)
-        if bar_row == 0 {
-            engine.toggle_menu_bar();
             return sidebar_width;
         }
-        let target_panel = match bar_row {
-            1 => Some(TuiPanel::Explorer),
-            2 => Some(TuiPanel::Search),
-            3 => Some(TuiPanel::Debug),
-            4 => Some(TuiPanel::Git),
-            5 => Some(TuiPanel::Extensions),
-            6 => Some(TuiPanel::Ai),
-            r if r == settings_row && settings_row >= 7 => Some(TuiPanel::Settings),
-            _ => None,
-        };
-        // Check if click is on an extension panel icon (rows 7+)
-        if target_panel.is_none() && bar_row >= 7 {
-            let ext_idx = (bar_row - 7) as usize;
-            let mut ext_names: Vec<_> = engine.ext_panels.keys().cloned().collect();
-            ext_names.sort();
-            if ext_idx < ext_names.len() {
-                let name = ext_names[ext_idx].clone();
+        let bar_row = row - menu_rows;
+        let bar_height = term_height.saturating_sub(menu_rows);
+        // Resolve click target using shared function
+        let mut ext_names: Vec<_> = engine.ext_panels.keys().cloned().collect();
+        ext_names.sort();
+        let ab_target =
+            crate::core::engine::resolve_activity_bar_click(bar_row, bar_height, &ext_names);
+        use crate::core::engine::{ActivityBarTarget, SidebarPanel};
+        match ab_target {
+            Some(ActivityBarTarget::MenuToggle) => {
+                engine.toggle_menu_bar();
+                return sidebar_width;
+            }
+            Some(ActivityBarTarget::ExtensionPanel(name)) => {
                 if sidebar.ext_panel_name.as_deref() == Some(&name) && sidebar.visible {
                     sidebar.visible = false;
                     sidebar.ext_panel_name = None;
@@ -1900,7 +1888,21 @@ pub(super) fn handle_mouse(
                 let _ = engine.session.save();
                 return sidebar_width;
             }
+            _ => {}
         }
+        // Map shared SidebarPanel to TUI-local TuiPanel
+        let target_panel = match ab_target {
+            Some(ActivityBarTarget::Panel(p)) => match p {
+                SidebarPanel::Explorer => Some(TuiPanel::Explorer),
+                SidebarPanel::Search => Some(TuiPanel::Search),
+                SidebarPanel::Debug => Some(TuiPanel::Debug),
+                SidebarPanel::Git => Some(TuiPanel::Git),
+                SidebarPanel::Extensions => Some(TuiPanel::Extensions),
+                SidebarPanel::Ai => Some(TuiPanel::Ai),
+            },
+            Some(ActivityBarTarget::Settings) => Some(TuiPanel::Settings),
+            _ => None,
+        };
         if let Some(panel) = target_panel {
             // Clear extension panel state when switching to a built-in panel
             sidebar.ext_panel_name = None;


### PR DESCRIPTION
## Summary
- Centralizes activity bar row→panel mapping into `resolve_activity_bar_click()` in engine/mod.rs
- New types: `ActivityBarTarget` enum, `SidebarPanel` enum
- TUI migrated — replaces hardcoded row match with shared resolver
- Panel item clicks (explorer tree, git items, etc.) left in backends — they need scroll-aware geometry

## Scope note
This covers the **activity bar** portion of #42. The sidebar panel item clicks are inherently scroll-dependent and backend-specific — centralizing those requires a different approach (per-frame geometry computation) that's better suited to #44 (abstract event layer).

## Test plan
- [x] 2 new tests: built-in panels + extension panel resolution
- [x] `cargo clippy -- -D warnings` — clean (all targets)
- [x] Full suite: 1936 passed, 0 failed

## Smoke test
In TUI: click each activity bar icon (explorer, search, debug, git, extensions, AI, settings) — should toggle panels same as before.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)