### PR TITLE
feat: GTK dialogs use engine dialog system instead of native widgets

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -617,6 +617,17 @@ pub(super) fn draw_editor(
         line_height,
     );
     *dialog_btn_rects_out.borrow_mut() = btn_rects;
+
+    draw_context_menu_popup(
+        cr,
+        &layout,
+        &screen,
+        &theme,
+        width as f64,
+        height as f64,
+        char_width,
+        line_height,
+    );
 }
 
 /// Draw thin Cairo horizontal scrollbars that overlay the bottom of each editor
@@ -3428,6 +3439,112 @@ pub(super) fn draw_dialog_popup(
         }
     }
     rects
+}
+
+/// Draw an engine-driven context menu popup on the DrawingArea.
+/// Uses the same data as TUI/Win-GUI for visual consistency.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn draw_context_menu_popup(
+    cr: &Context,
+    _layout: &pango::Layout,
+    screen: &render::ScreenLayout,
+    theme: &Theme,
+    editor_width: f64,
+    editor_height: f64,
+    char_width: f64,
+    line_height: f64,
+) {
+    let Some(cm) = &screen.context_menu else {
+        return;
+    };
+    if cm.items.is_empty() {
+        return;
+    }
+
+    let pango_ctx = pangocairo::create_context(cr);
+    let ui_font_desc = FontDescription::from_string(UI_FONT);
+    let ui_layout = pango::Layout::new(&pango_ctx);
+    ui_layout.set_font_description(Some(&ui_font_desc));
+
+    // Calculate popup dimensions.
+    let sep_count = cm.items.iter().filter(|i| i.separator_after).count();
+    let max_label = cm.items.iter().map(|i| i.label.len()).max().unwrap_or(4);
+    let max_sc = cm.items.iter().map(|i| i.shortcut.len()).max().unwrap_or(0);
+    let content_cols = (max_label + max_sc + 6).clamp(20, 50);
+    let popup_w = content_cols as f64 * char_width;
+    let popup_h = (cm.items.len() + sep_count + 2) as f64 * line_height;
+
+    // Position: use char-cell coordinates from engine, scaled to pixels.
+    let raw_x = cm.screen_col as f64 * char_width;
+    let raw_y = cm.screen_row as f64 * line_height;
+    let px = raw_x.min(editor_width - popup_w);
+    let py = raw_y.min(editor_height - popup_h);
+
+    // Background.
+    let (r, g, b) = theme.fuzzy_bg.to_cairo();
+    cr.set_source_rgb(r, g, b);
+    cr.rectangle(px, py, popup_w, popup_h);
+    cr.fill().ok();
+
+    // Border.
+    let (r, g, b) = theme.fuzzy_border.to_cairo();
+    cr.set_source_rgb(r, g, b);
+    cr.set_line_width(1.0);
+    cr.rectangle(px, py, popup_w, popup_h);
+    cr.stroke().ok();
+
+    // Items.
+    let mut visual_row: usize = 0;
+    let item_x = px + char_width;
+    for (i, item) in cm.items.iter().enumerate() {
+        let item_y = py + (visual_row + 1) as f64 * line_height;
+
+        // Selection highlight.
+        if i == cm.selected_idx && item.enabled {
+            let (r, g, b) = theme.fuzzy_selected_bg.to_cairo();
+            cr.set_source_rgb(r, g, b);
+            cr.rectangle(px + 1.0, item_y, popup_w - 2.0, line_height);
+            cr.fill().ok();
+        }
+
+        // Label.
+        let fg = if item.enabled {
+            theme.fuzzy_fg
+        } else {
+            theme.line_number_fg
+        };
+        let (r, g, b) = fg.to_cairo();
+        cr.set_source_rgb(r, g, b);
+        ui_layout.set_text(&item.label);
+        ui_layout.set_attributes(None);
+        cr.move_to(item_x, item_y);
+        pangocairo::show_layout(cr, &ui_layout);
+
+        // Shortcut (right-aligned).
+        if !item.shortcut.is_empty() {
+            ui_layout.set_text(&item.shortcut);
+            let (sw, _) = ui_layout.pixel_size();
+            let sc_x = px + popup_w - sw as f64 - char_width;
+            let (r, g, b) = theme.line_number_fg.to_cairo();
+            cr.set_source_rgb(r, g, b);
+            cr.move_to(sc_x, item_y);
+            pangocairo::show_layout(cr, &ui_layout);
+        }
+
+        visual_row += 1;
+
+        // Separator line.
+        if item.separator_after {
+            let sep_y = py + (visual_row + 1) as f64 * line_height + line_height / 2.0;
+            let (r, g, b) = theme.fuzzy_border.to_cairo();
+            cr.set_source_rgb(r, g, b);
+            cr.set_line_width(0.5);
+            cr.move_to(px + 4.0, sep_y);
+            cr.line_to(px + popup_w - 4.0, sep_y);
+            cr.stroke().ok();
+            visual_row += 1;
+        }
+    }
 }
 
 /// Draw the tab bar for the bottom panel (Terminal / Debug Output).

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6027,10 +6027,16 @@ impl App {
             drop(engine);
 
             if let Some(idx) = clicked_btn {
-                let _action = self.engine.borrow_mut().dialog_click_button(idx);
+                let action = self.engine.borrow_mut().dialog_click_button(idx);
                 if self.engine.borrow().explorer_needs_refresh {
                     self.engine.borrow_mut().explorer_needs_refresh = false;
                     sender.input(Msg::RefreshFileTree);
+                }
+                match action {
+                    EngineAction::Quit | EngineAction::SaveQuit => {
+                        self.save_session_and_exit();
+                    }
+                    _ => {}
                 }
             } else if outside {
                 self.engine.borrow_mut().dialog = None;
@@ -9357,41 +9363,33 @@ impl App {
                     // No unsaved changes — save session and exit immediately.
                     self.save_session_and_exit();
                 }
-                // Show a confirmation dialog listing the choice.
-                let dialog = gtk4::Dialog::with_buttons(
-                    Some("Unsaved Changes"),
-                    Some(&self.window),
-                    gtk4::DialogFlags::MODAL | gtk4::DialogFlags::DESTROY_WITH_PARENT,
-                    &[
-                        ("Save All & Quit", gtk4::ResponseType::Accept),
-                        ("Quit Without Saving", gtk4::ResponseType::Reject),
-                        ("Cancel", gtk4::ResponseType::Cancel),
+                use crate::core::engine::DialogButton;
+                self.engine.borrow_mut().show_dialog(
+                    "quit_unsaved",
+                    "Unsaved Changes",
+                    vec![
+                        "You have unsaved changes.".to_string(),
+                        "Do you want to save before quitting?".to_string(),
+                    ],
+                    vec![
+                        DialogButton {
+                            label: "Save All & Quit".into(),
+                            hotkey: 's',
+                            action: "save_quit".into(),
+                        },
+                        DialogButton {
+                            label: "Quit Without Saving".into(),
+                            hotkey: 'q',
+                            action: "discard_quit".into(),
+                        },
+                        DialogButton {
+                            label: "Cancel".into(),
+                            hotkey: '\0',
+                            action: "cancel".into(),
+                        },
                     ],
                 );
-                let label = gtk4::Label::new(Some(
-                    "You have unsaved changes.\nDo you want to save before quitting?",
-                ));
-                label.set_margin_top(12);
-                label.set_margin_bottom(12);
-                label.set_margin_start(12);
-                label.set_margin_end(12);
-                dialog.content_area().append(&label);
-                let engine_clone = self.engine.clone();
-                let s = sender.input_sender().clone();
-                dialog.connect_response(move |dlg, resp| {
-                    dlg.close();
-                    match resp {
-                        gtk4::ResponseType::Accept => {
-                            engine_clone.borrow_mut().save_all_dirty();
-                            s.send(Msg::QuitConfirmed).ok();
-                        }
-                        gtk4::ResponseType::Reject => {
-                            s.send(Msg::QuitConfirmed).ok();
-                        }
-                        _ => {} // Cancel — do nothing
-                    }
-                });
-                dialog.present();
+                self.draw_needed.set(true);
             }
 
             Msg::QuitConfirmed => {
@@ -9400,38 +9398,29 @@ impl App {
             }
 
             Msg::ShowCloseTabConfirm => {
-                let dialog = gtk4::Dialog::with_buttons(
-                    Some("Unsaved Changes"),
-                    Some(&self.window),
-                    gtk4::DialogFlags::MODAL | gtk4::DialogFlags::DESTROY_WITH_PARENT,
-                    &[
-                        ("Save & Close Tab", gtk4::ResponseType::Accept),
-                        ("Discard & Close Tab", gtk4::ResponseType::Reject),
-                        ("Cancel", gtk4::ResponseType::Cancel),
+                use crate::core::engine::DialogButton;
+                self.engine.borrow_mut().show_dialog(
+                    "close_tab_confirm",
+                    "Unsaved Changes",
+                    vec!["This file has unsaved changes.".to_string()],
+                    vec![
+                        DialogButton {
+                            label: "Save & Close".into(),
+                            hotkey: 's',
+                            action: "save_close".into(),
+                        },
+                        DialogButton {
+                            label: "Discard & Close".into(),
+                            hotkey: 'd',
+                            action: "discard".into(),
+                        },
+                        DialogButton {
+                            label: "Cancel".into(),
+                            hotkey: '\0',
+                            action: "cancel".into(),
+                        },
                     ],
                 );
-                let label = gtk4::Label::new(Some(
-                    "This file has unsaved changes.\nDo you want to save before closing the tab?",
-                ));
-                label.set_margin_top(12);
-                label.set_margin_bottom(12);
-                label.set_margin_start(12);
-                label.set_margin_end(12);
-                dialog.content_area().append(&label);
-                let s = sender.input_sender().clone();
-                dialog.connect_response(move |dlg, resp| {
-                    dlg.close();
-                    match resp {
-                        gtk4::ResponseType::Accept => {
-                            s.send(Msg::CloseTabConfirmed { save: true }).ok();
-                        }
-                        gtk4::ResponseType::Reject => {
-                            s.send(Msg::CloseTabConfirmed { save: false }).ok();
-                        }
-                        _ => {} // Cancel — do nothing
-                    }
-                });
-                dialog.present();
                 self.draw_needed.set(true);
             }
 


### PR DESCRIPTION
## Summary
- GTK close-tab-confirm and quit-unsaved-confirm dialogs now use `engine.show_dialog()` instead of native `gtk4::Dialog` widgets
- All 3 backends (GTK, TUI, Win-GUI) now render these dialogs from the same engine data via `draw_dialog_popup()`
- Hotkey labels (`[S]`, `[D]`, etc.) and keyboard shortcuts now work in GTK dialogs
- Dialog click handler now properly dispatches `Quit`/`SaveQuit` engine actions

## Before/After
**Before:** GTK showed a native OS dialog with horizontal buttons, no hotkey labels
**After:** GTK draws the same styled dialog as TUI/Win-GUI with `[S]ave & Close`, `[D]iscard & Close`, `Cancel`

## Test plan
- [x] `cargo clippy -- -D warnings` — clean
- [x] Full suite: 1939 passed, 0 failed

## Smoke test
**GTK:**
1. Open a file, make it dirty (`ihello<Esc>`)
2. Click the `×` on the tab → should show engine-drawn dialog (not native GTK dialog)
3. Press `D` → should discard and close
4. Repeat, press `S` → should save and close
5. Make dirty, `:q` or close window → quit-confirm dialog should look the same

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)