### PR TITLE
feat(quadraui): Phase B.1 — Backend trait + UiEvent + Accelerator scaffolding

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -52,9 +52,13 @@ test app; target downstream apps include a cross-platform k8s dashboard
 | **Phase A.8** — `TextDisplay` primitive scaffolding (no migration) | ✅ Done | `ff6b13f` | `quadraui-phase-a8-text-display` | any |
 | Phase A.9 — `TextEditor` + `BufferView` adapter | ⬜ Deferred (not needed for vimcode) | — | `quadraui-phase-a9-*` | any — biggest stage |
 | **Optional Win-GUI parity** — see "Win-GUI parity scope" section below | ⬜ Optional | — | `quadraui-phase-a*-win` | Windows |
-| Phase B — extract & stabilise API | ⬜ Later | — | — | any |
+| **Phase B.1** — `UiEvent` + `Accelerator` + `Backend` trait scaffolding | ✅ Done | _tbd_ | `quadraui-phase-b1-backend-trait` | any |
+| Phase B.2 — pilot migration: terminal maximize to `Accelerator::Global` | ⬜ Next | — | `quadraui-phase-b2-maximize-pilot` | any |
+| Phase B.3 — layout primitives (`Panel`, `Split`, `Tabs`, `MenuBar`, `Modal`) | ⬜ After B.2 | — | `quadraui-phase-b3-layout` | any |
+| Phase B.4+ — migrate remaining vimcode subsystems to UiEvent | ⬜ After B.3 | — | `quadraui-phase-b4-*` | any |
+| Phase B.5 — Postman-class validation app (#169) | ⬜ After B.3/B.4 | — | _new workspace member_ | any |
 | Phase C — macOS backend | ⬜ v1.x | — | — | macOS |
-| Phase D — polish + k8s validation app | ⬜ Later | — | — | any |
+| Phase D — polish + k8s validation app (#145) | ⬜ Later | — | — | any |
 
 **All required platform-specific stages are now done.** A.1b/A.2b/
 A.3c-2/A.4b/A.5b shipped on Linux GTK; A.1c (Session 314) and A.2c

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 21, 2026 (Session 318 — chrome helper + APP_ARCHITECTURE.md) | **Tests:** 5273 total (full `cargo test --workspace --no-default-features`); vimcode 5249 + quadraui 24
+**Last updated:** Apr 22, 2026 (Session 319 — Phase B.1 Backend trait scaffold) | **Tests:** 5295 total (full `cargo test --workspace --no-default-features`); vimcode 5249 + quadraui 46
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -26,6 +26,20 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 319 — Phase B.1 Backend trait scaffolding (#169 blocker):**
+
+1. **Pure additive quadraui types.** Three new files — `quadraui/src/event.rs`, `quadraui/src/accelerator.rs`, `quadraui/src/backend.rs` — plus re-exports in `lib.rs`. No vimcode runtime changes; no migration. The abstractions coexist with existing per-backend dispatch as designed in `BACKEND_TRAIT_PROPOSAL.md` §5 Phase B.1.
+2. **`UiEvent` enum (~60 variants/fields).** Backend-neutral event data covering input (`Accelerator`, `KeyPressed`, `CharTyped`), mouse (`MouseDown/Up/Moved/Entered/Left/DoubleClick/Scroll`), window (`WindowResized/Close/Focused/DpiChanged`), files (`FilesDropped/ClipboardPaste`), primitive-specific events re-wrapped (`Tree`, `List`, `Form`, `Palette`, `TabBar`, `StatusBar`, `ActivityBar`, `Terminal`, `TextDisplay`), and `BackendNative` escape hatch. All `Debug + Clone + PartialEq + Serialize + Deserialize` per §2 invariants. Supporting types: `Key`/`NamedKey`, `MouseButton`, `ButtonMask`, `Point`, `Rect`, `ScrollDelta`, `Viewport`, `BackendNativeEvent`.
+3. **`Accelerator` + `KeyBinding` + dual-format parser.** 13 universal bindings (`Save`, `Copy`, `Undo`, `Find`, ...) that render platform-appropriately, plus `KeyBinding::Literal(String)` that accepts **both** vim-style (`<C-S-t>`) and plus-style (`Ctrl+Shift+T`) input — first character dispatches. `AcceleratorScope` variants for `Global`/`Widget`/`Mode`. `Platform` enum and `render_accelerator`/`render_binding` helpers produce `⌘⇧T` on macOS, `Ctrl+Shift+T` elsewhere.
+4. **`Backend` trait + `PlatformServices` trait.** Frame lifecycle (`begin_frame`/`end_frame`), event polling (`poll_events`/`wait_events`), accelerator registration (`register_accelerator`/`unregister_accelerator`), services access, and **9 per-primitive draw methods** (`draw_tree`/`draw_list`/`draw_form`/.../`draw_text_display`) per Decision 2 (B). No `AnyPrimitive` enum. `Clipboard` sub-trait, `FileDialogOptions`, `Notification` support types.
+5. **22 new lib tests in `accelerator.rs`** covering both parser formats, modifier aliases (`Cmd`/`Command`/`Super`/`Win`/`Meta`), case-insensitivity, rejection cases, render platform-parity, serde round-trip. Quadraui test count: 24 → 46. Workspace total: 5273 → 5295.
+6. **Documentation updates.** `PLAN.md` stage table gains Phase B.1 (Done) + B.2/B.3/B.4/B.5 rows; `PROJECT_STATE.md` session note.
+7. **Quality gates all pass.** `cargo fmt` clean; `cargo clippy --workspace --no-default-features -- -D warnings` clean; `cargo test --workspace --no-default-features` 5295/0/19.
+8. **What this PR does NOT do.** Zero vimcode runtime change. No existing code migrated. No behaviour change for users. Pure additive — the new types sit unused until Phase B.2 (terminal maximize pilot migration) lands.
+9. **Path B landing.** Branch `quadraui-phase-b1-backend-trait` off develop; pushed for PR review.
+
+---
 
 **Session 318 — Closing the "where does app logic go?" gap:**
 

--- a/quadraui/src/accelerator.rs
+++ b/quadraui/src/accelerator.rs
@@ -1,0 +1,529 @@
+//! Declarative cross-platform keybindings.
+//!
+//! Apps declare `Accelerator`s and register them with the active
+//! [`Backend`][crate::Backend]. The backend watches native key events, matches
+//! them to the registered accelerators, and emits
+//! [`UiEvent::Accelerator`][crate::UiEvent::Accelerator] when one fires.
+//! Apps dispatch on [`AcceleratorId`] without parsing key strings themselves.
+//!
+//! ## Platform idiom parity
+//!
+//! Universal bindings ([`KeyBinding::Save`], [`KeyBinding::Copy`], etc.)
+//! render as `⌘S` on macOS and `Ctrl+S` elsewhere — the app doesn't care.
+//! App-specific bindings use [`KeyBinding::Literal`], which accepts both
+//! vim-style (`<C-S-t>`) and plus-style (`Ctrl+Shift+T`) input.
+//!
+//! See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §3 for the full rationale.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{Modifiers, WidgetId};
+
+/// Stable identifier for a registered accelerator. Apps match on this in the
+/// [`UiEvent::Accelerator`][crate::UiEvent::Accelerator] arm of their
+/// dispatcher.
+///
+/// Conventionally namespaced (`"editor.save"`, `"plugin:my-ext:send"`) so
+/// plugin accelerators don't collide with app accelerators.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AcceleratorId(pub String);
+
+impl AcceleratorId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for AcceleratorId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for AcceleratorId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// When an [`Accelerator`] should fire relative to app state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AcceleratorScope {
+    /// Fires regardless of what's focused. E.g. "Ctrl+P" for the palette.
+    Global,
+    /// Fires only when the given widget (or its descendants) have focus.
+    /// Used for widget-local shortcuts like Esc inside a picker.
+    Widget(WidgetId),
+    /// Fires only when the given mode is active. For vim-like apps: `"n"`
+    /// = Normal mode, `"i"` = Insert, `"v"` = Visual. Apps define the
+    /// mode strings.
+    Mode(String),
+}
+
+/// The key combination to bind.
+///
+/// Universal variants render platform-appropriately (e.g. `⌘S` on macOS);
+/// [`KeyBinding::Literal`] is for app-specific bindings that don't have a
+/// universal name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KeyBinding {
+    // ── Universal accelerators (render platform-appropriately) ─────────
+    Save,
+    Open,
+    New,
+    Close,
+    Copy,
+    Cut,
+    Paste,
+    Undo,
+    Redo,
+    SelectAll,
+    Find,
+    Replace,
+    Quit,
+
+    /// App-specific binding. Parser accepts **both** vim-style
+    /// (`<C-S-t>`) and plus-style (`Ctrl+Shift+T`) input; first character
+    /// determines which parser runs. See
+    /// [`parse_key_binding`] for the grammar.
+    Literal(String),
+}
+
+/// A declared accelerator: its stable ID, the keys that trigger it, the
+/// scope in which it's active, and an optional display label for menus.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Accelerator {
+    pub id: AcceleratorId,
+    pub binding: KeyBinding,
+    pub scope: AcceleratorScope,
+    /// Human-readable label for menus, tooltips, help. `None` means the
+    /// backend derives one from the binding (e.g. "Ctrl+Shift+T").
+    pub label: Option<String>,
+}
+
+// ─── Parsing ────────────────────────────────────────────────────────────────
+
+/// Parsed form of a [`KeyBinding::Literal`] string. Backends match native
+/// key events against this struct.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ParsedBinding {
+    pub modifiers: Modifiers,
+    /// Lowercased character for letters; uppercase named key (`Enter`,
+    /// `F1`, `Escape`) for non-printables.
+    pub key: String,
+}
+
+/// Parse a `KeyBinding::Literal` string. Accepts two formats:
+///
+/// - **Vim-style**: `<C-S-t>`, `<C-A-Left>`, `<F5>`. Starts with `<`.
+///   Modifier letters: `C` = Ctrl, `S` = Shift, `A` = Alt, `D`/`M` =
+///   Cmd/Super.
+/// - **Plus-style**: `Ctrl+Shift+T`, `Cmd+S`, `Alt+F4`. Case-insensitive
+///   modifiers.
+///
+/// Format is detected from the first character — `<` means vim-style,
+/// anything else means plus-style. Single-character bindings without
+/// separators (e.g. `"a"`, `"Escape"`) parse as plus-style with no
+/// modifiers.
+///
+/// Returns `None` on unparseable input.
+pub fn parse_key_binding(s: &str) -> Option<ParsedBinding> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if s.starts_with('<') {
+        parse_vim_style(s)
+    } else {
+        parse_plus_style(s)
+    }
+}
+
+/// Vim-style: `<C-S-t>`, `<C-A-Left>`, `<F5>`, `<Escape>`.
+fn parse_vim_style(s: &str) -> Option<ParsedBinding> {
+    let inner = s.strip_prefix('<')?.strip_suffix('>')?;
+    if inner.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = inner.split('-').collect();
+    // Last part is the key; earlier parts are modifier letters.
+    let (key_part, mod_parts) = parts.split_last()?;
+    let mut modifiers = Modifiers::default();
+    for m in mod_parts {
+        match *m {
+            "C" => modifiers.ctrl = true,
+            "S" => modifiers.shift = true,
+            "A" => modifiers.alt = true,
+            "D" | "M" => modifiers.cmd = true,
+            _ => return None,
+        }
+    }
+    Some(ParsedBinding {
+        modifiers,
+        key: normalise_key_name(key_part),
+    })
+}
+
+/// Plus-style: `Ctrl+Shift+T`, `Cmd+S`, `Alt+F4`, `Escape`.
+fn parse_plus_style(s: &str) -> Option<ParsedBinding> {
+    let parts: Vec<&str> = s.split('+').map(str::trim).collect();
+    if parts.is_empty() || parts.iter().any(|p| p.is_empty()) {
+        return None;
+    }
+    let mut modifiers = Modifiers::default();
+    let mut key: Option<String> = None;
+    for p in &parts {
+        let lower = p.to_ascii_lowercase();
+        match lower.as_str() {
+            "ctrl" | "control" => modifiers.ctrl = true,
+            "shift" => modifiers.shift = true,
+            "alt" | "option" | "opt" => modifiers.alt = true,
+            "cmd" | "command" | "super" | "win" | "meta" => modifiers.cmd = true,
+            _ => {
+                if key.is_some() {
+                    // More than one non-modifier token → malformed.
+                    return None;
+                }
+                key = Some(normalise_key_name(p));
+            }
+        }
+    }
+    Some(ParsedBinding {
+        modifiers,
+        key: key?,
+    })
+}
+
+/// Normalise a key name to the canonical form used by backends.
+///
+/// - Single letters → lowercase (`T` → `t`).
+/// - Named keys → TitleCase preserved (`Escape`, `F5`, `Left`).
+fn normalise_key_name(s: &str) -> String {
+    if s.chars().count() == 1 {
+        s.to_ascii_lowercase()
+    } else {
+        s.to_string()
+    }
+}
+
+// ─── Rendering ──────────────────────────────────────────────────────────────
+
+/// Render an [`Accelerator`] for display in a menu, tooltip, or help overlay.
+///
+/// Always platform-appropriate: `⌘⇧T` on macOS, `Ctrl+Shift+T` on
+/// Win/Linux/TUI — regardless of which input format the app used.
+pub fn render_accelerator(acc: &Accelerator, platform: Platform) -> String {
+    if let Some(ref label) = acc.label {
+        return label.clone();
+    }
+    render_binding(&acc.binding, platform)
+}
+
+/// Render just the [`KeyBinding`] portion.
+pub fn render_binding(b: &KeyBinding, platform: Platform) -> String {
+    match b {
+        KeyBinding::Save => platform.fmt_mod_letter("Ctrl", "S"),
+        KeyBinding::Open => platform.fmt_mod_letter("Ctrl", "O"),
+        KeyBinding::New => platform.fmt_mod_letter("Ctrl", "N"),
+        KeyBinding::Close => platform.fmt_mod_letter("Ctrl", "W"),
+        KeyBinding::Copy => platform.fmt_mod_letter("Ctrl", "C"),
+        KeyBinding::Cut => platform.fmt_mod_letter("Ctrl", "X"),
+        KeyBinding::Paste => platform.fmt_mod_letter("Ctrl", "V"),
+        KeyBinding::Undo => platform.fmt_mod_letter("Ctrl", "Z"),
+        KeyBinding::Redo => platform.fmt_mod_shift_letter("Ctrl", "Z"),
+        KeyBinding::SelectAll => platform.fmt_mod_letter("Ctrl", "A"),
+        KeyBinding::Find => platform.fmt_mod_letter("Ctrl", "F"),
+        KeyBinding::Replace => platform.fmt_mod_letter("Ctrl", "H"),
+        KeyBinding::Quit => platform.fmt_mod_letter("Ctrl", "Q"),
+        KeyBinding::Literal(s) => render_literal(s, platform),
+    }
+}
+
+fn render_literal(s: &str, platform: Platform) -> String {
+    match parse_key_binding(s) {
+        Some(p) => platform.fmt_parsed(&p),
+        // Unparseable literal — show the raw string rather than hide it.
+        None => s.to_string(),
+    }
+}
+
+/// Platform identity for rendering. Backends return their own variant from
+/// [`PlatformServices::platform_name`][crate::PlatformServices::platform_name].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Platform {
+    Macos,
+    Windows,
+    Linux,
+    Tui,
+}
+
+impl Platform {
+    fn fmt_mod_letter(self, modifier: &str, letter: &str) -> String {
+        match self {
+            Platform::Macos => format!("{}{}", self.cmd_glyph(), letter),
+            _ => format!("{}+{}", modifier, letter),
+        }
+    }
+
+    fn fmt_mod_shift_letter(self, modifier: &str, letter: &str) -> String {
+        match self {
+            Platform::Macos => format!("{}⇧{}", self.cmd_glyph(), letter),
+            _ => format!("{}+Shift+{}", modifier, letter),
+        }
+    }
+
+    fn fmt_parsed(self, p: &ParsedBinding) -> String {
+        match self {
+            Platform::Macos => {
+                let mut s = String::new();
+                if p.modifiers.ctrl {
+                    s.push('⌃');
+                }
+                if p.modifiers.alt {
+                    s.push('⌥');
+                }
+                if p.modifiers.shift {
+                    s.push('⇧');
+                }
+                if p.modifiers.cmd {
+                    s.push('⌘');
+                }
+                s.push_str(&display_key(&p.key));
+                s
+            }
+            _ => {
+                let mut parts: Vec<&str> = Vec::new();
+                if p.modifiers.ctrl {
+                    parts.push("Ctrl");
+                }
+                if p.modifiers.alt {
+                    parts.push("Alt");
+                }
+                if p.modifiers.shift {
+                    parts.push("Shift");
+                }
+                if p.modifiers.cmd {
+                    parts.push("Super");
+                }
+                let key_disp = display_key(&p.key);
+                parts.push(&key_disp);
+                parts.join("+")
+            }
+        }
+    }
+
+    fn cmd_glyph(self) -> &'static str {
+        match self {
+            Platform::Macos => "⌘",
+            _ => "",
+        }
+    }
+}
+
+fn display_key(k: &str) -> String {
+    if k.chars().count() == 1 {
+        k.to_ascii_uppercase()
+    } else {
+        k.to_string()
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mods(ctrl: bool, shift: bool, alt: bool, cmd: bool) -> Modifiers {
+        Modifiers {
+            ctrl,
+            shift,
+            alt,
+            cmd,
+        }
+    }
+
+    #[test]
+    fn parse_vim_style_basic() {
+        let p = parse_key_binding("<C-S-t>").unwrap();
+        assert_eq!(p.modifiers, mods(true, true, false, false));
+        assert_eq!(p.key, "t");
+    }
+
+    #[test]
+    fn parse_vim_style_named_key() {
+        let p = parse_key_binding("<C-A-Left>").unwrap();
+        assert_eq!(p.modifiers, mods(true, false, true, false));
+        assert_eq!(p.key, "Left");
+    }
+
+    #[test]
+    fn parse_vim_style_no_modifiers() {
+        let p = parse_key_binding("<F5>").unwrap();
+        assert_eq!(p.modifiers, Modifiers::default());
+        assert_eq!(p.key, "F5");
+    }
+
+    #[test]
+    fn parse_vim_style_cmd_via_d_modifier() {
+        let p = parse_key_binding("<D-s>").unwrap();
+        assert_eq!(p.modifiers, mods(false, false, false, true));
+    }
+
+    #[test]
+    fn parse_vim_style_rejects_unknown_modifier() {
+        assert!(parse_key_binding("<X-t>").is_none());
+    }
+
+    #[test]
+    fn parse_vim_style_rejects_unclosed() {
+        assert!(parse_key_binding("<C-t").is_none());
+    }
+
+    #[test]
+    fn parse_plus_style_basic() {
+        let p = parse_key_binding("Ctrl+Shift+T").unwrap();
+        assert_eq!(p.modifiers, mods(true, true, false, false));
+        assert_eq!(p.key, "t");
+    }
+
+    #[test]
+    fn parse_plus_style_case_insensitive_modifiers() {
+        let p = parse_key_binding("ctrl+SHIFT+t").unwrap();
+        assert_eq!(p.modifiers, mods(true, true, false, false));
+        assert_eq!(p.key, "t");
+    }
+
+    #[test]
+    fn parse_plus_style_cmd_aliases() {
+        for input in ["Cmd+S", "Command+S", "Super+S", "Win+S", "Meta+S"] {
+            let p = parse_key_binding(input).unwrap_or_else(|| panic!("failed to parse {input}"));
+            assert_eq!(p.modifiers, mods(false, false, false, true));
+            assert_eq!(p.key, "s", "input was {input}");
+        }
+    }
+
+    #[test]
+    fn parse_plus_style_alt_aliases() {
+        for input in ["Alt+F4", "Option+F4", "Opt+F4"] {
+            let p = parse_key_binding(input).unwrap();
+            assert_eq!(p.modifiers, mods(false, false, true, false));
+            assert_eq!(p.key, "F4");
+        }
+    }
+
+    #[test]
+    fn parse_plus_style_bare_key() {
+        let p = parse_key_binding("Escape").unwrap();
+        assert_eq!(p.modifiers, Modifiers::default());
+        assert_eq!(p.key, "Escape");
+
+        let p = parse_key_binding("a").unwrap();
+        assert_eq!(p.key, "a");
+    }
+
+    #[test]
+    fn parse_plus_style_rejects_multiple_keys() {
+        assert!(parse_key_binding("Ctrl+A+B").is_none());
+    }
+
+    #[test]
+    fn parse_plus_style_rejects_empty_parts() {
+        assert!(parse_key_binding("Ctrl++T").is_none());
+        assert!(parse_key_binding("+T").is_none());
+    }
+
+    #[test]
+    fn parse_empty_or_whitespace() {
+        assert!(parse_key_binding("").is_none());
+        assert!(parse_key_binding("   ").is_none());
+    }
+
+    #[test]
+    fn parse_round_trip_vim_and_plus_agree() {
+        let vim = parse_key_binding("<C-S-t>").unwrap();
+        let plus = parse_key_binding("Ctrl+Shift+T").unwrap();
+        assert_eq!(vim, plus);
+    }
+
+    #[test]
+    fn render_save_macos_vs_other() {
+        let acc = Accelerator {
+            id: AcceleratorId::new("app.save"),
+            binding: KeyBinding::Save,
+            scope: AcceleratorScope::Global,
+            label: None,
+        };
+        assert_eq!(render_accelerator(&acc, Platform::Macos), "⌘S");
+        assert_eq!(render_accelerator(&acc, Platform::Windows), "Ctrl+S");
+        assert_eq!(render_accelerator(&acc, Platform::Linux), "Ctrl+S");
+        assert_eq!(render_accelerator(&acc, Platform::Tui), "Ctrl+S");
+    }
+
+    #[test]
+    fn render_redo_uses_shift_on_every_platform() {
+        let b = KeyBinding::Redo;
+        assert_eq!(render_binding(&b, Platform::Macos), "⌘⇧Z");
+        assert_eq!(render_binding(&b, Platform::Linux), "Ctrl+Shift+Z");
+    }
+
+    #[test]
+    fn render_literal_parses_and_formats() {
+        let b = KeyBinding::Literal("<C-S-t>".into());
+        assert_eq!(render_binding(&b, Platform::Linux), "Ctrl+Shift+T");
+        assert_eq!(render_binding(&b, Platform::Macos), "⌃⇧T");
+    }
+
+    #[test]
+    fn render_literal_plus_style_round_trips() {
+        let b = KeyBinding::Literal("Ctrl+Shift+T".into());
+        assert_eq!(render_binding(&b, Platform::Linux), "Ctrl+Shift+T");
+    }
+
+    #[test]
+    fn render_literal_unparseable_falls_back_to_raw() {
+        let b = KeyBinding::Literal("gibberish".into());
+        assert_eq!(render_binding(&b, Platform::Linux), "gibberish");
+    }
+
+    #[test]
+    fn render_uses_explicit_label_when_set() {
+        let acc = Accelerator {
+            id: AcceleratorId::new("custom"),
+            binding: KeyBinding::Literal("<C-S-t>".into()),
+            scope: AcceleratorScope::Global,
+            label: Some("Secret handshake".into()),
+        };
+        assert_eq!(
+            render_accelerator(&acc, Platform::Linux),
+            "Secret handshake"
+        );
+    }
+
+    #[test]
+    fn accelerator_serde_round_trip() {
+        let acc = Accelerator {
+            id: AcceleratorId::new("editor.save"),
+            binding: KeyBinding::Save,
+            scope: AcceleratorScope::Global,
+            label: None,
+        };
+        let json = serde_json::to_string(&acc).unwrap();
+        let back: Accelerator = serde_json::from_str(&json).unwrap();
+        assert_eq!(acc, back);
+
+        let acc = Accelerator {
+            id: AcceleratorId::new("terminal.maximize"),
+            binding: KeyBinding::Literal("<C-S-t>".into()),
+            scope: AcceleratorScope::Mode("normal".into()),
+            label: Some("Maximize terminal".into()),
+        };
+        let json = serde_json::to_string(&acc).unwrap();
+        let back: Accelerator = serde_json::from_str(&json).unwrap();
+        assert_eq!(acc, back);
+    }
+}

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -1,0 +1,134 @@
+//! The `Backend` trait — one implementation per platform target.
+//!
+//! Each backend (TUI, GTK, Win-GUI, and eventually macOS) implements this
+//! trait. Apps write render code once, parameterised over `<B: Backend>`,
+//! and every supported platform rasterises the same primitive descriptions
+//! with platform-native drawing + input.
+//!
+//! See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §4 for design rationale.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::event::{Rect, UiEvent, Viewport};
+use crate::{
+    Accelerator, AcceleratorId, ActivityBar, Form, ListView, Palette, StatusBar, TabBar, Terminal,
+    TextDisplay, TreeView,
+};
+
+/// One implementation per platform. TUI, GTK, Win-GUI, and (v1.x) macOS.
+pub trait Backend {
+    // ─── Frame + viewport ──────────────────────────────────────────────
+    /// Viewport geometry in native units. TUI: cells; GTK/Win-GUI/macOS:
+    /// pixel-ish units with `scale` set to the DPI ratio.
+    fn viewport(&self) -> Viewport;
+
+    /// Begin a frame. Backends may set up the render target, clear, etc.
+    fn begin_frame(&mut self, viewport: Viewport);
+
+    /// Flush the current frame to screen.
+    fn end_frame(&mut self);
+
+    // ─── Events + keybindings ──────────────────────────────────────────
+    /// Drain all queued native events. Returns a fully-translated
+    /// `Vec<UiEvent>` ready for app dispatch. Never blocks.
+    fn poll_events(&mut self) -> Vec<UiEvent>;
+
+    /// Block for up to `timeout` waiting for at least one event. Returns an
+    /// empty `Vec` on timeout. Used by apps that don't want to busy-poll.
+    fn wait_events(&mut self, timeout: Duration) -> Vec<UiEvent>;
+
+    /// Register an accelerator. The backend stores it and emits
+    /// [`UiEvent::Accelerator`] when the native key event matches.
+    fn register_accelerator(&mut self, acc: &Accelerator);
+
+    /// Remove a previously-registered accelerator.
+    fn unregister_accelerator(&mut self, id: &AcceleratorId);
+
+    // ─── Platform services ─────────────────────────────────────────────
+    /// Clipboard, file dialogs, notifications, URL opening, platform name.
+    fn services(&self) -> &dyn PlatformServices;
+
+    // ─── Drawing — one method per primitive ────────────────────────────
+    //
+    // Implementations are thin wrappers around each backend crate's
+    // internal `pub fn draw_*` free functions. Example:
+    //
+    //   impl Backend for WinBackend {
+    //       fn draw_tree(&mut self, rect: Rect, tree: &TreeView) {
+    //           quadraui_win::draw_tree(self.ctx(), tree, self.theme(), rect);
+    //       }
+    //       // ... one per primitive
+    //   }
+    //
+    // Adding a primitive is a breaking change to this trait — intentional
+    // (see `BACKEND_TRAIT_PROPOSAL.md` §4). Backends opt in to the new
+    // primitive in the same PR that adds it to the trait.
+    fn draw_tree(&mut self, rect: Rect, tree: &TreeView);
+    fn draw_list(&mut self, rect: Rect, list: &ListView);
+    fn draw_form(&mut self, rect: Rect, form: &Form);
+    fn draw_palette(&mut self, rect: Rect, palette: &Palette);
+    fn draw_status_bar(&mut self, rect: Rect, bar: &StatusBar);
+    fn draw_tab_bar(&mut self, rect: Rect, bar: &TabBar);
+    fn draw_activity_bar(&mut self, rect: Rect, bar: &ActivityBar);
+    fn draw_terminal(&mut self, rect: Rect, term: &Terminal);
+    fn draw_text_display(&mut self, rect: Rect, td: &TextDisplay);
+}
+
+/// Platform services the backend exposes to apps: clipboard, file dialogs,
+/// notifications, URL opening.
+pub trait PlatformServices {
+    fn clipboard(&self) -> &dyn Clipboard;
+
+    /// Show a native file-open dialog (blocking). Returns `None` if the
+    /// user cancelled. TUI backends return `None` and write a hint to
+    /// stderr; apps should provide an in-TUI picker instead.
+    fn show_file_open_dialog(&self, opts: FileDialogOptions) -> Option<PathBuf>;
+
+    /// Show a native file-save dialog.
+    fn show_file_save_dialog(&self, opts: FileDialogOptions) -> Option<PathBuf>;
+
+    /// Dispatch a system notification.
+    fn send_notification(&self, n: Notification);
+
+    /// Open a URL in the platform's default browser.
+    fn open_url(&self, url: &str);
+
+    /// Platform identifier — matches the `BackendNative.backend` field.
+    /// One of `"tui"`, `"gtk"`, `"win-gui"`, `"macos"`.
+    fn platform_name(&self) -> &'static str;
+}
+
+/// Trait object-safe clipboard access.
+pub trait Clipboard {
+    /// Read the current clipboard contents as plain text. `None` on
+    /// empty / non-text clipboard or platform error.
+    fn read_text(&self) -> Option<String>;
+
+    /// Write plain text to the clipboard.
+    fn write_text(&self, text: &str);
+}
+
+/// Options for [`PlatformServices::show_file_open_dialog`] and
+/// [`PlatformServices::show_file_save_dialog`].
+#[derive(Debug, Clone, Default)]
+pub struct FileDialogOptions {
+    /// Dialog window title.
+    pub title: Option<String>,
+    /// Suggested starting directory.
+    pub initial_dir: Option<PathBuf>,
+    /// Suggested file name (save dialog only).
+    pub initial_filename: Option<String>,
+    /// File type filters — `(display_name, &[ext])` pairs.
+    pub filters: Vec<(String, Vec<String>)>,
+}
+
+/// A system notification request.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub title: String,
+    pub body: String,
+    /// Whether the notification is high-priority (e.g. error). Backends
+    /// may use this to pick a different icon or sound.
+    pub urgent: bool,
+}

--- a/quadraui/src/event.rs
+++ b/quadraui/src/event.rs
@@ -1,0 +1,308 @@
+//! Backend-neutral event type.
+//!
+//! `UiEvent` is what flows up from the active [`Backend`][crate::Backend] to
+//! the app each frame. Backends translate their native input events (crossterm
+//! key events, GTK signals, Win32 messages, Cocoa responder methods) into
+//! `UiEvent` variants; apps dispatch on the variant without caring which
+//! backend produced it.
+//!
+//! ## Invariants
+//!
+//! Every `UiEvent` satisfies:
+//! - `Debug + Clone + PartialEq + Serialize + Deserialize` — see
+//!   `BACKEND_TRAIT_PROPOSAL.md` §2 for rationale.
+//! - Owned data only — no closures, no non-`'static` references. A `UiEvent`
+//!   can be logged, replayed, serialised for a plugin boundary, or sent
+//!   across threads with no ceremony.
+//! - Mouse events carry `Option<WidgetId>` — the backend does hit-testing
+//!   **before** emitting so apps dispatch on widget identity.
+//!
+//! ## Event routing — hit-test vs focus
+//!
+//! | Class | Routed by |
+//! |---|---|
+//! | Mouse (`MouseDown`, `MouseUp`, `MouseMoved`, `MouseEntered`, `MouseLeft`, `DoubleClick`, `Scroll`) | Hit-test at cursor position |
+//! | Keyboard (`KeyPressed`, `CharTyped`) | Focus |
+//! | Accelerator | [`AcceleratorScope`][crate::AcceleratorScope] |
+//! | Window (`WindowResized`, `WindowClose`, `WindowFocused`, `DpiChanged`) | Application-global |
+//! | `FilesDropped` | Hit-test at drop position |
+//! | `ClipboardPaste` | Focus |
+//!
+//! The consequence apps rely on: **scroll wheel events dispatch to the
+//! widget under the cursor, regardless of which widget has keyboard focus.**
+//! Native convention on Win32, Cocoa, and GTK.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::types::{Modifiers, WidgetId};
+use crate::{
+    ActivityBarEvent, FormEvent, ListViewEvent, PaletteEvent, StatusBarEvent, TabBarEvent,
+    TerminalEvent, TextDisplayEvent, TreeEvent,
+};
+
+// ─── Supporting types ───────────────────────────────────────────────────────
+
+/// Keyboard key identity — a printable character or a named non-printable.
+///
+/// Apps that want every keystroke (text inputs, terminal passthrough) match
+/// on `Key`; apps that only want keybindings prefer [`UiEvent::Accelerator`]
+/// which already resolves the key + modifiers to a declared
+/// [`AcceleratorId`][crate::AcceleratorId].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Key {
+    /// Printable character (after keyboard layout resolution).
+    Char(char),
+    /// Named non-printable key.
+    Named(NamedKey),
+}
+
+/// Non-printable keyboard keys that have a stable cross-platform name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NamedKey {
+    Escape,
+    Tab,
+    BackTab,
+    Enter,
+    Backspace,
+    Delete,
+    Insert,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Up,
+    Down,
+    Left,
+    Right,
+    /// Function key 1-24. Values outside that range are backend-specific
+    /// (emitted via [`UiEvent::BackendNative`] instead).
+    F(u8),
+    /// Caps lock, num lock, scroll lock — typically consumed by the OS but
+    /// emitted for completeness.
+    CapsLock,
+    NumLock,
+    ScrollLock,
+    /// Menu / application key (right-click keyboard equivalent).
+    Menu,
+}
+
+/// Mouse button identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+    /// Back / forward navigation buttons on 5-button mice.
+    X1,
+    X2,
+    /// Backend-specific button index.
+    Other(u8),
+}
+
+/// Bitmask of mouse buttons currently held down during a `MouseMoved` event.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ButtonMask {
+    #[serde(default)]
+    pub left: bool,
+    #[serde(default)]
+    pub right: bool,
+    #[serde(default)]
+    pub middle: bool,
+}
+
+/// Cursor position in the backend's native units.
+///
+/// - **TUI**: whole cells (typically integral values stored as `f32`).
+/// - **GTK**: device-independent pixels (Cairo / Pango coordinates).
+/// - **Win-GUI**: Direct2D DIPs.
+/// - **macOS** (planned): Core Graphics points.
+///
+/// Apps that need to convert should use [`Viewport::scale`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Point {
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// Scroll-wheel delta. Positive `y` = scroll up (toward the top of content).
+/// Backends that report scroll in lines/cells/pixels normalise to their
+/// native unit before emitting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScrollDelta {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl ScrollDelta {
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// Rectangular region in the backend's native units.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl Rect {
+    pub const fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub fn contains(&self, p: Point) -> bool {
+        p.x >= self.x && p.x < self.x + self.width && p.y >= self.y && p.y < self.y + self.height
+    }
+}
+
+/// Backend viewport dimensions in native units.
+///
+/// TUI: `width` and `height` are cell counts; `scale = 1.0`.
+/// GTK / Win-GUI / macOS: pixel-ish units with `scale` = DPI ratio.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Viewport {
+    pub width: f32,
+    pub height: f32,
+    pub scale: f32,
+}
+
+impl Viewport {
+    pub const fn new(width: f32, height: f32, scale: f32) -> Self {
+        Self {
+            width,
+            height,
+            scale,
+        }
+    }
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self::new(80.0, 24.0, 1.0)
+    }
+}
+
+/// Backend-specific event the crate couldn't normalise.
+///
+/// The `payload` is an opaque backend-defined string (typically JSON). Apps
+/// ignore this variant by default; only special-case it when a specific
+/// platform feature is required.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BackendNativeEvent {
+    /// Backend identifier — matches [`Backend::platform_name`][crate::PlatformServices::platform_name].
+    pub backend: String,
+    /// Short name for the native event, e.g. `"win32.wm_sizing"`.
+    pub kind: String,
+    /// Opaque payload. Apps choosing to handle this variant parse it
+    /// per-backend.
+    pub payload: String,
+}
+
+// ─── The main event enum ────────────────────────────────────────────────────
+
+/// Everything a user (or platform) can do that an app might care about.
+///
+/// Produced by [`Backend::poll_events`][crate::Backend::poll_events] every
+/// frame; consumed by app dispatch code.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum UiEvent {
+    // ── Input ───────────────────────────────────────────────────────────
+    /// A declared accelerator fired. The backend matched a
+    /// [`KeyBinding`][crate::KeyBinding] to one of the app's registered
+    /// accelerators and is reporting the ID.
+    Accelerator(crate::AcceleratorId, Modifiers),
+
+    /// A raw key was pressed. Routes to the focused widget. Apps that only
+    /// want keybindings should prefer `Accelerator` — the backend handles
+    /// match-and-dispatch for them.
+    KeyPressed {
+        key: Key,
+        modifiers: Modifiers,
+        repeat: bool,
+    },
+
+    /// A character was typed (IME-composed, ready for insertion). Routes
+    /// to the focused text-input widget.
+    CharTyped(char),
+
+    // ── Mouse ──────────────────────────────────────────────────────────
+    MouseDown {
+        widget: Option<WidgetId>,
+        button: MouseButton,
+        position: Point,
+        modifiers: Modifiers,
+    },
+    MouseUp {
+        widget: Option<WidgetId>,
+        button: MouseButton,
+        position: Point,
+    },
+    MouseMoved {
+        position: Point,
+        buttons: ButtonMask,
+    },
+    MouseEntered {
+        widget: WidgetId,
+    },
+    MouseLeft {
+        widget: WidgetId,
+    },
+    DoubleClick {
+        widget: Option<WidgetId>,
+        position: Point,
+    },
+    /// Scroll-wheel event. **Routes to the widget under the cursor, not
+    /// to the focused widget.** This is the native convention on every
+    /// major desktop platform.
+    Scroll {
+        widget: Option<WidgetId>,
+        delta: ScrollDelta,
+        position: Point,
+    },
+
+    // ── Window ─────────────────────────────────────────────────────────
+    WindowResized {
+        viewport: Viewport,
+    },
+    WindowClose,
+    WindowFocused(bool),
+    DpiChanged(f32),
+
+    // ── Drops + paste ──────────────────────────────────────────────────
+    FilesDropped {
+        paths: Vec<PathBuf>,
+        position: Point,
+    },
+    ClipboardPaste(String),
+
+    // ── Primitive-specific events bubble up by WidgetId ───────────────
+    Tree(WidgetId, TreeEvent),
+    List(WidgetId, ListViewEvent),
+    Form(WidgetId, FormEvent),
+    Palette(WidgetId, PaletteEvent),
+    TabBar(WidgetId, TabBarEvent),
+    StatusBar(WidgetId, StatusBarEvent),
+    ActivityBar(WidgetId, ActivityBarEvent),
+    Terminal(WidgetId, TerminalEvent),
+    TextDisplay(WidgetId, TextDisplayEvent),
+
+    // ── Escape hatch ───────────────────────────────────────────────────
+    /// Backend-specific event the crate couldn't normalise. Apps ignore
+    /// unless they want to special-case a platform.
+    BackendNative(BackendNativeEvent),
+}

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -86,6 +86,14 @@
 pub mod primitives;
 pub mod types;
 
+// ── Phase B.1: Backend trait + UiEvent + Accelerator ────────────────────────
+// See quadraui/docs/BACKEND_TRAIT_PROPOSAL.md for design. These modules add
+// the unified cross-backend surface alongside the existing per-backend
+// free-function draw pattern; no migration yet (that's Phase B.2).
+pub mod accelerator;
+pub mod backend;
+pub mod event;
+
 pub use primitives::activity_bar::{ActivityBar, ActivityBarEvent, ActivityItem};
 pub use primitives::form::{FieldKind, Form, FormEvent, FormField};
 pub use primitives::list::{ListItem, ListView, ListViewEvent};
@@ -98,6 +106,17 @@ pub use primitives::tree::{TreeEvent, TreeRow, TreeView};
 pub use types::{
     Badge, Color, Decoration, Icon, Modifiers, SelectionMode, StyledSpan, StyledText, TreePath,
     TreeStyle, WidgetId,
+};
+
+// Phase B.1 re-exports.
+pub use accelerator::{
+    parse_key_binding, render_accelerator, render_binding, Accelerator, AcceleratorId,
+    AcceleratorScope, KeyBinding, ParsedBinding, Platform,
+};
+pub use backend::{Backend, Clipboard, FileDialogOptions, Notification, PlatformServices};
+pub use event::{
+    BackendNativeEvent, ButtonMask, Key, MouseButton, NamedKey, Point, Rect, ScrollDelta, UiEvent,
+    Viewport,
 };
 
 /// Crate version, sourced from `Cargo.toml`.


### PR DESCRIPTION
## Summary

Phase B.1 of the Backend trait migration per `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md`. Pure additive scaffolding — no vimcode runtime change, no migration, no behavior difference for users.

Blocks #169 (Postman-class validation app). Phase B.2 (terminal-maximize pilot migration) lands as the next PR and will be the first real consumer of these types.

## What's in the box

- **`UiEvent` enum** (quadraui/src/event.rs, ~270 LOC) — backend-neutral event data. Covers input (Accelerator, KeyPressed, CharTyped), mouse (Down/Up/Moved/Entered/Left/DoubleClick/Scroll — all with `Option<WidgetId>` from backend-side hit-test), window events, file drops, clipboard paste, primitive-specific events re-wrapped, and a BackendNative escape hatch.
- **`Accelerator` + dual-format parser** (quadraui/src/accelerator.rs, ~420 LOC) — 13 universal bindings (Save/Copy/Undo/Find/…) that render platform-appropriately (`⌘⇧T` on macOS, `Ctrl+Shift+T` elsewhere), plus `KeyBinding::Literal(String)` that accepts **both** vim-style (`<C-S-t>`) and plus-style (`Ctrl+Shift+T`) input — first character dispatches. Per Decision 5 (C).
- **`Backend` trait** (quadraui/src/backend.rs, ~130 LOC) — frame lifecycle, event polling, accelerator registration, services access, and 9 per-primitive `draw_*` methods per Decision 2 (B — no AnyPrimitive enum).

## Design decisions this PR implements

Per §9 of BACKEND_TRAIT_PROPOSAL.md, all resolved 2026-04-22:

| # | Decision | Chosen |
|---|---|---|
| 1 | Overall shape | A — ship `UiEvent` + `Accelerator` + `Backend` together |
| 2 | Drawing in trait | B — per-primitive methods, explicit impls required |
| 3 | Phase B.1 scope | A — scaffolding-alone, no feature migration bundled |
| 4 | B.2 pilot | A — terminal maximize (follow-up PR) |
| 5 | `Literal` format | C — parser accepts both vim-style and plus-style |

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --no-default-features -- -D warnings` clean
- [x] `cargo test --workspace --no-default-features` — 5295/0/19 (+22 from accelerator parser tests)
- [x] Quadraui tests: 24 → 46
- [x] No vimcode behaviour change (stubs are unused until Phase B.2)

## Follow-up

Phase B.2 — migrate terminal maximize (#34) onto `Accelerator::Global` + `UiEvent::Accelerator` dispatch. Target: -60 LOC net as duplicated per-backend key matchers / handlers / action-dispatch arms collapse into a single registration + match arm. Separate PR.

## References

- Design doc: `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md`
- App patterns: `quadraui/docs/APP_ARCHITECTURE.md`
- Backend implementer pitfalls: `docs/NATIVE_GUI_LESSONS.md`
- Related issues: #169 (Postman), #167 (scrollbar z-order), #168 (pixel mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)