### PR TITLE
Phase B.2: terminal-maximize accelerator migration (#169 enabler)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -6,7 +6,7 @@
 > source of truth for individual tasks — this file points at the current
 > wave and explains how to resume.
 >
-> **Last updated:** 2026-04-22 (Session 320 — Phase B.2 sketch landed: see `BACKEND_TRAIT_PROPOSAL.md` §11)
+> **Last updated:** 2026-04-22 (Session 321 — Phase B.2 shipped: engine-owned accelerator registry)
 
 ---
 
@@ -53,7 +53,7 @@ test app; target downstream apps include a cross-platform k8s dashboard
 | Phase A.9 — `TextEditor` + `BufferView` adapter | ⬜ Deferred (not needed for vimcode) | — | `quadraui-phase-a9-*` | any — biggest stage |
 | **Optional Win-GUI parity** — see "Win-GUI parity scope" section below | ⬜ Optional | — | `quadraui-phase-a*-win` | Windows |
 | **Phase B.1** — `UiEvent` + `Accelerator` + `Backend` trait scaffolding | ✅ Done | _tbd_ | `quadraui-phase-b1-backend-trait` | any |
-| Phase B.2 — pilot migration: terminal maximize to `Accelerator::Global` | ⬜ **Next — sketch first** (see below) | — | `quadraui-phase-b2-maximize-pilot` | any |
+| **Phase B.2** — pilot migration: terminal maximize to `Accelerator::Global` | ✅ Done | _tbd_ | `quadraui-phase-b2-maximize-pilot` | any |
 | Phase B.3 — layout primitives (`Panel`, `Split`, `Tabs`, `MenuBar`, `Modal`) | ⬜ After B.2 | — | `quadraui-phase-b3-layout` | any |
 | Phase B.4+ — migrate remaining vimcode subsystems to UiEvent | ⬜ After B.3 | — | `quadraui-phase-b4-*` | any |
 | Phase B.5 — Postman-class validation app (#169) | ⬜ After B.3/B.4 | — | _new workspace member_ | any |

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 22, 2026 (Session 319 — Phase B.1 Backend trait scaffold) | **Tests:** 5295 total (full `cargo test --workspace --no-default-features`); vimcode 5249 + quadraui 46
+**Last updated:** Apr 22, 2026 (Session 321 — Phase B.2 terminal-maximize accelerator migration) | **Tests:** 5305 total (full `cargo test --workspace --no-default-features`); vimcode 5259 + quadraui 46
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -26,6 +26,70 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 321 — Phase B.2 terminal-maximize accelerator migration:**
+
+1. **Engine-owned accelerator registry.** New `src/core/engine/mod.rs`
+   types + methods: `RegisteredAccelerator { acc, parsed }`,
+   `UiEventContext { terminal_cols, terminal_max_rows }`, and on
+   `Engine`: `accelerators: Vec<RegisteredAccelerator>` field;
+   `register_accelerator`, `unregister_accelerator`,
+   `match_accelerator`, `handle_ui_event`,
+   `register_default_accelerators`. Re-exports
+   `quadraui::{Accelerator, AcceleratorId, AcceleratorScope,
+   KeyBinding, UiEvent}`. `Engine::new()` registers
+   `"terminal.toggle_maximize"` from
+   `settings.panel_keys.toggle_terminal_maximize`.
+2. **Departs from §11 Q3.** The "backend owns the event loop" shape
+   was more invasive than one accelerator justified (~400 LOC of
+   back-translation for keys not yet migrated). Final shape:
+   engine owns the registry; backends call
+   `engine.match_accelerator(...)` synchronously from existing
+   key handlers. Same B.1 types exercised; zero event-loop
+   disruption. Backend-owned events can land in B.4 when
+   accelerator count grows.
+3. **Six sites migrated.** `src/tui_main/mod.rs:2888` (terminal-panel
+   early-intercept) and `:3586` (EngineAction arm). `src/gtk/mod.rs:
+   1386` (EventControllerKey closure) and `:7219`
+   (`Msg::ToggleTerminalMaximize` handler). `src/win_gui/mod.rs:1832`
+   (WndProc cascade) and `:4586` + `:6178` (EngineAction handlers).
+   Each `matches_*_key(&pk.toggle_terminal_maximize, ...)` + per-
+   backend flip+resize sequence collapses to
+   `engine.match_accelerator(...)` + `engine.handle_ui_event(...)`.
+4. **`EngineAction::ToggleTerminalMaximize` kept.** The ex command
+   `:TerminalMaximize` and toolbar click still return this action;
+   their handlers just route through `engine.handle_ui_event` now.
+   Full collapse is B.4 work.
+5. **10 new integration tests** in `tests/accelerator_registry.rs`:
+   default registration, match positive/negative, case
+   insensitivity, toggle + idempotent re-toggle,
+   unknown-accelerator no-op, re-register-same-id-replaces,
+   unregister-removes, non-Global-scope filtering. Workspace total
+   5295 → 5305.
+6. **`src/lib.rs` re-exports `quadraui`** so integration tests and
+   future downstream consumers pin to the version vimcode is built
+   against.
+7. **§11 updated** with "B.2 implementation notes" subsection
+   documenting the engine-owned vs backend-owned choice + rationale.
+   PLAN.md stage table marks B.2 Done.
+8. **Quality gates all pass.** `cargo fmt`, `cargo clippy
+   --no-default-features -- -D warnings`, `cargo clippy -- -D
+   warnings` (GTK), full `cargo test --workspace
+   --no-default-features` 5305/0/19. Win-GUI syntax manually
+   reviewed (cargo check --features win-gui fails on Linux due to
+   pre-existing `windows-future-0.2.1` incompat; user must verify
+   Windows build).
+9. **Net diff:** +339 / –74 across 6 files. Payoff materialises at
+   accelerator #2: each new binding adds ~1 line per backend.
+10. **Awaiting smoke test.** Verify: Ctrl+Shift+T still toggles
+    terminal maximize in TUI (kitty / modern alacritty without tmux,
+    since tmux strips Shift bit per §11 spike findings) and GTK.
+    `:TerminalMaximize` ex command still works. Toolbar maximize/
+    unmaximize button still works.
+11. **Path B landing.** Branch `quadraui-phase-b2-maximize-pilot`
+    off develop; PR expected after smoke test.
+
+---
 
 **Session 319 — Phase B.1 Backend trait scaffolding (#169 blocker):**
 

--- a/quadraui/docs/BACKEND_TRAIT_PROPOSAL.md
+++ b/quadraui/docs/BACKEND_TRAIT_PROPOSAL.md
@@ -1090,6 +1090,109 @@ lower-commitment alternative. (a) is fine if the spike code is
 considered too entangled with the diagnostic harness to extract
 cleanly.
 
+### B.2 implementation notes (2026-04-22) — engine-owned registry
+
+When B.2 was implemented, the "backend owns the event loop" shape
+from §11 Q3 proved more invasive than the maximize pilot justified.
+The final shape is **engine-owned registry, backend lookup-on-demand**.
+Same user-visible B.1 types (`Accelerator`, `UiEvent`,
+`KeyBinding`, `parse_key_binding`); same deletion of per-backend
+`matches_*_key` checks for the migrated keybinding; smaller blast
+radius to vimcode's three event loops.
+
+**What changed from §11 Q3:**
+
+§11 described a full event-loop swap: backend owns crossterm /
+GTK signals / WndProc, drains via `poll_events()`, emits typed
+`UiEvent`s for everything, apps consume in a `for ev in
+backend.poll_events()` loop. For B.2 with exactly one accelerator
+to migrate, that meant translating every crossterm mouse + paste +
+focus event into a faithful `UiEvent` variant and back-translating
+`UiEvent::KeyPressed` to vimcode's existing `(key_name, unicode,
+ctrl)` shape for all the keys *not* yet migrated — ~400 lines of
+back-translation code to light up one accelerator.
+
+The simpler shape implemented in B.2:
+
+```rust
+// Engine (src/core/engine/mod.rs)
+pub struct RegisteredAccelerator { acc, parsed }
+pub struct UiEventContext { terminal_cols, terminal_max_rows }
+impl Engine {
+    pub fn register_accelerator(&mut self, acc: Accelerator);
+    pub fn unregister_accelerator(&mut self, id: &AcceleratorId);
+    pub fn match_accelerator(&self, ctrl, shift, alt, key_char, is_tab, is_space, is_escape) -> Option<AcceleratorId>;
+    pub fn handle_ui_event(&mut self, ev: UiEvent, ctx: UiEventContext);
+    pub fn register_default_accelerators(&mut self);  // called from Engine::new()
+}
+```
+
+At each backend's existing key-handler site, the `matches_*_key`
+check becomes an `engine.match_accelerator(...)` lookup; on match,
+the backend fills a `UiEventContext` (terminal cols + max-rows in
+native units) and calls `engine.handle_ui_event(...)`. The engine
+owns the flip-and-resize sequence; backends keep their native
+viewport math because it genuinely differs (TUI: cells; GTK/Win-GUI:
+`floor(px/lh)`).
+
+**What this buys:**
+
+- **One registry, three backends.** Adding the second accelerator
+  in B.4 costs exactly one line (`register_accelerator(...)` in
+  `register_default_accelerators`) + one arm in `handle_ui_event`.
+  No new `matches_*_key` literal in any backend.
+- **Zero event-loop disruption.** TUI's `event_loop`, GTK's Relm4
+  dispatcher, and Win-GUI's WndProc all stay exactly as they are.
+  The migration sits inside existing key-handler blocks.
+- **No back-translation cost.** Keys that aren't registered
+  accelerators flow through legacy paths unchanged. No
+  `UiEvent::KeyPressed → (key_name, unicode, ctrl)` shim.
+
+**What it defers:**
+
+- **Full backend-owned event loops** (§11 Q3's recommendation).
+  Real payoff is in B.4 when accelerator count grows; B.2's one
+  accelerator doesn't justify the rewrite cost. Each stack of
+  `engine.match_accelerator(...)` calls across the three backends
+  could still migrate to `backend.poll_events()` later, and the
+  engine-owned registry is the natural home for that logic.
+- **`Backend` trait impls for vimcode's own backends.** There are
+  no `TuiBackend` / `GtkBackend` / `WinBackend` structs in vimcode
+  after B.2. The trait from B.1 is exercised by the spike (and
+  available to Postman / future consumers); vimcode uses the
+  engine-owned helpers directly. When B.5 kicks off the Postman
+  validation app it'll write its own `PostmanTuiBackend` etc.,
+  which is when the trait's value proposition lands.
+- **Live rebinding.** `register_accelerator` replaces prior
+  entries by id (tested), but there's no hook on settings reload
+  yet. Rebinding requires restart. B.4+ can add a
+  `Engine::rebuild_accelerators()` hook alongside
+  `rebuild_user_keymaps()`.
+
+**Five sites migrated:**
+
+| File | Before | After |
+|---|---|---|
+| `src/tui_main/mod.rs:2888` (terminal-panel key intercept) | `matches_tui_key(&pk.toggle_terminal_maximize, ...)` + 8-line flip+resize | `engine.match_accelerator(...)` + `engine.handle_ui_event(...)` |
+| `src/tui_main/mod.rs:3586` (EngineAction dispatch arm) | 9-line flip+resize sequence | `engine.handle_ui_event(...)` |
+| `src/gtk/mod.rs:1386` (EventControllerKey closure) | `matches_gtk_key(&pk.toggle_terminal_maximize, ...)` | `engine.match_accelerator(...)` + `sender.input(Msg::ToggleTerminalMaximize)` |
+| `src/gtk/mod.rs:7219` (`Msg::ToggleTerminalMaximize` handler) | 14-line flip+resize sequence | `engine.handle_ui_event(...)` |
+| `src/win_gui/mod.rs:1832` (WndProc cascade) | `if ctrl && shift && !alt && key.key_name == "t"` + inline flip+resize | `engine.match_accelerator(...)` + `engine.handle_ui_event(...)` |
+| `src/win_gui/mod.rs:4586` + `:6178` (EngineAction handlers) | 15 + 10 line flip+resize sequences | `engine.handle_ui_event(...)` at both |
+
+**LOC delta:** +339 / -74 across 6 files. Net +265 for one
+accelerator. The payoff shows up at accelerator #2: each new
+registered binding adds ~1 line per backend (just the `match` arm on
+`AcceleratorId` if backends dispatch per-id, or zero lines if the
+backend routes all matched accelerators through a single
+`Msg::DispatchAccelerator`).
+
+**Integration tests:** `tests/accelerator_registry.rs` — 10 tests
+covering default registration, match positive/negative, case
+insensitivity, idempotent toggle, unknown-accelerator no-op,
+re-register-same-id replaces, unregister removes, scope filtering
+(non-Global rejected).
+
 ### What §11 explicitly does NOT decide
 
 - **Focus model.** Per §6.4, deferred. B.2 only uses `Accelerator::Global`,

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -35,6 +35,13 @@ use std::borrow::Cow;
 
 use super::{Cursor, Mode};
 
+// ─── Phase B.2: accelerator registry + UiEvent dispatch ──────────────────────
+// Engine owns the registered accelerators + the dispatch entry point. Backends
+// look up matches via [`Engine::match_accelerator`] in their existing key
+// handlers, then call [`Engine::handle_ui_event`] with viewport context.
+// See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §11.
+pub use quadraui::{Accelerator, AcceleratorId, AcceleratorScope, KeyBinding, UiEvent};
+
 /// High bit marker for synthetic "Non-Public Members" group var_refs.
 /// Real DAP adapters use sequential integers that never set this bit.
 const SYNTHETIC_NON_PUBLIC_MASK: u64 = 0x8000_0000_0000_0000;
@@ -74,6 +81,37 @@ pub enum EngineAction {
     QuitWithError,
     /// Open a URL in the default browser (validated as safe by the engine).
     OpenUrl(String),
+}
+
+/// One entry in the engine's accelerator registry. Caches the parsed form of
+/// `acc.binding` so [`Engine::match_accelerator`] can do a tight comparison
+/// without re-parsing per keypress.
+#[derive(Debug)]
+pub struct RegisteredAccelerator {
+    pub acc: Accelerator,
+    /// Cached parse of `acc.binding` in vimcode's native form
+    /// (`(ctrl, shift, alt, key_name)`). `None` if the binding string is
+    /// unparseable; the registration is still kept so `unregister_accelerator`
+    /// can find it by id.
+    pub parsed: Option<(bool, bool, bool, String)>,
+}
+
+/// Per-call backend context that [`Engine::handle_ui_event`] needs to act on
+/// terminal-oriented accelerators. Backends fill this in from their own native
+/// viewport math (TUI: cells; GTK/Win-GUI: pixel/line_height).
+///
+/// See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §11 for the rationale on
+/// why the engine doesn't compute these itself: the per-backend chrome
+/// arithmetic uses native units, and `PanelChromeDesc` is the right place
+/// for backends to derive `terminal_max_rows`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UiEventContext {
+    /// Terminal width in columns/cells (TUI: crossterm size; GTK/Win-GUI:
+    /// `floor(width_px / char_width)`).
+    pub terminal_cols: u16,
+    /// Maximum content rows the terminal panel can fill when maximized.
+    /// Backends compute via `PanelChromeDesc::max_panel_content_rows()`.
+    pub terminal_max_rows: u16,
 }
 
 /// Row-count description of everything that surrounds a bottom panel (terminal,
@@ -3276,6 +3314,13 @@ pub struct Engine {
     file_watcher_rx: Option<std::sync::mpsc::Receiver<notify::Result<notify::Event>>>,
     /// Paths that have been reported as modified but not yet handled (avoids duplicate dialogs).
     pub file_watcher_pending: HashSet<PathBuf>,
+
+    // ─── Phase B.2: accelerator registry ─────────────────────────────────
+    /// Registered accelerators. Backends call [`Engine::match_accelerator`]
+    /// from their existing key handlers to look up matches; on a match
+    /// they dispatch via [`Engine::handle_ui_event`] with backend-supplied
+    /// viewport context. See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §11.
+    pub accelerators: Vec<RegisteredAccelerator>,
 }
 
 impl Engine {
@@ -3667,9 +3712,12 @@ impl Engine {
             file_watcher: None,
             file_watcher_rx: None,
             file_watcher_pending: HashSet::new(),
+            accelerators: Vec::new(),
         };
         // Initialize file watcher
         engine.init_file_watcher();
+        // Register Phase B.2 accelerators (terminal maximize for now).
+        engine.register_default_accelerators();
         // If vscode mode is configured, start in Insert mode with menu visible
         if engine.is_vscode_mode() {
             engine.mode = Mode::Insert;
@@ -3803,6 +3851,131 @@ impl Engine {
     /// Returns true if there are any completed notifications waiting to be dismissed.
     pub fn has_done_notifications(&self) -> bool {
         self.notifications.iter().any(|n| n.done)
+    }
+
+    // ─── Phase B.2: accelerator registry + UiEvent dispatch ──────────────
+    //
+    // Backends look up matches synchronously via `match_accelerator` from
+    // their existing key handlers. On a match they fill a `UiEventContext`
+    // (terminal cols + max-rows in their native units) and call
+    // `handle_ui_event`. The engine owns the dispatch — no per-backend
+    // duplication of the toggle + resize sequence.
+    //
+    // See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §11 for the design,
+    // including why this is engine-owned (not backend-owned) for B.2.
+
+    /// Register an accelerator. Re-registration with the same id replaces
+    /// the prior entry (for live rebinding).
+    pub fn register_accelerator(&mut self, acc: Accelerator) {
+        let parsed = match &acc.binding {
+            KeyBinding::Literal(s) => crate::core::settings::parse_key_binding_named(s),
+            // Universal bindings render platform-appropriately; for vimcode
+            // (Linux/Windows; macOS not yet a backend) Ctrl+letter is the
+            // canonical form. parse_key_binding_named handles the vim-style
+            // strings.
+            KeyBinding::Save => crate::core::settings::parse_key_binding_named("<C-s>"),
+            KeyBinding::Open => crate::core::settings::parse_key_binding_named("<C-o>"),
+            KeyBinding::New => crate::core::settings::parse_key_binding_named("<C-n>"),
+            KeyBinding::Close => crate::core::settings::parse_key_binding_named("<C-w>"),
+            KeyBinding::Copy => crate::core::settings::parse_key_binding_named("<C-c>"),
+            KeyBinding::Cut => crate::core::settings::parse_key_binding_named("<C-x>"),
+            KeyBinding::Paste => crate::core::settings::parse_key_binding_named("<C-v>"),
+            KeyBinding::Undo => crate::core::settings::parse_key_binding_named("<C-z>"),
+            KeyBinding::Redo => crate::core::settings::parse_key_binding_named("<C-S-z>"),
+            KeyBinding::SelectAll => crate::core::settings::parse_key_binding_named("<C-a>"),
+            KeyBinding::Find => crate::core::settings::parse_key_binding_named("<C-f>"),
+            KeyBinding::Replace => crate::core::settings::parse_key_binding_named("<C-h>"),
+            KeyBinding::Quit => crate::core::settings::parse_key_binding_named("<C-q>"),
+        };
+        self.accelerators.retain(|r| r.acc.id != acc.id);
+        self.accelerators
+            .push(RegisteredAccelerator { acc, parsed });
+    }
+
+    /// Remove a previously-registered accelerator by id. No-op if not found.
+    /// Public API surface for live rebinding; no internal callers in B.2 yet
+    /// (the integration test suite covers the behaviour).
+    #[allow(dead_code)]
+    pub fn unregister_accelerator(&mut self, id: &AcceleratorId) {
+        self.accelerators.retain(|r| &r.acc.id != id);
+    }
+
+    /// Look up the registered accelerator (if any) that matches the given
+    /// modifier+key combo. First-match-wins, scope-filtered (only `Global`
+    /// scope is honoured in B.2; `Widget` and `Mode` scope are deferred to
+    /// B.3+).
+    ///
+    /// Backends pass the same `(ctrl, shift, alt, key_char, is_tab,
+    /// is_space, is_escape)` shape they already use with
+    /// [`crate::render::matches_key_binding`], so this slots into existing
+    /// key-handler sites without translation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn match_accelerator(
+        &self,
+        ctrl: bool,
+        shift: bool,
+        alt: bool,
+        key_char: Option<char>,
+        is_tab: bool,
+        is_space: bool,
+        is_escape: bool,
+    ) -> Option<AcceleratorId> {
+        for reg in &self.accelerators {
+            if !matches!(reg.acc.scope, AcceleratorScope::Global) {
+                continue;
+            }
+            let Some((want_ctrl, want_shift, want_alt, ref key_name)) = reg.parsed else {
+                continue;
+            };
+            if want_ctrl != ctrl || want_shift != shift || want_alt != alt {
+                continue;
+            }
+            let matches = match key_name.as_str() {
+                "Tab" | "tab" => is_tab,
+                "Space" | "space" => is_space,
+                "Escape" | "Esc" => is_escape,
+                s if s.chars().count() == 1 => {
+                    let want = s.chars().next().unwrap().to_ascii_lowercase();
+                    key_char
+                        .map(|c| c.to_ascii_lowercase() == want)
+                        .unwrap_or(false)
+                }
+                _ => false,
+            };
+            if matches {
+                return Some(reg.acc.id.clone());
+            }
+        }
+        None
+    }
+
+    /// Dispatch a `UiEvent` to its engine-side handler. B.2 supports exactly
+    /// one accelerator (`"terminal.toggle_maximize"`); other arms are no-ops
+    /// for now.
+    pub fn handle_ui_event(&mut self, ev: UiEvent, ctx: UiEventContext) {
+        if let UiEvent::Accelerator(id, _mods) = ev {
+            if id.as_str() == "terminal.toggle_maximize" {
+                self.toggle_terminal_maximize();
+                let effective = self.effective_terminal_panel_rows(ctx.terminal_max_rows);
+                if self.terminal_panes.is_empty() {
+                    self.terminal_new_tab(ctx.terminal_cols, effective);
+                } else {
+                    self.terminal_resize(ctx.terminal_cols, effective);
+                }
+            }
+        }
+    }
+
+    /// Register the built-in accelerators that ship with vimcode. Called
+    /// once from `Engine::new()`. New accelerators added in B.4+ go here.
+    /// Public so integration tests can re-run after resetting settings.
+    pub fn register_default_accelerators(&mut self) {
+        self.register_accelerator(Accelerator {
+            id: AcceleratorId::new("terminal.toggle_maximize"),
+            binding: KeyBinding::Literal(self.settings.panel_keys.toggle_terminal_maximize.clone()),
+            scope: AcceleratorScope::Global,
+            label: Some("Toggle terminal maximize".into()),
+        });
     }
 }
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -1382,10 +1382,27 @@ impl SimpleComponent for App {
                                         sender.input(Msg::ToggleTerminal);
                                         return gtk4::glib::Propagation::Stop;
                                     }
-                                    // Ctrl+Shift+T: toggle terminal maximize (panel fills editor area)
-                                    if matches_gtk_key(&pk.toggle_terminal_maximize, key, modifier) {
-                                        sender.input(Msg::ToggleTerminalMaximize);
-                                        return gtk4::glib::Propagation::Stop;
+                                    // Phase B.2: accelerator-registry dispatch.
+                                    // Replaces per-binding `matches_gtk_key`
+                                    // checks with a single registry lookup.
+                                    {
+                                        let eng = engine.borrow();
+                                        if let Some(id) = eng.match_accelerator(
+                                            modifier.contains(gdk::ModifierType::CONTROL_MASK),
+                                            modifier.contains(gdk::ModifierType::SHIFT_MASK),
+                                            modifier.contains(gdk::ModifierType::ALT_MASK),
+                                            key.to_unicode(),
+                                            key == gdk::Key::Tab
+                                                || key == gdk::Key::ISO_Left_Tab,
+                                            key.to_unicode() == Some(' '),
+                                            key == gdk::Key::Escape,
+                                        ) {
+                                            drop(eng);
+                                            if id.as_str() == "terminal.toggle_maximize" {
+                                                sender.input(Msg::ToggleTerminalMaximize);
+                                            }
+                                            return gtk4::glib::Propagation::Stop;
+                                        }
                                     }
                                     // Terminal key routing: when terminal has focus, all keys
                                     // are forwarded as PTY bytes without going to the engine.
@@ -7217,21 +7234,20 @@ impl App {
                 self.draw_needed.set(true);
             }
             Msg::ToggleTerminalMaximize => {
-                let target = self.terminal_target_maximize_rows();
-                let cols = self.terminal_cols();
-                {
-                    let mut engine = self.engine.borrow_mut();
-                    engine.toggle_terminal_maximize();
-                }
-                // Create a pane if none exists; otherwise resize the existing
-                // PTY to the new effective content rows.
-                let needs_new_tab = self.engine.borrow().terminal_panes.is_empty();
-                let effective = self.engine.borrow().effective_terminal_panel_rows(target);
-                if needs_new_tab {
-                    self.engine.borrow_mut().terminal_new_tab(cols, effective);
-                } else {
-                    self.engine.borrow_mut().terminal_resize(cols, effective);
-                }
+                // Phase B.2: route through engine's UiEvent dispatch — same
+                // path as the keybinding above + the EngineAction handler
+                // + the toolbar click handler.
+                let ctx = crate::core::engine::UiEventContext {
+                    terminal_cols: self.terminal_cols(),
+                    terminal_max_rows: self.terminal_target_maximize_rows(),
+                };
+                self.engine.borrow_mut().handle_ui_event(
+                    crate::core::engine::UiEvent::Accelerator(
+                        crate::core::engine::AcceleratorId::new("terminal.toggle_maximize"),
+                        quadraui::Modifiers::default(),
+                    ),
+                    ctx,
+                );
                 self.draw_needed.set(true);
             }
             Msg::OpenTerminalAt(dir) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@
 pub mod core;
 pub mod icons;
 
+// Re-export quadraui so integration tests + downstream consumers pin to the
+// same version vimcode is built against.
+pub use quadraui;
+
 // Convenience re-exports so integration tests can write `use vimcode_core::Engine` etc.
 pub use core::buffer::Buffer;
 pub use core::cursor::Cursor;

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -2884,19 +2884,41 @@ fn event_loop(
                             continue;
                         }
 
-                        // Ctrl+Shift+T: toggle terminal maximize (panel fills editor area)
-                        if matches_tui_key(&pk.toggle_terminal_maximize, code, mods) {
+                        // Phase B.2: keybinding accelerator dispatch.
+                        // Engine owns the registry + dispatch. Backends just
+                        // look up + supply native viewport ctx.
+                        if let Some(acc_id) = engine.match_accelerator(
+                            mods.contains(KeyModifiers::CONTROL),
+                            mods.contains(KeyModifiers::SHIFT),
+                            mods.contains(KeyModifiers::ALT),
+                            match code {
+                                KeyCode::Char(c) => Some(c),
+                                _ => None,
+                            },
+                            matches!(code, KeyCode::Tab),
+                            matches!(code, KeyCode::Char(' ')),
+                            matches!(code, KeyCode::Esc),
+                        ) {
                             let size = terminal.size().ok();
-                            let screen_h = size.map(|s| s.height).unwrap_or(24);
-                            let cols = size.map(|s| s.width).unwrap_or(80);
-                            engine.toggle_terminal_maximize();
-                            let target = terminal_target_maximize_rows_tui(engine, screen_h);
-                            let effective = engine.effective_terminal_panel_rows(target);
-                            if engine.terminal_panes.is_empty() {
-                                engine.terminal_new_tab(cols, effective);
-                            } else {
-                                engine.terminal_resize(cols, effective);
-                            }
+                            let ctx = crate::core::engine::UiEventContext {
+                                terminal_cols: size.map(|s| s.width).unwrap_or(80),
+                                terminal_max_rows: terminal_target_maximize_rows_tui(
+                                    engine,
+                                    size.map(|s| s.height).unwrap_or(24),
+                                ),
+                            };
+                            engine.handle_ui_event(
+                                crate::core::engine::UiEvent::Accelerator(
+                                    acc_id,
+                                    quadraui::Modifiers {
+                                        ctrl: mods.contains(KeyModifiers::CONTROL),
+                                        shift: mods.contains(KeyModifiers::SHIFT),
+                                        alt: mods.contains(KeyModifiers::ALT),
+                                        cmd: false,
+                                    },
+                                ),
+                                ctx,
+                            );
                             needs_redraw = true;
                             continue;
                         }
@@ -3584,17 +3606,28 @@ fn event_loop(
                             engine.terminal_new_tab(cols, engine.session.terminal_panel_rows);
                             needs_redraw = true;
                         } else if action == EngineAction::ToggleTerminalMaximize {
+                            // Phase B.2: route through engine's UiEvent
+                            // dispatch — same path as the keybinding above.
+                            // This site stays because :TerminalMaximize ex
+                            // command + toolbar click still return the
+                            // EngineAction; B.4 may collapse them too.
                             let size = terminal.size().ok();
-                            let screen_h = size.map(|s| s.height).unwrap_or(24);
-                            let cols = size.map(|s| s.width).unwrap_or(80);
-                            engine.toggle_terminal_maximize();
-                            let target = terminal_target_maximize_rows_tui(engine, screen_h);
-                            let effective = engine.effective_terminal_panel_rows(target);
-                            if engine.terminal_panes.is_empty() {
-                                engine.terminal_new_tab(cols, effective);
-                            } else {
-                                engine.terminal_resize(cols, effective);
-                            }
+                            let ctx = crate::core::engine::UiEventContext {
+                                terminal_cols: size.map(|s| s.width).unwrap_or(80),
+                                terminal_max_rows: terminal_target_maximize_rows_tui(
+                                    engine,
+                                    size.map(|s| s.height).unwrap_or(24),
+                                ),
+                            };
+                            engine.handle_ui_event(
+                                crate::core::engine::UiEvent::Accelerator(
+                                    crate::core::engine::AcceleratorId::new(
+                                        "terminal.toggle_maximize",
+                                    ),
+                                    quadraui::Modifiers::default(),
+                                ),
+                                ctx,
+                            );
                             needs_redraw = true;
                         } else if let EngineAction::RunInTerminal(cmd) = action {
                             let cols = terminal.size().ok().map(|s| s.width).unwrap_or(80);

--- a/src/win_gui/mod.rs
+++ b/src/win_gui/mod.rs
@@ -1829,8 +1829,24 @@ fn on_key_down(wparam: WPARAM, _lparam: LPARAM) -> bool {
             return false;
         }
 
-        // ── Ctrl-Shift-T: toggle terminal maximize ───────────────────────
-        if ctrl && shift && !alt && (key.key_name == "t" || key.key_name == "T") {
+        // Phase B.2: accelerator-registry dispatch.
+        // Replaces inline `if ctrl && shift && key == "t"` checks with a
+        // single registry lookup. Other accelerators added in B.4+ flow
+        // through the same path with no per-binding code.
+        let key_char = if key.key_name.chars().count() == 1 {
+            key.key_name.chars().next()
+        } else {
+            None
+        };
+        if let Some(id) = state.engine.match_accelerator(
+            ctrl,
+            shift,
+            alt,
+            key_char,
+            key.key_name == "Tab",
+            key_char == Some(' '),
+            key.key_name == "Escape",
+        ) {
             let mut rc = RECT::default();
             unsafe {
                 let _ = GetClientRect(state.hwnd, &mut rc);
@@ -1839,14 +1855,22 @@ fn on_key_down(wparam: WPARAM, _lparam: LPARAM) -> bool {
             let height = (rc.bottom - rc.top) as f32;
             let cols = ((width - state.sidebar.total_width()) / state.char_width) as u16;
             let lh = state.line_height.max(1.0);
-            let target = win_gui_terminal_target_maximize_rows(&state.engine, height, lh);
-            state.engine.toggle_terminal_maximize();
-            let effective = state.engine.effective_terminal_panel_rows(target);
-            if state.engine.terminal_panes.is_empty() {
-                state.engine.terminal_new_tab(cols, effective);
-            } else {
-                state.engine.terminal_resize(cols, effective);
-            }
+            let ctx = crate::core::engine::UiEventContext {
+                terminal_cols: cols,
+                terminal_max_rows: win_gui_terminal_target_maximize_rows(&state.engine, height, lh),
+            };
+            state.engine.handle_ui_event(
+                crate::core::engine::UiEvent::Accelerator(
+                    id,
+                    quadraui::Modifiers {
+                        ctrl,
+                        shift,
+                        alt,
+                        cmd: false,
+                    },
+                ),
+                ctx,
+            );
             unsafe {
                 let _ = InvalidateRect(Some(state.hwnd), None, false);
             }
@@ -4584,6 +4608,8 @@ fn on_mouse_down(hwnd: HWND, lparam: LPARAM) {
                                     );
                                 }
                                 EngineAction::ToggleTerminalMaximize => {
+                                    // Phase B.2: route through engine's
+                                    // UiEvent dispatch.
                                     let cols = (rw_px / cw).floor() as u16;
                                     let lh = state.line_height.max(1.0);
                                     let mut rc = RECT::default();
@@ -4591,19 +4617,23 @@ fn on_mouse_down(hwnd: HWND, lparam: LPARAM) {
                                         let _ = GetClientRect(state.hwnd, &mut rc);
                                     }
                                     let height = (rc.bottom - rc.top) as f32;
-                                    let target = win_gui_terminal_target_maximize_rows(
-                                        &state.engine,
-                                        height,
-                                        lh,
+                                    let ctx = crate::core::engine::UiEventContext {
+                                        terminal_cols: cols,
+                                        terminal_max_rows: win_gui_terminal_target_maximize_rows(
+                                            &state.engine,
+                                            height,
+                                            lh,
+                                        ),
+                                    };
+                                    state.engine.handle_ui_event(
+                                        crate::core::engine::UiEvent::Accelerator(
+                                            crate::core::engine::AcceleratorId::new(
+                                                "terminal.toggle_maximize",
+                                            ),
+                                            quadraui::Modifiers::default(),
+                                        ),
+                                        ctx,
                                     );
-                                    state.engine.toggle_terminal_maximize();
-                                    let effective =
-                                        state.engine.effective_terminal_panel_rows(target);
-                                    if state.engine.terminal_panes.is_empty() {
-                                        state.engine.terminal_new_tab(cols, effective);
-                                    } else {
-                                        state.engine.terminal_resize(cols, effective);
-                                    }
                                 }
                                 _ => {}
                             }
@@ -6176,17 +6206,21 @@ fn handle_action(engine: &mut Engine, action: EngineAction) -> bool {
             false
         }
         EngineAction::ToggleTerminalMaximize => {
-            // The standalone dispatcher has no access to the Win32 client rect.
-            // Since the panel size is now derived at render time from
-            // `Engine::effective_terminal_panel_rows(target)` and the next
-            // WM_PAINT cycle will supply the right target, we just flip the
-            // flag here — WM_PAINT will handle the actual resize.
-            let cols = 80;
-            engine.toggle_terminal_maximize();
-            let rows = engine.session.terminal_panel_rows;
-            if engine.terminal_panes.is_empty() {
-                engine.terminal_new_tab(cols, rows);
-            }
+            // Standalone dispatcher (palette/action handler) — no client
+            // rect access here. Phase B.2: route through engine's UiEvent
+            // dispatch with terminal_max_rows=0; WM_PAINT picks up the
+            // saved-rows fallback via `effective_terminal_panel_rows`.
+            let ctx = crate::core::engine::UiEventContext {
+                terminal_cols: 80,
+                terminal_max_rows: 0,
+            };
+            engine.handle_ui_event(
+                crate::core::engine::UiEvent::Accelerator(
+                    crate::core::engine::AcceleratorId::new("terminal.toggle_maximize"),
+                    quadraui::Modifiers::default(),
+                ),
+                ctx,
+            );
             false
         }
         EngineAction::RunInTerminal(cmd) => {

--- a/tests/accelerator_registry.rs
+++ b/tests/accelerator_registry.rs
@@ -1,0 +1,198 @@
+//! Phase B.2 — accelerator registry + UiEvent dispatch.
+//!
+//! Validates the engine-owned accelerator pattern that B.2 ships:
+//! `register_accelerator` → `match_accelerator` → `handle_ui_event`. See
+//! `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §11 for the design.
+
+mod common;
+use common::*;
+use vimcode_core::core::engine::{
+    Accelerator, AcceleratorId, AcceleratorScope, KeyBinding, UiEvent, UiEventContext,
+};
+use vimcode_core::quadraui::Modifiers;
+
+#[test]
+fn default_registry_has_terminal_maximize() {
+    let e = engine_with("");
+    let ids: Vec<&str> = e.accelerators.iter().map(|r| r.acc.id.as_str()).collect();
+    assert!(
+        ids.contains(&"terminal.toggle_maximize"),
+        "default accelerators should include terminal.toggle_maximize, got: {ids:?}"
+    );
+}
+
+#[test]
+fn match_accelerator_finds_default_binding() {
+    let e = engine_with("");
+    // Default binding is <C-S-t>; press Ctrl+Shift+T.
+    let id = e.match_accelerator(true, true, false, Some('t'), false, false, false);
+    assert_eq!(
+        id.as_ref().map(|i| i.as_str()),
+        Some("terminal.toggle_maximize")
+    );
+}
+
+#[test]
+fn match_accelerator_rejects_wrong_modifiers() {
+    let e = engine_with("");
+    // Without Shift: should not match the default <C-S-t> binding.
+    assert!(e
+        .match_accelerator(true, false, false, Some('t'), false, false, false)
+        .is_none());
+    // Without Ctrl: should not match.
+    assert!(e
+        .match_accelerator(false, true, false, Some('t'), false, false, false)
+        .is_none());
+    // Wrong key: should not match.
+    assert!(e
+        .match_accelerator(true, true, false, Some('q'), false, false, false)
+        .is_none());
+}
+
+#[test]
+fn match_accelerator_case_insensitive_letter() {
+    let e = engine_with("");
+    // Both 'T' and 't' should match — the parser lowercases internally.
+    let lower = e.match_accelerator(true, true, false, Some('t'), false, false, false);
+    let upper = e.match_accelerator(true, true, false, Some('T'), false, false, false);
+    assert!(lower.is_some());
+    assert!(upper.is_some());
+    assert_eq!(lower, upper);
+}
+
+#[test]
+fn handle_ui_event_toggles_maximize_and_grows_panel() {
+    let mut e = engine_with("");
+    e.session.terminal_panel_rows = 12;
+    assert!(!e.terminal_maximized);
+
+    let ctx = UiEventContext {
+        terminal_cols: 80,
+        terminal_max_rows: 30,
+    };
+    e.handle_ui_event(
+        UiEvent::Accelerator(
+            AcceleratorId::new("terminal.toggle_maximize"),
+            Modifiers {
+                ctrl: true,
+                shift: true,
+                alt: false,
+                cmd: false,
+            },
+        ),
+        ctx,
+    );
+
+    assert!(e.terminal_maximized);
+    assert!(e.terminal_open);
+    assert_eq!(
+        e.session.terminal_panel_rows, 12,
+        "saved rows must not change"
+    );
+}
+
+#[test]
+fn handle_ui_event_idempotent_toggle() {
+    let mut e = engine_with("");
+    e.session.terminal_panel_rows = 10;
+    let ctx = UiEventContext {
+        terminal_cols: 80,
+        terminal_max_rows: 30,
+    };
+    let ev = || {
+        UiEvent::Accelerator(
+            AcceleratorId::new("terminal.toggle_maximize"),
+            Modifiers::default(),
+        )
+    };
+
+    e.handle_ui_event(ev(), ctx);
+    assert!(e.terminal_maximized);
+
+    e.handle_ui_event(ev(), ctx);
+    assert!(
+        !e.terminal_maximized,
+        "second toggle should restore non-maximized state"
+    );
+}
+
+#[test]
+fn handle_ui_event_unknown_accelerator_is_noop() {
+    let mut e = engine_with("");
+    e.handle_ui_event(
+        UiEvent::Accelerator(
+            AcceleratorId::new("nonexistent.action"),
+            Modifiers::default(),
+        ),
+        UiEventContext {
+            terminal_cols: 80,
+            terminal_max_rows: 30,
+        },
+    );
+    assert!(!e.terminal_maximized);
+    assert!(!e.terminal_open);
+}
+
+#[test]
+fn register_accelerator_is_idempotent_by_id() {
+    let mut e = engine_with("");
+    let before = e.accelerators.len();
+
+    // Register the same id twice — should replace, not duplicate.
+    e.register_accelerator(Accelerator {
+        id: AcceleratorId::new("terminal.toggle_maximize"),
+        binding: KeyBinding::Literal("<C-A-m>".into()),
+        scope: AcceleratorScope::Global,
+        label: None,
+    });
+    e.register_accelerator(Accelerator {
+        id: AcceleratorId::new("terminal.toggle_maximize"),
+        binding: KeyBinding::Literal("<C-A-n>".into()),
+        scope: AcceleratorScope::Global,
+        label: None,
+    });
+
+    assert_eq!(
+        e.accelerators.len(),
+        before,
+        "re-registering same id must not duplicate"
+    );
+    // Latest binding wins.
+    assert!(e
+        .match_accelerator(true, false, true, Some('n'), false, false, false)
+        .is_some());
+    assert!(e
+        .match_accelerator(true, false, true, Some('m'), false, false, false)
+        .is_none());
+}
+
+#[test]
+fn unregister_accelerator_removes_match() {
+    let mut e = engine_with("");
+    assert!(e
+        .match_accelerator(true, true, false, Some('t'), false, false, false)
+        .is_some());
+
+    e.unregister_accelerator(&AcceleratorId::new("terminal.toggle_maximize"));
+
+    assert!(e
+        .match_accelerator(true, true, false, Some('t'), false, false, false)
+        .is_none());
+}
+
+#[test]
+fn match_accelerator_skips_non_global_scopes() {
+    let mut e = engine_with("");
+    e.unregister_accelerator(&AcceleratorId::new("terminal.toggle_maximize"));
+
+    // Mode-scoped registration — B.2 only honours Global, so this must NOT match.
+    e.register_accelerator(Accelerator {
+        id: AcceleratorId::new("test.mode_scoped"),
+        binding: KeyBinding::Literal("<C-S-t>".into()),
+        scope: AcceleratorScope::Mode("normal".into()),
+        label: None,
+    });
+    assert!(e
+        .match_accelerator(true, true, false, Some('t'), false, false, false)
+        .is_none());
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -23,6 +23,11 @@ pub fn engine_with(text: &str) -> Engine {
     // Reset mode + keymaps in case Engine::new() loaded VSCode mode from disk.
     e.mode = Mode::Normal;
     e.rebuild_user_keymaps();
+    // Re-register Phase B.2 accelerators against the reset settings so the
+    // registry uses the default `<C-S-t>` binding (not whatever the user's
+    // real settings.json had on disk).
+    e.accelerators.clear();
+    e.register_default_accelerators();
     if !text.is_empty() {
         e.buffer_mut().insert(0, text);
     }


### PR DESCRIPTION
## Summary

- **Engine-owned accelerator registry** + `Engine::handle_ui_event` dispatch — the first real consumer of the B.1 `Accelerator` / `UiEvent` / `KeyBinding` types
- **Six sites migrated** across TUI / GTK / Win-GUI: each `matches_*_key(&pk.toggle_terminal_maximize, …)` + per-backend flip+resize sequence collapses to `engine.match_accelerator(...)` + `engine.handle_ui_event(...)`
- **+10 integration tests** in `tests/accelerator_registry.rs` covering match positive/negative, scope filtering, idempotent toggle, register/unregister semantics

Workspace tests: **5305/0/19** (baseline 5295). All quality gates pass on TUI + GTK; Win-GUI cargo build can't run on Linux due to pre-existing `windows-future-0.2.1` incompat — needs Windows smoke test.

## Departure from §11 Q3

Original §11 sketch had the backend own the event loop (`for ev in backend.poll_events()`). For B.2 with one accelerator, that meant translating every crossterm/GTK/Win32 event to UiEvent variants AND back-translating `UiEvent::KeyPressed` to vimcode's existing `(key_name, unicode, ctrl)` shape for every key not yet migrated — ~400 LOC of plumbing for one keybinding.

Final shape: **engine owns the registry**; backends call `engine.match_accelerator(...)` synchronously from existing key-handler sites; on match, fill a `UiEventContext` (cols + max-rows in their native units) and call `engine.handle_ui_event(...)`. Same B.1 types exercised; zero event-loop disruption; backend-owned events lands in B.4 when accelerator count grows enough to justify the rework.

Documented in `BACKEND_TRAIT_PROPOSAL.md` §11 "B.2 implementation notes" subsection along with the deferred work (full backend-owned events, `Backend` trait impls for vimcode itself, live rebinding, full collapse of `EngineAction::ToggleTerminalMaximize`).

## Smoke-test results (gnome-terminal Linux)

- **TUI** — `Ctrl+Shift+T` intercepted by gnome-terminal (pre-existing limitation per §11 spike findings; works in kitty/foot/alacritty-without-tmux). `:TerminalMaximize` ex command works correctly (toggle + resize). Toolbar maximize/unmaximize button works correctly.
- **GTK** — Ctrl+Shift+T toggles maximize correctly. Pre-existing #167 (scrollbar z-order on maximized terminal) still applies; deferred to B.3 (Panel primitive owns z-order).
- **Win-GUI** — code paths follow the same engine.handle_ui_event pattern as TUI/GTK; needs Windows smoke verification.

## Test plan

- [ ] Verify TUI `:TerminalMaximize` + toolbar button still toggle correctly (any terminal)
- [ ] Verify TUI Ctrl+Shift+T toggles in a terminal that doesn't intercept it (kitty / foot / alacritty no tmux)
- [ ] Verify GTK Ctrl+Shift+T toggles correctly + toolbar button works + `:TerminalMaximize` works
- [ ] Verify Win-GUI Ctrl+Shift+T toggles correctly on Windows (cannot test from Linux)
- [ ] `cargo test --workspace --no-default-features` — should be 5305/0/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)