### PR TITLE
Phase A.6b-win: Win-GUI status bar via quadraui

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -6,7 +6,7 @@
 > source of truth for individual tasks — this file points at the current
 > wave and explains how to resume.
 >
-> **Last updated:** 2026-04-22 (Session 321 — Phase B.2 shipped: engine-owned accelerator registry)
+> **Last updated:** 2026-04-23 (Session 322 — Phase A.6b-win shipped: Win-GUI status bar via quadraui)
 
 ---
 
@@ -802,12 +802,12 @@ optional polish — landing them brings Win-GUI up to feature parity
 with the Linux GTK side and demonstrates that the quadraui primitives
 work across all three rendering backends (Direct2D, Cairo, ratatui).
 
-| Optional stage | Adds | Linux reference | Estimated size |
-|----------------|------|-----------------|----------------|
-| A.6b-win | Win-GUI `quadraui_win::draw_status_bar` | `src/gtk/quadraui_gtk.rs::draw_status_bar` (~120 lines) + `src/gtk/draw.rs::draw_window_status_bar` wrapper (~30 lines) | ~200 lines |
-| A.6d-win | Win-GUI `quadraui_win::draw_tab_bar` | `src/gtk/quadraui_gtk.rs::draw_tab_bar` (~340 lines) | ~400 lines |
-| A.6f-win | Win-GUI `quadraui_win::draw_activity_bar` + native→DA atomic switchover | `src/gtk/quadraui_gtk.rs::draw_activity_bar` + `src/gtk/mod.rs` adapter / wiring (~500 lines total) | ~500 lines |
-| A.7-win | Win-GUI `quadraui_win::draw_terminal_cells` | `src/gtk/quadraui_gtk.rs::draw_terminal_cells` (~95 lines) + `src/gtk/draw.rs` wrapper (~25 lines) | ~150 lines |
+| Optional stage | Status | Adds | Linux reference | Estimated size |
+|----------------|--------|------|-----------------|----------------|
+| **A.6b-win** | ✅ Done | Win-GUI `quadraui_win::draw_status_bar` | `src/gtk/quadraui_gtk.rs::draw_status_bar` (~120 lines) + `src/gtk/draw.rs::draw_window_status_bar` wrapper (~30 lines) | ~200 lines (actual: +135/-76) |
+| A.6d-win | ⬜ Next | Win-GUI `quadraui_win::draw_tab_bar` | `src/gtk/quadraui_gtk.rs::draw_tab_bar` (~340 lines) | ~400 lines |
+| A.6f-win | ⬜ Pending | Win-GUI `quadraui_win::draw_activity_bar` + native→DA atomic switchover | `src/gtk/quadraui_gtk.rs::draw_activity_bar` + `src/gtk/mod.rs` adapter / wiring (~500 lines total) | ~500 lines |
+| A.7-win | ⬜ Pending | Win-GUI `quadraui_win::draw_terminal_cells` | `src/gtk/quadraui_gtk.rs::draw_terminal_cells` (~95 lines) + `src/gtk/draw.rs` wrapper (~25 lines) | ~150 lines |
 
 **Scope each as its own branch** following the established pattern
 (`quadraui-phase-a6b-status-bar-win`, etc.), one stage per commit,

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # VimCode Project State
 
-**Last updated:** Apr 22, 2026 (Session 321 — Phase B.2 terminal-maximize accelerator migration) | **Tests:** 5305 total (full `cargo test --workspace --no-default-features`); vimcode 5259 + quadraui 46
+**Last updated:** Apr 23, 2026 (Session 322 — Phase A.6b-win Win-GUI status bar via quadraui) | **Tests:** 5291 total (full `cargo test --workspace --no-default-features`); vimcode 5241 + quadraui 50
 
 > Feature documentation lives in **README.md**.
 > Per-session implementation notes through Session 279 are in **SESSION_HISTORY.md**.
@@ -26,6 +26,43 @@ When implementing a new key/command, add tests covering:
 ---
 
 ## Recent Work
+
+**Session 322 — Phase A.6b-win Win-GUI status bar via quadraui:**
+
+1. **`quadraui_win::draw_status_bar` rasteriser** (`src/win_gui/quadraui_win.rs:+95`).
+   Direct2D / DirectWrite counterpart to `quadraui_gtk::draw_status_bar`:
+   per-segment background fills, left-segments-from-left + right-segments-
+   right-aligned layout, `quadraui::StatusBar::fit_right_start_chars` policy
+   so low-priority right segments drop cleanly when the bar is too narrow
+   (#159 fix; previously they overflowed past the right edge).
+2. **Two call sites refactored.** Per-window status bar inside
+   `draw_editor_window` (`src/win_gui/draw.rs:696`, ~40 LOC of bespoke
+   segment-fill code deleted) and `draw_separated_status_line`
+   (`src/win_gui/draw.rs:920`, ~30 LOC deleted) both build the primitive
+   via `render::window_status_line_to_status_bar` and call the new
+   rasteriser. The global bottom bar (`draw_status_bar`, plain text only,
+   only fires when per-window mode is OFF) was left as-is — no parity gap.
+3. **Hit-test stays in lockstep.** `win_status_segment_hit_test`
+   (`src/win_gui/mod.rs:6597`) now applies the same
+   `fit_right_start_chars(width, MIN_GAP_CHARS=2)` so clicks on a dropped
+   right segment cannot fire. Same primitive + same policy on both sides
+   (rasteriser + hit-test) keeps them aligned without a cached zone map.
+4. **Bold attribute deferred.** Win-GUI's text path uses a single non-bold
+   `IDWriteTextFormat`; supporting bold needs a second format and would
+   make the hit-test diverge from the rasteriser (proportional vs char-
+   count widths). Pre-A.6b code didn't honour bold either. Documented in
+   the rasteriser doc comment.
+5. **Pre-existing clippy unblock** (separate commit `ce1f500`): six
+   `collapsible_match` warnings introduced by the Rust 1.95.0 toolchain
+   bump in `dap_ops.rs`, `ext_panel.rs`, `keys.rs`, `motions.rs`,
+   `vscode.rs`, `lsp.rs`. Mechanical `cargo clippy --fix`. Was blocking
+   the A.6b-win quality gate.
+6. **Two settings paper-cuts surfaced during smoke test, filed as
+   separate issues:** #173 (`status_line_above_terminal` label is
+   inverted from its behaviour — `true` keeps bars *inside* windows, not
+   above the terminal) and #174 (`:set window_status_line` rejected
+   because the ex command only accepts vim-style `:set wsl`). Both
+   pre-existing, neither blocks A.6b-win.
 
 **Session 321 — Phase B.2 terminal-maximize accelerator migration:**
 

--- a/src/core/engine/dap_ops.rs
+++ b/src/core/engine/dap_ops.rs
@@ -856,16 +856,15 @@ impl Engine {
             "x" | "d" => {
                 let sel = self.dap_sidebar_selected;
                 match self.dap_sidebar_section {
-                    DebugSidebarSection::Watch => {
+                    DebugSidebarSection::Watch
                         // Remove the selected watch expression.
-                        if sel < self.dap_watch_expressions.len() {
+                        if sel < self.dap_watch_expressions.len() => {
                             self.dap_remove_watch(sel);
                             let new_len = self.dap_watch_expressions.len();
                             if self.dap_sidebar_selected >= new_len && new_len > 0 {
                                 self.dap_sidebar_selected = new_len - 1;
                             }
                         }
-                    }
                     DebugSidebarSection::Breakpoints => {
                         // Remove the selected breakpoint.
                         if let Some((path, bp_idx)) = self.dap_bp_at_flat_index(sel) {

--- a/src/core/engine/ext_panel.rs
+++ b/src/core/engine/ext_panel.rs
@@ -2119,157 +2119,150 @@ impl Engine {
             "/" => {
                 self.settings_input_active = true;
             }
-            "j" | "Down" => {
-                if total > 0 {
-                    self.settings_selected = (self.settings_selected + 1).min(total - 1);
-                }
+            "j" | "Down" if total > 0 => {
+                self.settings_selected = (self.settings_selected + 1).min(total - 1);
             }
             "k" | "Up" => {
                 self.settings_selected = self.settings_selected.saturating_sub(1);
             }
-            "Tab" | "Return" | "Space" | "l" | "Right" | "h" | "Left" => {
-                if self.settings_selected < total {
-                    match &flat[self.settings_selected] {
-                        SettingsRow::CoreCategory(cat_idx) => {
-                            let cat_idx = *cat_idx;
-                            if matches!(key, "Tab" | "Return" | "Space")
-                                && cat_idx < self.settings_collapsed.len()
-                            {
-                                self.settings_collapsed[cat_idx] =
-                                    !self.settings_collapsed[cat_idx];
-                            }
+            "Tab" | "Return" | "Space" | "l" | "Right" | "h" | "Left"
+                if self.settings_selected < total =>
+            {
+                match &flat[self.settings_selected] {
+                    SettingsRow::CoreCategory(cat_idx) => {
+                        let cat_idx = *cat_idx;
+                        if matches!(key, "Tab" | "Return" | "Space")
+                            && cat_idx < self.settings_collapsed.len()
+                        {
+                            self.settings_collapsed[cat_idx] = !self.settings_collapsed[cat_idx];
                         }
-                        SettingsRow::CoreSetting(idx) => {
-                            let idx = *idx;
-                            let def = &SETTING_DEFS[idx];
-                            match &def.setting_type {
-                                SettingType::Bool => {
-                                    if matches!(key, "Return" | "Space") {
-                                        let cur = self.settings.get_value_str(def.key);
-                                        let new_val = if cur == "true" { "false" } else { "true" };
-                                        if self.settings.set_value_str(def.key, new_val).is_ok() {
+                    }
+                    SettingsRow::CoreSetting(idx) => {
+                        let idx = *idx;
+                        let def = &SETTING_DEFS[idx];
+                        match &def.setting_type {
+                            SettingType::Bool => {
+                                if matches!(key, "Return" | "Space") {
+                                    let cur = self.settings.get_value_str(def.key);
+                                    let new_val = if cur == "true" { "false" } else { "true" };
+                                    if self.settings.set_value_str(def.key, new_val).is_ok() {
+                                        let _ = self.settings.save();
+                                    }
+                                    // Lazy-init spell checker when toggled on
+                                    if def.key == "spell" && self.settings.spell {
+                                        self.ensure_spell_checker();
+                                    }
+                                }
+                            }
+                            SettingType::Enum(options) => {
+                                let forward = matches!(key, "Return" | "Space" | "l" | "Right");
+                                let backward = matches!(key, "h" | "Left");
+                                if forward || backward {
+                                    let cur = self.settings.get_value_str(def.key);
+                                    if let Some(pos) =
+                                        options.iter().position(|&o| o == cur.as_str())
+                                    {
+                                        let next = if forward {
+                                            (pos + 1) % options.len()
+                                        } else {
+                                            (pos + options.len() - 1) % options.len()
+                                        };
+                                        if self
+                                            .settings
+                                            .set_value_str(def.key, options[next])
+                                            .is_ok()
+                                        {
                                             let _ = self.settings.save();
                                         }
-                                        // Lazy-init spell checker when toggled on
-                                        if def.key == "spell" && self.settings.spell {
-                                            self.ensure_spell_checker();
+                                    }
+                                }
+                            }
+                            SettingType::DynamicEnum(options_fn) => {
+                                let forward = matches!(key, "Return" | "Space" | "l" | "Right");
+                                let backward = matches!(key, "h" | "Left");
+                                if forward || backward {
+                                    let options = options_fn();
+                                    let cur = self.settings.get_value_str(def.key);
+                                    if let Some(pos) = options.iter().position(|o| o == &cur) {
+                                        let next = if forward {
+                                            (pos + 1) % options.len()
+                                        } else {
+                                            (pos + options.len() - 1) % options.len()
+                                        };
+                                        if self
+                                            .settings
+                                            .set_value_str(def.key, &options[next])
+                                            .is_ok()
+                                        {
+                                            let _ = self.settings.save();
                                         }
                                     }
                                 }
-                                SettingType::Enum(options) => {
+                            }
+                            SettingType::Integer { .. } | SettingType::StringVal => {
+                                if matches!(key, "Return") {
+                                    self.settings_editing = Some(idx);
+                                    self.settings_edit_buf = self.settings.get_value_str(def.key);
+                                }
+                            }
+                            SettingType::BufferEditor => {
+                                if matches!(key, "Return" | "Space" | "l" | "Right") {
+                                    match def.key {
+                                        "keymaps" => self.open_keymaps_editor(),
+                                        "extension_registries" => self.open_registries_editor(),
+                                        _ => {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    SettingsRow::ExtCategory(name) => {
+                        if matches!(key, "Tab" | "Return" | "Space") {
+                            let collapsed = self
+                                .ext_settings_collapsed
+                                .entry(name.clone())
+                                .or_insert(false);
+                            *collapsed = !*collapsed;
+                        }
+                    }
+                    SettingsRow::ExtSetting(ext_name, ext_key) => {
+                        let ext_name = ext_name.clone();
+                        let ext_key = ext_key.clone();
+                        if let Some(def) = self.find_ext_setting_def(&ext_name, &ext_key) {
+                            match def.r#type.as_str() {
+                                "bool" => {
+                                    if matches!(key, "Return" | "Space") {
+                                        let cur = self.get_ext_setting(&ext_name, &ext_key);
+                                        let new_val = if cur == "true" { "false" } else { "true" };
+                                        self.set_ext_setting(&ext_name, &ext_key, new_val);
+                                    }
+                                }
+                                "enum" => {
                                     let forward = matches!(key, "Return" | "Space" | "l" | "Right");
                                     let backward = matches!(key, "h" | "Left");
-                                    if forward || backward {
-                                        let cur = self.settings.get_value_str(def.key);
+                                    if (forward || backward) && !def.options.is_empty() {
+                                        let cur = self.get_ext_setting(&ext_name, &ext_key);
                                         if let Some(pos) =
-                                            options.iter().position(|&o| o == cur.as_str())
+                                            def.options.iter().position(|o| o == &cur)
                                         {
                                             let next = if forward {
-                                                (pos + 1) % options.len()
+                                                (pos + 1) % def.options.len()
                                             } else {
-                                                (pos + options.len() - 1) % options.len()
+                                                (pos + def.options.len() - 1) % def.options.len()
                                             };
-                                            if self
-                                                .settings
-                                                .set_value_str(def.key, options[next])
-                                                .is_ok()
-                                            {
-                                                let _ = self.settings.save();
-                                            }
+                                            self.set_ext_setting(
+                                                &ext_name,
+                                                &ext_key,
+                                                &def.options[next],
+                                            );
                                         }
                                     }
                                 }
-                                SettingType::DynamicEnum(options_fn) => {
-                                    let forward = matches!(key, "Return" | "Space" | "l" | "Right");
-                                    let backward = matches!(key, "h" | "Left");
-                                    if forward || backward {
-                                        let options = options_fn();
-                                        let cur = self.settings.get_value_str(def.key);
-                                        if let Some(pos) = options.iter().position(|o| o == &cur) {
-                                            let next = if forward {
-                                                (pos + 1) % options.len()
-                                            } else {
-                                                (pos + options.len() - 1) % options.len()
-                                            };
-                                            if self
-                                                .settings
-                                                .set_value_str(def.key, &options[next])
-                                                .is_ok()
-                                            {
-                                                let _ = self.settings.save();
-                                            }
-                                        }
-                                    }
-                                }
-                                SettingType::Integer { .. } | SettingType::StringVal => {
+                                _ => {
                                     if matches!(key, "Return") {
-                                        self.settings_editing = Some(idx);
                                         self.settings_edit_buf =
-                                            self.settings.get_value_str(def.key);
-                                    }
-                                }
-                                SettingType::BufferEditor => {
-                                    if matches!(key, "Return" | "Space" | "l" | "Right") {
-                                        match def.key {
-                                            "keymaps" => self.open_keymaps_editor(),
-                                            "extension_registries" => self.open_registries_editor(),
-                                            _ => {}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        SettingsRow::ExtCategory(name) => {
-                            if matches!(key, "Tab" | "Return" | "Space") {
-                                let collapsed = self
-                                    .ext_settings_collapsed
-                                    .entry(name.clone())
-                                    .or_insert(false);
-                                *collapsed = !*collapsed;
-                            }
-                        }
-                        SettingsRow::ExtSetting(ext_name, ext_key) => {
-                            let ext_name = ext_name.clone();
-                            let ext_key = ext_key.clone();
-                            if let Some(def) = self.find_ext_setting_def(&ext_name, &ext_key) {
-                                match def.r#type.as_str() {
-                                    "bool" => {
-                                        if matches!(key, "Return" | "Space") {
-                                            let cur = self.get_ext_setting(&ext_name, &ext_key);
-                                            let new_val =
-                                                if cur == "true" { "false" } else { "true" };
-                                            self.set_ext_setting(&ext_name, &ext_key, new_val);
-                                        }
-                                    }
-                                    "enum" => {
-                                        let forward =
-                                            matches!(key, "Return" | "Space" | "l" | "Right");
-                                        let backward = matches!(key, "h" | "Left");
-                                        if (forward || backward) && !def.options.is_empty() {
-                                            let cur = self.get_ext_setting(&ext_name, &ext_key);
-                                            if let Some(pos) =
-                                                def.options.iter().position(|o| o == &cur)
-                                            {
-                                                let next = if forward {
-                                                    (pos + 1) % def.options.len()
-                                                } else {
-                                                    (pos + def.options.len() - 1)
-                                                        % def.options.len()
-                                                };
-                                                self.set_ext_setting(
-                                                    &ext_name,
-                                                    &ext_key,
-                                                    &def.options[next],
-                                                );
-                                            }
-                                        }
-                                    }
-                                    _ => {
-                                        if matches!(key, "Return") {
-                                            self.settings_edit_buf =
-                                                self.get_ext_setting(&ext_name, &ext_key);
-                                            self.ext_settings_editing = Some((ext_name, ext_key));
-                                        }
+                                            self.get_ext_setting(&ext_name, &ext_key);
+                                        self.ext_settings_editing = Some((ext_name, ext_key));
                                     }
                                 }
                             }

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -811,20 +811,18 @@ impl Engine {
                     }
                     return EngineAction::None;
                 }
-                '0' => {
-                    if self.count.is_some() {
-                        // Accumulate: 10, 20, 100, etc.
-                        let new_count = self.count.unwrap() * 10;
-                        if new_count > 10_000 {
-                            self.count = Some(10_000);
-                            self.message = "Count limited to 10,000".to_string();
-                        } else {
-                            self.count = Some(new_count);
-                        }
-                        return EngineAction::None;
+                '0' if self.count.is_some() => {
+                    // Accumulate: 10, 20, 100, etc.
+                    let new_count = self.count.unwrap() * 10;
+                    if new_count > 10_000 {
+                        self.count = Some(10_000);
+                        self.message = "Count limited to 10,000".to_string();
+                    } else {
+                        self.count = Some(new_count);
                     }
-                    // Fall through to handle '0' as "go to column 0" below
+                    return EngineAction::None;
                 }
+                // Fall through to handle '0' as "go to column 0" below
                 _ => {}
             }
         }
@@ -2410,16 +2408,15 @@ impl Engine {
                 }
                 _ => {}
             },
-            'd' => {
+            'd'
                 // This should not be reached - 'd' is now handled as pending_operator
                 // But keep for backward compatibility during transition
-                if unicode == Some('d') {
+                if unicode == Some('d') => {
                     let count = self.take_count();
                     self.start_undo_group();
                     self.delete_lines(count, changed);
                     self.finish_undo_group();
                 }
-            }
             '"' => {
                 // Register selection: "x sets selected_register for next operation
                 // Uppercase A-Z appends to lowercase register

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -1523,9 +1523,9 @@ impl Engine {
                     }
                 }
             }
-            'F' => {
+            'F'
                 // Find backward (inclusive): search left of cursor
-                if col > 0 {
+                if col > 0 => {
                     for i in (0..col).rev() {
                         let ch = self.buffer().content.char(line_start + i);
                         if ch == target {
@@ -1534,7 +1534,6 @@ impl Engine {
                         }
                     }
                 }
-            }
             't' => {
                 // Till forward (exclusive): stop before target
                 for i in (col + 1)..line_len {
@@ -1547,9 +1546,9 @@ impl Engine {
                     }
                 }
             }
-            'T' => {
+            'T'
                 // Till backward (exclusive): stop after target
-                if col > 0 {
+                if col > 0 => {
                     for i in (0..col).rev() {
                         let ch = self.buffer().content.char(line_start + i);
                         if ch == target {
@@ -1558,7 +1557,6 @@ impl Engine {
                         }
                     }
                 }
-            }
             _ => {}
         }
         // Character not found - cursor doesn't move (Vim behavior)

--- a/src/core/engine/vscode.rs
+++ b/src/core/engine/vscode.rs
@@ -127,11 +127,9 @@ impl Engine {
         match op {
             "Right" => self.move_right_insert(),
             "Left" => self.move_left(),
-            "Up" => {
-                if self.view().cursor.line > 0 {
-                    self.view_mut().cursor.line -= 1;
-                    self.clamp_cursor_col_insert();
-                }
+            "Up" if self.view().cursor.line > 0 => {
+                self.view_mut().cursor.line -= 1;
+                self.clamp_cursor_col_insert();
             }
             "Down" => {
                 let max_line = self.buffer().len_lines().saturating_sub(1);

--- a/src/core/lsp.rs
+++ b/src/core/lsp.rs
@@ -1509,13 +1509,11 @@ fn reader_thread(
             let is_error = json.get("error").is_some();
 
             match method.as_deref() {
-                Some("initialize") => {
-                    if !initialized_sent {
-                        if let Some(r) = result {
-                            if let Some(caps) = r.get("capabilities") {
-                                initialized_sent = true;
-                                let _ = tx.send(LspEvent::Initialized(server_id, caps.clone()));
-                            }
+                Some("initialize") if !initialized_sent => {
+                    if let Some(r) = result {
+                        if let Some(caps) = r.get("capabilities") {
+                            initialized_sent = true;
+                            let _ = tx.send(LspEvent::Initialized(server_id, caps.clone()));
                         }
                     }
                 }

--- a/src/win_gui/draw.rs
+++ b/src/win_gui/draw.rs
@@ -693,46 +693,18 @@ impl<'a> DrawContext<'a> {
             }
         }
 
-        // Per-window status line (with per-segment background colors)
+        // Per-window status line — A.6b-win: route through quadraui::StatusBar.
+        // Right-segment fit policy (#159) drops low-priority segments when the
+        // bar is narrow; `win_status_segment_hit_test` applies the same policy
+        // so clicks stay aligned with what's actually drawn.
         if let Some(ref status) = rw.status_line {
             let status_y = ry + rw.rect.height as f32 - self.line_height;
             let bar_w = rw.rect.width as f32;
-            // Base background for the whole bar
-            let base_bg = self.solid_brush(self.theme.background.lighten(0.10));
-            unsafe {
-                self.rt
-                    .FillRectangle(&rect_f(rx, status_y, bar_w, self.line_height), &base_bg);
-            }
-            // Left segments with per-segment background
-            let mut sx = rx;
-            for seg in &status.left_segments {
-                let seg_w = seg.text.chars().count() as f32 * self.char_width;
-                let seg_bg = self.solid_brush(seg.bg);
-                unsafe {
-                    self.rt
-                        .FillRectangle(&rect_f(sx, status_y, seg_w, self.line_height), &seg_bg);
-                }
-                self.draw_text(&seg.text, sx, status_y, seg.fg);
-                sx += seg_w;
-            }
-            // Right segments with per-segment background
-            let right_text: String = status
-                .right_segments
-                .iter()
-                .map(|s| s.text.as_str())
-                .collect();
-            let right_w = right_text.chars().count() as f32 * self.char_width;
-            let mut sx = rx + bar_w - right_w;
-            for seg in &status.right_segments {
-                let seg_w = seg.text.chars().count() as f32 * self.char_width;
-                let seg_bg = self.solid_brush(seg.bg);
-                unsafe {
-                    self.rt
-                        .FillRectangle(&rect_f(sx, status_y, seg_w, self.line_height), &seg_bg);
-                }
-                self.draw_text(&seg.text, sx, status_y, seg.fg);
-                sx += seg_w;
-            }
+            let bar = crate::render::window_status_line_to_status_bar(
+                status,
+                quadraui::WidgetId::new("status:window"),
+            );
+            super::quadraui_win::draw_status_bar(self, rx, status_y, bar_w, &bar);
         }
 
         // Pop editor window clip
@@ -926,40 +898,22 @@ impl<'a> DrawContext<'a> {
         let x0 = self.editor_left;
         // The separated status sits just above the terminal panel.
         // Layout: editor | sep_status | terminal | status_bar | cmd_line
-        // The terminal panel content row count tells us how much space it uses.
         let terminal_px = _layout
             .bottom_tabs
             .terminal
             .as_ref()
             .map(|t| (t.content_rows as f32 + 2.0) * self.line_height)
             .unwrap_or(0.0);
-        // Layout when above: [editor][sep_status][cmd][terminal]
-        // sep_y = height - terminal - cmd - sep_status
         let sep_y = height - terminal_px - 2.0 * self.line_height;
         let bar_width = width - x0;
-        let bg = self.solid_brush(self.theme.status_bg);
-        unsafe {
-            self.rt
-                .FillRectangle(&rect_f(x0, sep_y, bar_width, self.line_height), &bg);
-        }
-        // Left segments
-        let mut sx = x0 + self.char_width * 0.5;
-        for seg in &status.left_segments {
-            self.draw_text(&seg.text, sx, sep_y, seg.fg);
-            sx += seg.text.chars().count() as f32 * self.char_width;
-        }
-        // Right segments
-        let right_text: String = status
-            .right_segments
-            .iter()
-            .map(|s| s.text.as_str())
-            .collect();
-        let right_w = right_text.chars().count() as f32 * self.char_width;
-        let mut sx2 = x0 + bar_width - right_w - self.char_width * 0.5;
-        for seg in &status.right_segments {
-            self.draw_text(&seg.text, sx2, sep_y, seg.fg);
-            sx2 += seg.text.chars().count() as f32 * self.char_width;
-        }
+        // A.6b-win: route through quadraui::StatusBar so #159 fit policy +
+        // per-segment background fills + future bold/click-region work all
+        // share the same code path with the per-window status bar.
+        let bar = crate::render::window_status_line_to_status_bar(
+            status,
+            quadraui::WidgetId::new("status:separated"),
+        );
+        super::quadraui_win::draw_status_bar(self, x0, sep_y, bar_width, &bar);
     }
 
     // ─── Command line ────────────────────────────────────────────────────────

--- a/src/win_gui/mod.rs
+++ b/src/win_gui/mod.rs
@@ -2263,12 +2263,11 @@ fn on_key_down(wparam: WPARAM, _lparam: LPARAM) -> bool {
                         state.sidebar.has_focus = false;
                         state.engine.search_has_focus = false;
                     }
-                    "Down" => {
+                    "Down"
                         // Switch to results mode
-                        if !state.engine.project_search_results.is_empty() {
+                        if !state.engine.project_search_results.is_empty() => {
                             state.sidebar.search_input_mode = false;
                         }
-                    }
                     _ => {}
                 }
             } else {
@@ -6593,18 +6592,27 @@ fn translate_key_to_pty(key_name: &str, unicode: Option<char>, ctrl: bool) -> Ve
     }
 }
 
-/// Hit-test a per-window status bar click, returning the action if any segment matches.
+/// Hit-test a per-window status bar click, returning the action if any
+/// segment matches.
+///
+/// Applies `quadraui::StatusBar::fit_right_start_chars` so clicks on a
+/// right segment that the rasterizer dropped (because the bar was too
+/// narrow — see #159) cannot fire. Must stay in sync with
+/// `quadraui_win::draw_status_bar`'s fit policy: both pass the same
+/// `MIN_GAP_CHARS` so the visible-segment set agrees with the hit-test
+/// set.
 fn win_status_segment_hit_test(
     status: &crate::render::WindowStatusLine,
     width: usize,
     click_col: usize,
 ) -> Option<StatusAction> {
-    let right_width: usize = status
-        .right_segments
-        .iter()
-        .map(|s| s.text.chars().count())
-        .sum();
-    let right_start = width.saturating_sub(right_width);
+    const MIN_GAP_CHARS: usize = 2;
+
+    let bar = crate::render::window_status_line_to_status_bar(
+        status,
+        quadraui::WidgetId::new("status:hit"),
+    );
+    let start_idx = bar.fit_right_start_chars(width, MIN_GAP_CHARS);
 
     let mut col = 0;
     for seg in &status.left_segments {
@@ -6615,8 +6623,13 @@ fn win_status_segment_hit_test(
         col += seg_len;
     }
 
-    let mut col = right_start;
-    for seg in &status.right_segments {
+    let visible_widths: Vec<usize> = bar.right_segments[start_idx..]
+        .iter()
+        .map(|s| s.text.chars().count())
+        .collect();
+    let visible_total: usize = visible_widths.iter().sum();
+    let mut col = width.saturating_sub(visible_total).max(col);
+    for seg in status.right_segments.iter().skip(start_idx) {
         let seg_len = seg.text.chars().count();
         if click_col >= col && click_col < col + seg_len {
             return seg.action.clone();

--- a/src/win_gui/quadraui_win.rs
+++ b/src/win_gui/quadraui_win.rs
@@ -1,7 +1,8 @@
 //! Win-GUI (Direct2D / DirectWrite) backend for `quadraui` primitives.
 //!
 //! Direct2D counterpart to `src/tui_main/quadraui_tui.rs` and
-//! `src/gtk/quadraui_gtk.rs`. Currently supports `TreeView` (A.1c).
+//! `src/gtk/quadraui_gtk.rs`. Currently supports `TreeView` (A.1c) and
+//! `StatusBar` (A.6b-win).
 
 use windows::Win32::Graphics::Direct2D::Common::D2D_RECT_F;
 
@@ -191,5 +192,96 @@ pub(super) fn draw_tree(
         }
 
         y_off += row_h;
+    }
+}
+
+// ─── StatusBar (A.6b-win) ────────────────────────────────────────────────────
+
+/// Minimum gap (in character columns) between the rightmost left segment
+/// and the leftmost visible right segment. Mirrors the GTK backend's
+/// `MIN_GAP_PX = 16` once converted to char widths (~2 mono cells).
+const STATUS_BAR_MIN_GAP_CHARS: usize = 2;
+
+/// Draw a `quadraui::StatusBar` into `(x, y, width, ctx.line_height)` on
+/// `ctx.rt`, using the editor's monospace font.
+///
+/// Matches the GTK reference (`src/gtk/quadraui_gtk.rs::draw_status_bar`)
+/// in shape: left segments accumulate from `x`; right segments are
+/// right-aligned, with low-priority segments dropped from the front per
+/// `quadraui::StatusBar::fit_right_start_chars` (#159) so the cursor
+/// position is always visible. Backgrounds clip when the two halves
+/// would collide.
+///
+/// Width and hit positions are computed in **character columns** (Win-GUI
+/// uses a fixed-width mono font: `pixel_width = chars().count() * char_width`).
+/// `win_status_segment_hit_test` consults the same `fit_right_start_chars`
+/// policy so clicks on a hidden right segment cannot fire.
+///
+/// **Bold attribute is ignored for v1.** Win-GUI's text path uses a
+/// single non-bold `IDWriteTextFormat`; supporting bold would require a
+/// second format and would make hit-test math diverge from the rasterizer
+/// (proportional vs char-count widths). The pre-A.6b Win-GUI per-window
+/// status bar didn't honour `bold` either.
+pub(super) fn draw_status_bar(
+    ctx: &DrawContext,
+    x: f32,
+    y: f32,
+    width: f32,
+    bar: &quadraui::StatusBar,
+) {
+    if width <= 0.0 {
+        return;
+    }
+    let cw = ctx.char_width;
+    let lh = ctx.line_height;
+    let bar_chars = (width / cw).floor() as usize;
+
+    // Background fill: first segment's bg, else theme.background.
+    let fill = bar
+        .left_segments
+        .first()
+        .or(bar.right_segments.first())
+        .map(|s| qc_to_color(s.bg))
+        .unwrap_or(ctx.theme.background);
+    unsafe {
+        let brush = ctx.solid_brush(fill);
+        ctx.rt.FillRectangle(&rect(x, y, width, lh), &brush);
+    }
+
+    // ── Left segments — accumulate from x ────────────────────────────────
+    let mut cx = x;
+    let x_end = x + width;
+    for seg in &bar.left_segments {
+        if cx >= x_end {
+            break;
+        }
+        let seg_w = seg.text.chars().count() as f32 * cw;
+        let visible_w = (x_end - cx).min(seg_w);
+        let bg = qc_to_color(seg.bg);
+        unsafe {
+            let brush = ctx.solid_brush(bg);
+            ctx.rt.FillRectangle(&rect(cx, y, visible_w, lh), &brush);
+        }
+        ctx.draw_text(&seg.text, cx, y, qc_to_color(seg.fg));
+        cx += seg_w;
+    }
+
+    // ── Right segments — drop low-priority ones until they fit ───────────
+    let start_idx = bar.fit_right_start_chars(bar_chars, STATUS_BAR_MIN_GAP_CHARS);
+    let visible_widths: Vec<f32> = bar.right_segments[start_idx..]
+        .iter()
+        .map(|seg| seg.text.chars().count() as f32 * cw)
+        .collect();
+    let visible_total: f32 = visible_widths.iter().sum();
+    let mut rx = (x + width - visible_total).max(cx);
+    for (offset, seg) in bar.right_segments[start_idx..].iter().enumerate() {
+        let seg_w = visible_widths[offset];
+        let bg = qc_to_color(seg.bg);
+        unsafe {
+            let brush = ctx.solid_brush(bg);
+            ctx.rt.FillRectangle(&rect(rx, y, seg_w, lh), &brush);
+        }
+        ctx.draw_text(&seg.text, rx, y, qc_to_color(seg.fg));
+        rx += seg_w;
     }
 }


### PR DESCRIPTION
## Summary

- Migrates Win-GUI's per-window and separated status bars to render through `quadraui::StatusBar`, completing A.6b parity for the third backend (TUI ✅ / GTK ✅ / **Win-GUI ✅**).
- New `quadraui_win::draw_status_bar` rasteriser (Direct2D + DirectWrite) mirrors the GTK reference: per-segment background fills, left-from-left + right-aligned-with-fit-policy layout. ~70 LOC of bespoke segment-fill code at two call sites in `src/win_gui/draw.rs` deleted.
- `win_status_segment_hit_test` now applies the same `quadraui::StatusBar::fit_right_start_chars` policy so clicks on a dropped right segment cannot fire — keeps the rasteriser and hit-test in lockstep without a cached zone map.

## Commits

1. **`ce1f500` chore(clippy): collapsible_match cleanup in core engine** — six pre-existing warnings introduced by the Rust 1.95.0 toolchain bump in `dap_ops.rs`, `ext_panel.rs`, `keys.rs`, `motions.rs`, `vscode.rs`, `lsp.rs`. Mechanical `cargo clippy --fix`. Was blocking the A.6b-win quality gate. Bundled here so the gate passes; could be split off if preferred.
2. **`4da5771` feat(quadraui): Phase A.6b-win** — the actual rasteriser + two refactored call sites + hit-test fit-policy alignment (3 files, +135 / -76).
3. **`05034ae` docs(quadraui): A.6b-win shipped** — PLAN.md row marked ✅ Done with actual LOC; PROJECT_STATE.md Recent Work entry; A.6d-win promoted to Next.

## Caveats

- **Bold attribute deferred.** Win-GUI's text path uses a single non-bold `IDWriteTextFormat`; supporting bold needs a second format and would make hit-test math diverge from the rasteriser (proportional vs char-count widths). Pre-A.6b code didn't honour bold either. Documented in the rasteriser doc comment.
- **Global bottom `draw_status_bar`** (plain text, fires only when per-window mode is OFF) left as-is. Migration optional, no parity gap.
- **Hit regions recomputed at click time** rather than cached. Both rasteriser and hit-test use the same primitive + same fit policy, so they stay aligned. Avoids threading a `RefCell` zone cache through `DrawContext`.

## Behavioural change to flag

Narrow editor windows (e.g. heavily horizontal-split) now drop low-priority right-side status segments cleanly per #159, instead of overflowing them past the bar's right edge. This is the intended fix; surfaces a visible difference for users running narrow splits.

## Smoke-test paper-cuts (filed separately, not in scope)

- **#173** — \`status_line_above_terminal\` label is inverted from its behaviour (\`true\` keeps bars *inside* windows, not above terminal).
- **#174** — \`:set window_status_line\` is rejected by the ex command, which only accepts vim-style \`:set wsl\`.

Both pre-existing; surfaced during smoke test of this work.

## Quality gates

- \`cargo build --bin vimcode-win --features win-gui --no-default-features\` ✓
- \`cargo clippy --features win-gui --no-default-features --bin vimcode-win -- -D warnings\` ✓
- \`cargo clippy --no-default-features -- -D warnings\` ✓
- \`cargo test --workspace --no-default-features\` 5291 passed / 0 failed / 20 ignored ✓
- Manual smoke test on Win-GUI: per-window status renders, click-to-toggle-sidebar still fires, separated bar above terminal renders, narrow-window right-drop confirmed.

## Test plan

- [ ] CI green on Win-GUI build + clippy
- [ ] CI green on full \`cargo test --workspace --no-default-features\`
- [ ] Visual diff review of \`quadraui_win.rs\` rasteriser vs. \`quadraui_gtk.rs\` reference
- [ ] Confirm bundled \`ce1f500\` clippy-cleanup commit is acceptable (alternative: split off as separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)