### PR TITLE
test(quadraui): TUI TreeView paint↔click round-trip harness

### DIFF
--- a/quadraui/src/tui/tree.rs
+++ b/quadraui/src/tui/tree.rs
@@ -11,7 +11,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 
 use super::{draw_styled_text, qc, ratatui_color, set_cell};
-use crate::primitives::tree::{TreeRowMeasure, TreeView};
+use crate::primitives::tree::{TreeRowMeasure, TreeView, TreeViewLayout};
 use crate::theme::Theme;
 use crate::types::Decoration;
 
@@ -60,9 +60,7 @@ pub fn draw_tree(
 
     let indent_cells = tree.style.indent as usize;
 
-    let layout = tree.layout(area.width as f32, area.height as f32, |_| {
-        TreeRowMeasure::new(1.0)
-    });
+    let layout = tui_tree_layout(tree, area);
 
     for visible_row in &layout.visible_rows {
         let row = &tree.rows[visible_row.row_idx];
@@ -165,6 +163,22 @@ pub fn draw_tree(
 
         let _ = col;
     }
+}
+
+/// Compute the layout the TUI rasteriser would produce for `tree` in
+/// `area`. Hosts and tests call this to drive hit-testing without
+/// re-deriving metrics that could drift from paint. `draw_tree` uses
+/// this same helper internally so paint and hit_test consume one
+/// layout instance produced by one set of metrics — the source-of-
+/// truth contract.
+///
+/// TUI rows are uniform 1-cell tall. The layout is in tree-local coords
+/// (origin at 0,0); convert absolute click coords by subtracting
+/// `area.x` / `area.y` before calling [`TreeViewLayout::hit_test`].
+pub fn tui_tree_layout(tree: &TreeView, area: Rect) -> TreeViewLayout {
+    tree.layout(area.width as f32, area.height as f32, |_| {
+        TreeRowMeasure::new(1.0)
+    })
 }
 
 #[cfg(test)]
@@ -296,5 +310,213 @@ mod tests {
             false,
         );
         assert_eq!(cell_char(&buf, 0, 0), ' ');
+    }
+
+    // ── Paint↔click round-trip harness ─────────────────────────────────────
+    //
+    // Per the Session 346 course correction (PLAN.md "🧭 Course
+    // correction"): primitives that promise paint/click consistency
+    // need empirical verification, not just structural design. These
+    // tests paint a `TreeView` into a `ratatui::Buffer`, find the cells
+    // the rasteriser actually wrote glyphs into, then hit_test those
+    // exact coordinates against the layout the rasteriser used and
+    // assert the hit identifies the painted-into row. If paint and
+    // click ever drift in the TUI tree rasteriser, one of these fails.
+    //
+    // TreeView uses tree-local coords (origin at 0,0) for `hit_test`,
+    // unlike `MultiSectionView` which uses absolute coords. The harness
+    // converts between them by subtracting `area.x`/`area.y` from the
+    // painted absolute y. Same source-of-truth contract; different
+    // origin convention.
+    //
+    // Mirrors the MultiSectionView harness shape (#298) so future
+    // primitives can copy this pattern.
+
+    use crate::primitives::tree::TreeViewHit;
+    use crate::tui::tree::tui_tree_layout;
+    use crate::types::TreePath;
+
+    fn row_text(buf: &Buffer, y: u16) -> String {
+        let area = buf.area;
+        (area.x..area.x + area.width)
+            .map(|x| cell_char(buf, x, y))
+            .collect()
+    }
+
+    fn find_row_with(buf: &Buffer, needle: &str) -> Option<u16> {
+        let area = buf.area;
+        for y in area.y..area.y + area.height {
+            if row_text(buf, y).contains(needle) {
+                return Some(y);
+            }
+        }
+        None
+    }
+
+    fn long_tree(n: usize) -> TreeView {
+        let labels: Vec<String> = (0..n).map(|i| format!("item-{i:02}")).collect();
+        let rows: Vec<TreeRow> = labels
+            .iter()
+            .enumerate()
+            .map(|(i, label)| TreeRow {
+                path: vec![i as u16] as TreePath,
+                indent: 0,
+                text: StyledText {
+                    spans: vec![StyledSpan::plain(label.clone())],
+                },
+                icon: None,
+                badge: None,
+                is_expanded: None,
+                decoration: Decoration::Normal,
+            })
+            .collect();
+        TreeView {
+            id: WidgetId::new("long"),
+            rows,
+            selection_mode: crate::types::SelectionMode::default(),
+            selected_path: None,
+            scroll_offset: 0,
+            has_focus: false,
+            style: TreeStyle::default(),
+        }
+    }
+
+    fn paint_then_layout(
+        buf: &mut Buffer,
+        area: Rect,
+        tree: &TreeView,
+        theme: &Theme,
+        nerd_fonts_enabled: bool,
+    ) -> TreeViewLayout {
+        draw_tree(buf, area, tree, theme, nerd_fonts_enabled);
+        tui_tree_layout(tree, area)
+    }
+
+    /// Round-trip: paint, find each row's label in the buffer, hit_test
+    /// the same coordinate, assert the hit returns Row(idx) for the
+    /// matching tree.rows index.
+    #[test]
+    fn clicks_land_on_painted_row() {
+        let area = Rect::new(0, 0, 30, 8);
+        let mut buf = Buffer::empty(area);
+        let tree = long_tree(5);
+        let layout = paint_then_layout(&mut buf, area, &tree, &Theme::default(), false);
+
+        for visible in &layout.visible_rows {
+            let needle = tree.rows[visible.row_idx]
+                .text
+                .spans
+                .first()
+                .map(|s| s.text.clone())
+                .unwrap_or_default();
+            let painted_y = find_row_with(&buf, &needle)
+                .unwrap_or_else(|| panic!("row {} ({:?}) not painted", visible.row_idx, needle));
+            // TreeView hit_test takes tree-local coords (origin at 0,0).
+            let local_y = (painted_y - area.y) as f32;
+            let hit = layout.hit_test(0.5, local_y);
+            match hit {
+                TreeViewHit::Row(idx) => assert_eq!(
+                    idx, visible.row_idx,
+                    "row {} ({:?}) painted at y={} but hit_test returned Row({})",
+                    visible.row_idx, needle, painted_y, idx
+                ),
+                other => panic!(
+                    "row {} ({:?}) painted at y={} but hit_test returned {:?}",
+                    visible.row_idx, needle, painted_y, other
+                ),
+            }
+        }
+    }
+
+    /// Click below the last visible row returns Empty.
+    #[test]
+    fn click_below_last_row_returns_empty() {
+        let area = Rect::new(0, 0, 30, 8);
+        let mut buf = Buffer::empty(area);
+        // 2 rows in an 8-row viewport leaves 6 rows of empty space.
+        let tree = long_tree(2);
+        let layout = paint_then_layout(&mut buf, area, &tree, &Theme::default(), false);
+        let hit = layout.hit_test(0.5, 5.0); // y=5, well below the 2 painted rows
+        assert!(
+            matches!(hit, TreeViewHit::Empty),
+            "click at y=5 below last row returned {:?}",
+            hit
+        );
+    }
+
+    /// With `scroll_offset > 0`, painted row 0 must be `tree.rows[scroll_offset]`,
+    /// and clicking it must return `Row(scroll_offset)` — NOT `Row(0)`.
+    /// This is the bug class where paint advances by scroll_offset but
+    /// click forgets, or vice versa.
+    #[test]
+    fn scroll_offset_paint_and_click_agree() {
+        let area = Rect::new(0, 0, 30, 4);
+        let mut buf = Buffer::empty(area);
+        let mut tree = long_tree(10);
+        tree.scroll_offset = 3;
+        let layout = paint_then_layout(&mut buf, area, &tree, &Theme::default(), false);
+
+        // Painted row 0 should be `tree.rows[3]` ("item-03").
+        let painted_y = find_row_with(&buf, "item-03")
+            .expect("scroll_offset=3 should make row 0 paint as 'item-03'");
+        let local_y = (painted_y - area.y) as f32;
+        let hit = layout.hit_test(0.5, local_y);
+        assert!(
+            matches!(hit, TreeViewHit::Row(3)),
+            "scroll_offset=3: row painted as 'item-03' at y={}; expected Row(3), got {:?}",
+            painted_y,
+            hit
+        );
+
+        // Painted row 0 should NOT be the original "item-00" — that one
+        // is scrolled out and shouldn't appear in the buffer at all.
+        assert!(
+            find_row_with(&buf, "item-00").is_none(),
+            "item-00 should be scrolled out under scroll_offset=3 but appears in buffer"
+        );
+    }
+
+    /// Header rows (Decoration::Header) and leaf rows are equally
+    /// hit-testable. Mixed-row trees should round-trip cleanly across
+    /// every visible row regardless of decoration.
+    #[test]
+    fn header_and_leaf_rows_both_hit_testable() {
+        let area = Rect::new(0, 0, 30, 6);
+        let mut buf = Buffer::empty(area);
+        let tree = TreeView {
+            id: WidgetId::new("mixed"),
+            rows: vec![
+                TreeRow {
+                    path: vec![0],
+                    indent: 0,
+                    text: StyledText {
+                        spans: vec![StyledSpan::plain("CHANGES")],
+                    },
+                    icon: None,
+                    badge: None,
+                    is_expanded: Some(true),
+                    decoration: Decoration::Header,
+                },
+                row(&[0, 0], 1, "alpha", None),
+                row(&[0, 1], 1, "beta", None),
+            ],
+            selection_mode: crate::types::SelectionMode::default(),
+            selected_path: None,
+            scroll_offset: 0,
+            has_focus: false,
+            style: TreeStyle::default(),
+        };
+        let layout = paint_then_layout(&mut buf, area, &tree, &Theme::default(), false);
+
+        for (expected_idx, needle) in [(0usize, "CHANGES"), (1, "alpha"), (2, "beta")] {
+            let painted_y =
+                find_row_with(&buf, needle).unwrap_or_else(|| panic!("row {needle:?} not painted"));
+            let local_y = (painted_y - area.y) as f32;
+            let hit = layout.hit_test(0.5, local_y);
+            assert!(
+                matches!(hit, TreeViewHit::Row(idx) if idx == expected_idx),
+                "row {needle:?} painted at y={painted_y}: expected Row({expected_idx}), got {hit:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Step 4 of the [Session 346 course correction](../blob/develop/PLAN.md#-course-correction-session-346--harness-first-quadraui). Adds 4 round-trip tests to `quadraui::tui::tree::tests` mirroring the MultiSectionView harness pattern from #298 — paint into a `ratatui::Buffer`, find painted glyph cells, hit_test those exact coordinates, assert paint and click identify the same row.

Also extracts `pub fn tui_tree_layout(tree, area) -> TreeViewLayout` from `draw_tree`'s body so paint and tests share one source of truth (same shape as `tui_msv_layout` from #298).

## Tests added
- `clicks_land_on_painted_row` — each visible row's painted text round-trips: hit_test at the y where the rasteriser drew the row returns `TreeViewHit::Row(idx)` for the matching `tree.rows` index.
- `click_below_last_row_returns_empty` — 2 rows in an 8-row viewport, click at y=5 returns `Empty` (not a stale `Row` from a prior paint).
- `scroll_offset_paint_and_click_agree` — `scroll_offset=3` in a 10-row tree makes painted row 0 = `tree.rows[3]` (text `"item-03"`). Hit_test there returns `Row(3)`. Also asserts `tree.rows[0]` (text `"item-00"`) is absent from the buffer because it scrolled out. Catches the bug class where paint advances by `scroll_offset` but click forgets, or vice versa.
- `header_and_leaf_rows_both_hit_testable` — mixed `Decoration::Header` + `Decoration::Normal` rows all round-trip.

## Origin convention difference vs MSV
TreeView's layout uses tree-local coords (origin at 0,0), unlike `MultiSectionView` which uses absolute coords. The harness converts by subtracting `area.x`/`area.y` from the painted absolute y before calling `layout.hit_test`. Same source-of-truth contract; different origin convention. Documented on the new `tui_tree_layout` helper and inline in the test mod.

## Empirical verification that the harness catches scroll_offset drift
Temporarily patched `primitives/tree.rs::layout()` to start the visible-row loop at `i = 0` instead of `i = resolved_scroll_offset` (i.e. paint forgets to apply scroll):

```
test scroll_offset_paint_and_click_agree ... FAILED
test clicks_land_on_painted_row ... ok
test click_below_last_row_returns_empty ... ok
test header_and_leaf_rows_both_hit_testable ... ok
```

Restored: all 4 pass. Harness catches scroll/paint drift specifically without false-flagging on related-but-different bug classes.

## Refactor: `tui_tree_layout`
`draw_tree` previously inlined `tree.layout(area.width as f32, area.height as f32, |_| TreeRowMeasure::new(1.0))`. Extracted to a `pub fn tui_tree_layout(tree, area) -> TreeViewLayout` that the rasteriser calls internally and tests/hosts call independently. Same pattern as `tui_msv_layout` from #298. Means future TUI consumers can call `tui_tree_layout` for click handling without rebuilding the measurer that could drift from paint.

## Test plan
- [x] `cargo build --no-default-features` clean
- [x] `cargo clippy --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --no-default-features` (1950 vimcode tests) green
- [x] `cd quadraui && cargo test --features tui` (302 tests, +4 new harness) green
- [x] Empirically verified: harness fails when scroll_offset application is removed; passes when restored

## Files changed
- `quadraui/src/tui/tree.rs` — `+226/-4`. Extract `tui_tree_layout`; add 4 round-trip tests + helpers (`row_text`, `find_row_with`, `long_tree`, `paint_then_layout`).

## Next steps (per PLAN.md "🧭 Course correction")
- Step 5: Extract quadraui to its own repo (0.0.1, path-dep)
- Step 6: Re-do #296 with the harness gating
- Step 7: Migrate SC (#282) using the harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)