### PR TITLE
feat: migrate TUI search panel to quadraui MSV + Form + TreeView (#302)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2442,6 +2442,8 @@ pub struct Engine {
         Option<std::sync::mpsc::Receiver<Result<ReplaceResult, SearchError>>>,
     /// True while a background replace thread is running.
     pub project_replace_running: bool,
+    /// Search-specific status message ("N matches in M files").
+    pub project_search_status: String,
     /// Per-file collapse state in search results. Indexed by file group order.
     pub search_file_expanded: Vec<bool>,
     /// Cached MSV layout from the last search panel paint. Written at paint time.
@@ -3382,6 +3384,7 @@ impl Engine {
             project_replace_text: String::new(),
             project_replace_receiver: None,
             project_replace_running: false,
+            project_search_status: String::new(),
             search_file_expanded: Vec::new(),
             search_panel_msv_layout: std::cell::RefCell::new(None),
             search_panel_form_focus: std::cell::RefCell::new(Some("search:query".to_string())),

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2442,6 +2442,17 @@ pub struct Engine {
         Option<std::sync::mpsc::Receiver<Result<ReplaceResult, SearchError>>>,
     /// True while a background replace thread is running.
     pub project_replace_running: bool,
+    /// Per-file collapse state in search results. Indexed by file group order.
+    pub search_file_expanded: Vec<bool>,
+    /// Cached MSV layout from the last search panel paint. Written at paint time.
+    pub search_panel_msv_layout: std::cell::RefCell<Option<quadraui::MultiSectionViewLayout>>,
+    /// Which form field in the search panel has focus (widget ID string).
+    /// Written at paint time from TUI sidebar state.
+    pub search_panel_form_focus: std::cell::RefCell<Option<String>>,
+    /// Cursor position (char offset) in the search query input.
+    pub search_query_caret: std::cell::Cell<usize>,
+    /// Cursor position (char offset) in the replace text input.
+    pub replace_text_caret: std::cell::Cell<usize>,
 
     // --- LSP state ---
     /// Multi-server LSP coordinator. None until first LSP-capable file is opened.
@@ -3371,6 +3382,11 @@ impl Engine {
             project_replace_text: String::new(),
             project_replace_receiver: None,
             project_replace_running: false,
+            search_file_expanded: Vec::new(),
+            search_panel_msv_layout: std::cell::RefCell::new(None),
+            search_panel_form_focus: std::cell::RefCell::new(Some("search:query".to_string())),
+            search_query_caret: std::cell::Cell::new(0),
+            replace_text_caret: std::cell::Cell::new(0),
             lsp_manager: None,
             lsp_diagnostics: HashMap::new(),
             lsp_hover_text: None,

--- a/src/core/engine/panels.rs
+++ b/src/core/engine/panels.rs
@@ -282,6 +282,13 @@ impl Engine {
                 }
                 EngineAction::None
             }
+            "search_replace_all" => {
+                if action == "replace" {
+                    let root = self.cwd.clone();
+                    self.start_project_replace(root);
+                }
+                EngineAction::None
+            }
             "ext_remove" => {
                 if let Some(name) = self.pending_ext_remove.take() {
                     match action {

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -586,8 +586,44 @@ impl Engine {
                 self.start_project_search(root);
             }
             "search:replace_all" => {
-                let root = self.cwd.clone();
-                self.start_project_replace(root);
+                if self.project_search_results.is_empty() {
+                    self.message = "No search results to replace".to_string();
+                    return;
+                }
+                let query = self.project_search_query.clone();
+                let replace = self.project_replace_text.clone();
+                let file_count = self.search_file_expanded.len();
+                let match_count = self.project_search_results.len();
+                let replace_display = if replace.is_empty() {
+                    "(empty string)".to_string()
+                } else {
+                    format!("\"{}\"", replace)
+                };
+                self.show_dialog(
+                    "search_replace_all",
+                    "Replace All",
+                    vec![format!(
+                        "Replace {} occurrence{} of \"{}\" with {} across {} file{}?",
+                        match_count,
+                        if match_count == 1 { "" } else { "s" },
+                        query,
+                        replace_display,
+                        file_count,
+                        if file_count == 1 { "" } else { "s" },
+                    )],
+                    vec![
+                        DialogButton {
+                            label: "Cancel".to_string(),
+                            hotkey: 'c',
+                            action: "cancel".to_string(),
+                        },
+                        DialogButton {
+                            label: "Replace All".to_string(),
+                            hotkey: 'r',
+                            action: "replace".to_string(),
+                        },
+                    ],
+                );
             }
             "search:replace_next" => {
                 let idx = self.project_search_selected;

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -589,6 +589,15 @@ impl Engine {
                 let root = self.cwd.clone();
                 self.start_project_replace(root);
             }
+            "search:replace_next" => {
+                let idx = self.project_search_selected;
+                self.open_search_result(idx);
+            }
+            "search:buttons" => {
+                let root = self.cwd.clone();
+                self.start_project_search(root);
+            }
+            "search:toggles" => {}
             "search:query" => {
                 self.search_panel_form_focus
                     .replace(Some("search:query".to_string()));

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -521,16 +521,16 @@ impl Engine {
     /// Store search results and update the status message. Called by both sync and async paths.
     pub(crate) fn apply_search_results(&mut self, results: Vec<ProjectMatch>, query: &str) {
         let capped = results.len() >= 10_000;
+        let file_count = {
+            let mut files: Vec<&std::path::Path> =
+                results.iter().map(|m| m.file.as_path()).collect();
+            files.sort();
+            files.dedup();
+            files.len()
+        };
         if results.is_empty() {
             self.message = format!("No results for \"{}\"", query);
         } else {
-            let file_count = {
-                let mut files: Vec<&std::path::Path> =
-                    results.iter().map(|m| m.file.as_path()).collect();
-                files.sort();
-                files.dedup();
-                files.len()
-            };
             self.message = format!(
                 "{} match{} in {} file{}{}",
                 results.len(),
@@ -540,6 +540,7 @@ impl Engine {
                 if capped { " (capped at 10000)" } else { "" }
             );
         }
+        self.search_file_expanded = vec![true; file_count];
         self.project_search_results = results;
         self.project_search_selected = 0;
     }
@@ -570,6 +571,84 @@ impl Engine {
     /// Move the project search selection up by one, clamped to 0.
     pub fn project_search_select_prev(&mut self) {
         self.project_search_selected = self.project_search_selected.saturating_sub(1);
+    }
+
+    /// Handle a click on a search-panel form element (toggle, button) by widget ID.
+    pub fn handle_search_form_hit(&mut self, id: &str) {
+        match id {
+            "search:case" => self.toggle_project_search_case(),
+            "search:word" => self.toggle_project_search_whole_word(),
+            "search:regex" => self.toggle_project_search_regex(),
+            "search:find_next" => {
+                let root = self.cwd.clone();
+                self.start_project_search(root);
+            }
+            "search:replace_all" => {
+                let root = self.cwd.clone();
+                self.start_project_replace(root);
+            }
+            "search:query" => {
+                self.search_panel_form_focus
+                    .replace(Some("search:query".to_string()));
+            }
+            "search:replace" => {
+                self.search_panel_form_focus
+                    .replace(Some("search:replace".to_string()));
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle a click on a search-panel tree row.
+    /// `path[0]` = file group index, `path[1]` = match within that file.
+    pub fn handle_search_tree_hit(&mut self, path: &[u16]) {
+        if path.len() == 1 {
+            let fi = path[0] as usize;
+            if fi < self.search_file_expanded.len() {
+                self.search_file_expanded[fi] = !self.search_file_expanded[fi];
+            }
+        } else if path.len() >= 2 {
+            let fi = path[0] as usize;
+            let mi = path[1] as usize;
+            if let Some(result_idx) = self.tree_path_to_result_idx(fi, mi) {
+                self.project_search_selected = result_idx;
+                self.open_search_result(result_idx);
+            }
+        }
+    }
+
+    /// Map a tree path (file_idx, match_within_file) back to a flat result index.
+    fn tree_path_to_result_idx(&self, file_idx: usize, match_idx: usize) -> Option<usize> {
+        let mut current_file: usize = 0;
+        let mut last_file: Option<&std::path::Path> = None;
+        let mut match_within: usize = 0;
+
+        for (i, m) in self.project_search_results.iter().enumerate() {
+            if last_file != Some(m.file.as_path()) {
+                if last_file.is_some() {
+                    current_file += 1;
+                }
+                last_file = Some(m.file.as_path());
+                match_within = 0;
+            }
+            if current_file == file_idx && match_within == match_idx {
+                return Some(i);
+            }
+            match_within += 1;
+        }
+        None
+    }
+
+    /// Open the file at the given result index and jump to the match line.
+    pub(crate) fn open_search_result(&mut self, result_idx: usize) {
+        if let Some(m) = self.project_search_results.get(result_idx) {
+            let path = m.file.clone();
+            let line = m.line;
+            self.open_file_in_tab(&path);
+            let wid = self.active_window_id();
+            self.set_cursor_for_window(wid, line, 0);
+            self.ensure_cursor_visible();
+        }
     }
 
     // =======================================================================

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -528,18 +528,20 @@ impl Engine {
             files.dedup();
             files.len()
         };
-        if results.is_empty() {
-            self.message = format!("No results for \"{}\"", query);
+        let status = if results.is_empty() {
+            format!("No results for \"{}\"", query)
         } else {
-            self.message = format!(
+            format!(
                 "{} match{} in {} file{}{}",
                 results.len(),
                 if results.len() == 1 { "" } else { "es" },
                 file_count,
                 if file_count == 1 { "" } else { "s" },
                 if capped { " (capped at 10000)" } else { "" }
-            );
-        }
+            )
+        };
+        self.message = status.clone();
+        self.project_search_status = status;
         self.search_file_expanded = vec![true; file_count];
         self.project_search_results = results;
         self.project_search_selected = 0;

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2278,9 +2278,12 @@ impl SimpleComponent for App {
         *settings_panel_box_ref.borrow_mut() = Some(widgets.settings_panel.clone());
         *ai_panel_box_ref.borrow_mut() = Some(widgets.ai_panel_box.clone());
         // ── Search sidebar DrawingArea setup ──────────────────────────────
-        backend
-            .borrow_mut()
-            .set_pango_context(widgets.search_sidebar_da.pango_context());
+        {
+            let pango_ctx = widgets.search_sidebar_da.pango_context();
+            let font_desc = pango::FontDescription::from_string(&draw::UI_FONT());
+            pango_ctx.set_font_description(Some(&font_desc));
+            backend.borrow_mut().set_pango_context(pango_ctx);
+        }
         {
             let engine = engine.clone();
             let backend_d = backend.clone();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -317,7 +317,7 @@ struct App {
     sidebar_revealer: Rc<RefCell<Option<gtk4::Revealer>>>,
     /// Direct refs to each panel's outer Box for programmatic show/hide.
     explorer_panel_box: Rc<RefCell<Option<gtk4::Box>>>,
-    search_panel_box: Rc<RefCell<Option<gtk4::Box>>>,
+    search_sidebar_da_ref: Rc<RefCell<Option<gtk4::DrawingArea>>>,
     debug_panel_box: Rc<RefCell<Option<gtk4::Box>>>,
     git_panel_box: Rc<RefCell<Option<gtk4::Box>>>,
     ext_panel_box: Rc<RefCell<Option<gtk4::Box>>>,
@@ -359,10 +359,6 @@ struct App {
     #[allow(dead_code)] // Kept alive to continue monitoring settings.json
     settings_monitor: Option<gio::FileMonitor>,
     sender: relm4::Sender<Msg>,
-    /// Status text shown below the project search input ("N matches in M files").
-    project_search_status: String,
-    /// Ref to the search results ListBox so we can rebuild it after each search.
-    search_results_list: Rc<RefCell<Option<gtk4::ListBox>>>,
     /// Last content written to system clipboard.
     /// Used to avoid redundant writes on every keystroke.
     last_clipboard_content: Option<String>,
@@ -812,6 +808,8 @@ enum Msg {
     ProjectReplaceTextChanged(String),
     /// User clicked "Replace All" button — run replace across files.
     ProjectReplaceAll,
+    SearchPanelClick(f64, f64),
+    SearchPanelKey(String, Option<char>),
     /// Mouse scroll wheel on editor drawing area.
     MouseScroll {
         delta_x: f64,
@@ -1155,161 +1153,23 @@ impl SimpleComponent for App {
                             },
                         },
 
-                        // Search panel
+                        // Search panel (quadraui DrawingArea)
                         #[name = "search_panel"]
                         gtk4::Box {
                             set_orientation: gtk4::Orientation::Vertical,
                             set_css_classes: &["sidebar"],
 
                             #[watch]
-                            set_visible: model.active_panel == SidebarPanel::Search,
-
-                            // Header
-                            gtk4::Box {
-                                set_orientation: gtk4::Orientation::Horizontal,
-                                set_css_classes: &["sidebar-header"],
-                                gtk4::Label {
-                                    set_text: " SEARCH",
-                                    set_halign: gtk4::Align::Start,
-                                    set_hexpand: true,
-                                    set_css_classes: &["sidebar-title"],
-                                },
+                            set_visible: {
+                                if model.active_panel == SidebarPanel::Search {
+                                    search_sidebar_da.queue_draw();
+                                }
+                                model.active_panel == SidebarPanel::Search
                             },
 
-                            // Search input row
-                            gtk4::Box {
-                                set_orientation: gtk4::Orientation::Horizontal,
-                                set_margin_top: 6,
-                                set_margin_bottom: 4,
-                                set_margin_start: 6,
-                                set_margin_end: 6,
-
-                                #[name = "project_search_entry"]
-                                gtk4::Entry {
-                                    set_hexpand: true,
-                                    set_width_chars: 1,
-                                    set_placeholder_text: Some("Search files…"),
-
-                                    connect_changed[sender] => move |entry| {
-                                        sender.input(Msg::ProjectSearchQueryChanged(
-                                            entry.text().to_string(),
-                                        ));
-                                    },
-
-                                    connect_activate[sender] => move |_| {
-                                        sender.input(Msg::ProjectSearchSubmit);
-                                    },
-                                },
-                            },
-
-                            // Toggle buttons row (Aa / Ab| / .*)
-                            gtk4::Box {
-                                set_orientation: gtk4::Orientation::Horizontal,
-                                set_margin_start: 6,
-                                set_margin_end: 6,
-                                set_margin_bottom: 4,
-                                set_spacing: 4,
-
-                                gtk4::ToggleButton {
-                                    set_label: "Aa",
-                                    set_tooltip_text: Some("Match Case"),
-                                    set_css_classes: &["search-toggle-btn"],
-
-                                    #[watch]
-                                    set_active: model.engine.borrow().project_search_options.case_sensitive,
-
-                                    connect_clicked[sender] => move |_| {
-                                        sender.input(Msg::ProjectSearchToggleCase);
-                                    },
-                                },
-
-                                gtk4::ToggleButton {
-                                    set_label: "Ab|",
-                                    set_tooltip_text: Some("Match Whole Word"),
-                                    set_css_classes: &["search-toggle-btn"],
-
-                                    #[watch]
-                                    set_active: model.engine.borrow().project_search_options.whole_word,
-
-                                    connect_clicked[sender] => move |_| {
-                                        sender.input(Msg::ProjectSearchToggleWholeWord);
-                                    },
-                                },
-
-                                gtk4::ToggleButton {
-                                    set_label: ".*",
-                                    set_tooltip_text: Some("Use Regular Expression"),
-                                    set_css_classes: &["search-toggle-btn"],
-
-                                    #[watch]
-                                    set_active: model.engine.borrow().project_search_options.use_regex,
-
-                                    connect_clicked[sender] => move |_| {
-                                        sender.input(Msg::ProjectSearchToggleRegex);
-                                    },
-                                },
-                            },
-
-                            // Replace input row
-                            gtk4::Box {
-                                set_orientation: gtk4::Orientation::Horizontal,
-                                set_margin_top: 2,
-                                set_margin_bottom: 4,
-                                set_margin_start: 6,
-                                set_margin_end: 6,
-                                set_spacing: 4,
-
-                                gtk4::Entry {
-                                    set_hexpand: true,
-                                    set_width_chars: 1,
-                                    set_placeholder_text: Some("Replace…"),
-
-                                    connect_changed[sender] => move |entry| {
-                                        sender.input(Msg::ProjectReplaceTextChanged(
-                                            entry.text().to_string(),
-                                        ));
-                                    },
-
-                                    connect_activate[sender] => move |_| {
-                                        sender.input(Msg::ProjectReplaceAll);
-                                    },
-                                },
-
-                                gtk4::Button {
-                                    set_label: "All",
-                                    set_tooltip_text: Some("Replace all matches in project"),
-                                    set_css_classes: &["search-toggle-btn"],
-
-                                    connect_clicked[sender] => move |_| {
-                                        sender.input(Msg::ProjectReplaceAll);
-                                    },
-                                },
-                            },
-
-                            // Status label ("N results in M files" / empty)
-                            gtk4::Label {
-                                set_margin_start: 8,
-                                set_margin_bottom: 4,
-                                set_halign: gtk4::Align::Start,
-                                set_css_classes: &["dim-label"],
-
-                                #[watch]
-                                set_text: &model.project_search_status,
-                            },
-
-                            // Results list
-                            gtk4::ScrolledWindow {
+                            #[name = "search_sidebar_da"]
+                            gtk4::DrawingArea {
                                 set_vexpand: true,
-                                set_hscrollbar_policy: gtk4::PolicyType::Never,
-                                set_vscrollbar_policy: gtk4::PolicyType::Automatic,
-                                set_overlay_scrolling: false,
-                                set_css_classes: &["search-results-scroll"],
-
-                                #[name = "search_results_list"]
-                                gtk4::ListBox {
-                                    set_selection_mode: gtk4::SelectionMode::Single,
-                                    set_css_classes: &["search-results-list"],
-                                },
                             },
                         },
 
@@ -2224,7 +2084,8 @@ impl SimpleComponent for App {
         // initial_width + total_offset instead of accumulating delta per event.
         let sidebar_drag_start_w: Rc<Cell<i32>> = Rc::new(Cell::new(300));
         let explorer_panel_box_ref: Rc<RefCell<Option<gtk4::Box>>> = Rc::new(RefCell::new(None));
-        let search_panel_box_ref: Rc<RefCell<Option<gtk4::Box>>> = Rc::new(RefCell::new(None));
+        let search_sidebar_da_ref: Rc<RefCell<Option<gtk4::DrawingArea>>> =
+            Rc::new(RefCell::new(None));
         let debug_panel_box_ref: Rc<RefCell<Option<gtk4::Box>>> = Rc::new(RefCell::new(None));
         let git_panel_box_ref: Rc<RefCell<Option<gtk4::Box>>> = Rc::new(RefCell::new(None));
         let ext_panel_box_ref: Rc<RefCell<Option<gtk4::Box>>> = Rc::new(RefCell::new(None));
@@ -2237,8 +2098,6 @@ impl SimpleComponent for App {
         let settings_da_ref: Rc<RefCell<Option<gtk4::DrawingArea>>> = Rc::new(RefCell::new(None));
         let ai_panel_box_ref: Rc<RefCell<Option<gtk4::Box>>> = Rc::new(RefCell::new(None));
         let ai_sidebar_da_ref: Rc<RefCell<Option<gtk4::DrawingArea>>> = Rc::new(RefCell::new(None));
-        let search_results_list_ref: Rc<RefCell<Option<gtk4::ListBox>>> =
-            Rc::new(RefCell::new(None));
 
         // Set up file watcher for settings.json
         let settings_path = std::env::var("HOME")
@@ -2349,7 +2208,7 @@ impl SimpleComponent for App {
             sidebar_inner_sw: sidebar_inner_sw_ref.clone(),
             sidebar_revealer: sidebar_revealer_ref.clone(),
             explorer_panel_box: explorer_panel_box_ref.clone(),
-            search_panel_box: search_panel_box_ref.clone(),
+            search_sidebar_da_ref: search_sidebar_da_ref.clone(),
             debug_panel_box: debug_panel_box_ref.clone(),
             git_panel_box: git_panel_box_ref.clone(),
             ext_panel_box: ext_panel_box_ref.clone(),
@@ -2358,8 +2217,6 @@ impl SimpleComponent for App {
             settings_panel_box: settings_panel_box_ref.clone(),
             settings_da_ref: settings_da_ref.clone(),
             ai_panel_box_ref: ai_panel_box_ref.clone(),
-            project_search_status: String::new(),
-            search_results_list: search_results_list_ref.clone(),
             last_clipboard_content: None,
             clipboard,
             h_sb_dragging: None,
@@ -2413,14 +2270,67 @@ impl SimpleComponent for App {
         *sidebar_inner_sw_ref.borrow_mut() = Some(widgets.sidebar_inner_sw.clone());
         *sidebar_revealer_ref.borrow_mut() = Some(widgets.sidebar_revealer.clone());
         *explorer_panel_box_ref.borrow_mut() = Some(widgets.explorer_panel.clone());
-        *search_panel_box_ref.borrow_mut() = Some(widgets.search_panel.clone());
+        *search_sidebar_da_ref.borrow_mut() = Some(widgets.search_sidebar_da.clone());
         *debug_panel_box_ref.borrow_mut() = Some(widgets.debug_panel.clone());
         *git_panel_box_ref.borrow_mut() = Some(widgets.git_panel.clone());
         *ext_panel_box_ref.borrow_mut() = Some(widgets.ext_panel.clone());
         *ext_dyn_panel_box_ref.borrow_mut() = Some(widgets.ext_dyn_panel.clone());
         *settings_panel_box_ref.borrow_mut() = Some(widgets.settings_panel.clone());
         *ai_panel_box_ref.borrow_mut() = Some(widgets.ai_panel_box.clone());
-        *search_results_list_ref.borrow_mut() = Some(widgets.search_results_list.clone());
+        // ── Search sidebar DrawingArea setup ──────────────────────────────
+        {
+            let engine = engine.clone();
+            let backend_d = backend.clone();
+            widgets
+                .search_sidebar_da
+                .set_draw_func(move |da, cr, _w, _h| {
+                    let engine = engine.borrow();
+                    let theme = Theme::from_name(&engine.settings.colorscheme);
+                    let q_theme = crate::gtk::quadraui_gtk::q_theme(&theme);
+                    let root = engine.cwd.clone();
+                    let view = render::build_search_panel_msv(&engine, &root);
+                    let w = da.width() as f64;
+                    let h = da.height() as f64;
+                    let pango_ctx = pangocairo::create_context(cr);
+                    let font_desc = pango::FontDescription::from_string(&draw::UI_FONT());
+                    let pango_layout = pango::Layout::new(&pango_ctx);
+                    pango_layout.set_font_description(Some(&font_desc));
+                    let area = quadraui::Rect::new(0.0, 0.0, w as f32, h as f32);
+                    use quadraui::Backend;
+                    backend_d
+                        .borrow_mut()
+                        .enter_frame_scope(cr, &pango_layout, |b| {
+                            b.set_current_theme(q_theme);
+                            let line_height = {
+                                pango_layout.set_text("Xy");
+                                pango_layout.pixel_size().1 as f64
+                            };
+                            b.set_current_line_height(line_height);
+                            b.draw_multi_section_view(area, &view);
+                        });
+                });
+        }
+        {
+            let sender_click = sender.input_sender().clone();
+            let gesture = gtk4::GestureClick::new();
+            gesture.set_button(1);
+            gesture.connect_pressed(move |_, _, x, y| {
+                sender_click.send(Msg::SearchPanelClick(x, y)).ok();
+            });
+            widgets.search_sidebar_da.add_controller(gesture);
+        }
+        {
+            let sender_key = sender.input_sender().clone();
+            let key_ctrl = gtk4::EventControllerKey::new();
+            key_ctrl.connect_key_pressed(move |_, key, _, _modifier| {
+                let key_name = key.name().map(|s| s.to_string()).unwrap_or_default();
+                let unicode = key.to_unicode().filter(|c| !c.is_control());
+                sender_key.send(Msg::SearchPanelKey(key_name, unicode)).ok();
+                gtk4::glib::Propagation::Stop
+            });
+            widgets.search_sidebar_da.set_focusable(true);
+            widgets.search_sidebar_da.add_controller(key_ctrl);
+        }
 
         // ── Settings sidebar (Phase A.3c-2: native widgets → DrawingArea) ──────
         {
@@ -4830,15 +4740,11 @@ impl SimpleComponent for App {
             Msg::ProjectReplaceAll => {
                 let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 self.engine.borrow_mut().start_project_replace(cwd);
-                let status = self.engine.borrow().message.clone();
-                self.project_search_status = status;
                 self.draw_needed.set(true);
             }
             Msg::ProjectSearchSubmit => {
                 let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 self.engine.borrow_mut().start_project_search(cwd);
-                let status = self.engine.borrow().message.clone();
-                self.project_search_status = status;
                 self.draw_needed.set(true);
             }
             Msg::SearchPollTick => {
@@ -4861,6 +4767,72 @@ impl SimpleComponent for App {
                     self.engine.borrow_mut().ensure_cursor_visible();
                 }
                 self.draw_needed.set(true);
+            }
+            Msg::SearchPanelClick(_x, _y) => {
+                // TODO: MSV hit_test → form/tree dispatch (same as TUI)
+                self.draw_needed.set(true);
+                if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
+                    da.queue_draw();
+                }
+            }
+            Msg::SearchPanelKey(key_name, unicode) => {
+                let mapped = map_gtk_key_name(key_name.as_str());
+                let mut engine = self.engine.borrow_mut();
+                let is_query =
+                    engine.search_panel_form_focus.borrow().as_deref() == Some("search:query");
+                let is_replace =
+                    engine.search_panel_form_focus.borrow().as_deref() == Some("search:replace");
+                match mapped {
+                    "Return" => {
+                        if is_replace {
+                            let cwd = engine.cwd.clone();
+                            engine.start_project_replace(cwd);
+                        } else {
+                            let cwd = engine.cwd.clone();
+                            engine.start_project_search(cwd);
+                        }
+                    }
+                    "BackSpace" => {
+                        if is_replace {
+                            engine.project_replace_text.pop();
+                        } else if is_query {
+                            engine.project_search_query.pop();
+                        }
+                    }
+                    "Tab" => {
+                        if is_query {
+                            engine
+                                .search_panel_form_focus
+                                .replace(Some("search:replace".to_string()));
+                        } else {
+                            engine
+                                .search_panel_form_focus
+                                .replace(Some("search:query".to_string()));
+                        }
+                    }
+                    "Escape" => {
+                        engine.search_panel_form_focus.replace(None);
+                    }
+                    _ => {
+                        if let Some(ch) = unicode {
+                            if is_replace {
+                                engine.project_replace_text.push(ch);
+                            } else {
+                                if !is_query {
+                                    engine
+                                        .search_panel_form_focus
+                                        .replace(Some("search:query".to_string()));
+                                }
+                                engine.project_search_query.push(ch);
+                            }
+                        }
+                    }
+                }
+                drop(engine);
+                self.draw_needed.set(true);
+                if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
+                    da.queue_draw();
+                }
             }
             Msg::RenameFile(_, _)
             | Msg::MoveFile(_, _)
@@ -5242,78 +5214,6 @@ impl App {
             }
             self.last_clipboard_content = new_content;
         }
-    }
-
-    /// Rebuild the search results ListBox from current engine state.
-    fn rebuild_search_results(&self, sender: &relm4::Sender<Msg>) {
-        let list = match self.search_results_list.borrow().as_ref() {
-            Some(l) => l.clone(),
-            None => return,
-        };
-
-        // Remove all existing rows
-        while let Some(child) = list.first_child() {
-            list.remove(&child);
-        }
-
-        let engine = self.engine.borrow();
-        let results = &engine.project_search_results;
-        if results.is_empty() {
-            return;
-        }
-
-        let theme = Theme::from_name(&engine.settings.colorscheme);
-        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let mut last_file: Option<PathBuf> = None;
-
-        for (idx, m) in results.iter().enumerate() {
-            // Add a file header row when the file changes
-            if last_file.as_deref() != Some(&m.file) {
-                last_file = Some(m.file.clone());
-                let rel = m.file.strip_prefix(&cwd).unwrap_or(&m.file);
-                let file_label = gtk4::Label::new(None);
-                let header_markup = format!(
-                    "<b><span foreground='{}'>{}</span></b>",
-                    theme.function.to_hex(),
-                    gtk4::glib::markup_escape_text(&rel.display().to_string())
-                );
-                file_label.set_markup(&header_markup);
-                file_label.set_halign(gtk4::Align::Start);
-                file_label.set_margin_top(4);
-                file_label.set_margin_start(4);
-                let header_row = gtk4::ListBoxRow::new();
-                header_row.set_selectable(false);
-                header_row.set_child(Some(&file_label));
-                list.append(&header_row);
-            }
-
-            // Result row
-            let snippet = format!("  {}: {}", m.line + 1, m.line_text.trim());
-            let row_label = gtk4::Label::new(None);
-            let result_markup = format!(
-                "<span foreground='{}'>{}</span>",
-                theme.foreground.to_hex(),
-                gtk4::glib::markup_escape_text(&snippet)
-            );
-            row_label.set_markup(&result_markup);
-            row_label.set_halign(gtk4::Align::Start);
-            row_label.set_ellipsize(pango::EllipsizeMode::End);
-            row_label.set_margin_start(4);
-            let result_row = gtk4::ListBoxRow::new();
-            result_row.set_selectable(true);
-
-            // Tag the row with its result index via the widget name
-            result_row.set_widget_name(&idx.to_string());
-            result_row.set_child(Some(&row_label));
-            list.append(&result_row);
-        }
-
-        let sender_clone = sender.clone();
-        list.connect_row_activated(move |_, row| {
-            if let Ok(idx) = row.widget_name().parse::<usize>() {
-                sender_clone.send(Msg::ProjectSearchOpenResult(idx)).ok();
-            }
-        });
     }
 
     /// Rebuild and sync scrollbars for all windows
@@ -6050,17 +5950,15 @@ impl App {
             }
         }
         if self.engine.borrow_mut().poll_project_search() {
-            let status = self.engine.borrow().message.clone();
-            self.project_search_status = status;
-            let s = self.sender.clone();
-            self.rebuild_search_results(&s);
+            if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
+                da.queue_draw();
+            }
             self.draw_needed.set(true);
         }
         if self.engine.borrow_mut().poll_project_replace() {
-            let status = self.engine.borrow().message.clone();
-            self.project_search_status = status;
-            let s = self.sender.clone();
-            self.rebuild_search_results(&s);
+            if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
+                da.queue_draw();
+            }
             self.draw_needed.set(true);
         }
         // LSP: flush debounced didChange notifications and poll for events
@@ -10233,7 +10131,6 @@ impl App {
                 }
                 for (which, panel_ref) in [
                     (SidebarPanel::Explorer, &self.explorer_panel_box),
-                    (SidebarPanel::Search, &self.search_panel_box),
                     (SidebarPanel::Debug, &self.debug_panel_box),
                     (SidebarPanel::Git, &self.git_panel_box),
                     (SidebarPanel::Extensions, &self.ext_panel_box),
@@ -10339,7 +10236,6 @@ impl App {
                 }
                 for (which, panel_ref) in [
                     (SidebarPanel::Explorer, &self.explorer_panel_box),
-                    (SidebarPanel::Search, &self.search_panel_box),
                     (SidebarPanel::Debug, &self.debug_panel_box),
                     (SidebarPanel::Git, &self.git_panel_box),
                     (SidebarPanel::Extensions, &self.ext_panel_box),

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2278,6 +2278,9 @@ impl SimpleComponent for App {
         *settings_panel_box_ref.borrow_mut() = Some(widgets.settings_panel.clone());
         *ai_panel_box_ref.borrow_mut() = Some(widgets.ai_panel_box.clone());
         // ── Search sidebar DrawingArea setup ──────────────────────────────
+        backend
+            .borrow_mut()
+            .set_pango_context(widgets.search_sidebar_da.pango_context());
         {
             let engine = engine.clone();
             let backend_d = backend.clone();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4820,8 +4820,38 @@ impl SimpleComponent for App {
                                     let form_layout = form.layout(
                                         sl.body_bounds.width,
                                         sl.body_bounds.height,
-                                        |_| {
-                                            quadraui::primitives::form::FormFieldMeasure::new(row_h)
+                                        |i| {
+                                            use quadraui::primitives::form::{
+                                                FieldKind, FormFieldMeasure, FormItemMeasure,
+                                            };
+                                            let field = &form.fields[i];
+                                            match &field.kind {
+                                                FieldKind::ToggleGroup { toggles } => {
+                                                    let items = toggles
+                                                        .iter()
+                                                        .map(|t| FormItemMeasure {
+                                                            id: t.id.clone(),
+                                                            width: t.label.len() as f32 * 8.0,
+                                                        })
+                                                        .collect();
+                                                    FormFieldMeasure::with_items(
+                                                        row_h, 8.0, 8.0, items,
+                                                    )
+                                                }
+                                                FieldKind::ButtonRow { buttons } => {
+                                                    let items = buttons
+                                                        .iter()
+                                                        .map(|b| FormItemMeasure {
+                                                            id: b.id.clone(),
+                                                            width: (b.label.len() + 2) as f32 * 8.0,
+                                                        })
+                                                        .collect();
+                                                    FormFieldMeasure::with_items(
+                                                        row_h, 8.0, 8.0, items,
+                                                    )
+                                                }
+                                                _ => FormFieldMeasure::new(row_h),
+                                            }
                                         },
                                     );
                                     let local_x = hx - sl.body_bounds.x;
@@ -4886,8 +4916,14 @@ impl SimpleComponent for App {
                     "BackSpace" => {
                         if is_replace {
                             engine.project_replace_text.pop();
+                            engine
+                                .replace_text_caret
+                                .set(engine.project_replace_text.len());
                         } else if is_query {
                             engine.project_search_query.pop();
+                            engine
+                                .search_query_caret
+                                .set(engine.project_search_query.len());
                         }
                     }
                     "Tab" => {
@@ -4908,6 +4944,9 @@ impl SimpleComponent for App {
                         if let Some(ch) = unicode {
                             if is_replace {
                                 engine.project_replace_text.push(ch);
+                                engine
+                                    .replace_text_caret
+                                    .set(engine.project_replace_text.len());
                             } else {
                                 if !is_query {
                                     engine
@@ -4915,6 +4954,9 @@ impl SimpleComponent for App {
                                         .replace(Some("search:query".to_string()));
                                 }
                                 engine.project_search_query.push(ch);
+                                engine
+                                    .search_query_caret
+                                    .set(engine.project_search_query.len());
                             }
                         }
                     }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2312,9 +2312,11 @@ impl SimpleComponent for App {
         }
         {
             let sender_click = sender.input_sender().clone();
+            let da_for_click = widgets.search_sidebar_da.clone();
             let gesture = gtk4::GestureClick::new();
             gesture.set_button(1);
             gesture.connect_pressed(move |_, _, x, y| {
+                da_for_click.grab_focus();
                 sender_click.send(Msg::SearchPanelClick(x, y)).ok();
             });
             widgets.search_sidebar_da.add_controller(gesture);
@@ -4768,8 +4770,98 @@ impl SimpleComponent for App {
                 }
                 self.draw_needed.set(true);
             }
-            Msg::SearchPanelClick(_x, _y) => {
-                // TODO: MSV hit_test → form/tree dispatch (same as TUI)
+            Msg::SearchPanelClick(x, y) => {
+                let root = self.engine.borrow().cwd.clone();
+                let view = render::build_search_panel_msv(&self.engine.borrow(), &root);
+                let da_w = self
+                    .search_sidebar_da_ref
+                    .borrow()
+                    .as_ref()
+                    .map(|da| da.width() as f32)
+                    .unwrap_or(200.0);
+                let da_h = self
+                    .search_sidebar_da_ref
+                    .borrow()
+                    .as_ref()
+                    .map(|da| da.height() as f32)
+                    .unwrap_or(400.0);
+                let bounds = quadraui::Rect::new(0.0, 0.0, da_w, da_h);
+                let line_height = 20.0_f32;
+                let metrics = quadraui::MsvLayoutMetrics {
+                    header_size: line_height,
+                    divider_size: 0.0,
+                    scrollbar_size: 12.0,
+                    cell_quantum: 0.0,
+                };
+                let layout = view.layout(bounds, metrics, |i| {
+                    let s = &view.sections[i];
+                    let aux_size = if s.aux.is_some() {
+                        metrics.header_size
+                    } else {
+                        0.0
+                    };
+                    let content_size = match &s.body {
+                        quadraui::SectionBody::Tree(t) => t.rows.len() as f32 * metrics.header_size,
+                        quadraui::SectionBody::Form(f) => {
+                            f.fields.len() as f32 * metrics.header_size
+                        }
+                        _ => 0.0,
+                    };
+                    quadraui::SectionMeasure {
+                        content_size,
+                        aux_size,
+                    }
+                });
+                let hx = x as f32;
+                let hy = y as f32;
+                match layout.hit_test(hx, hy) {
+                    quadraui::MultiSectionViewHit::Body { section: 0, .. } => {
+                        if let Some(sl) = layout.sections.first() {
+                            if let quadraui::SectionBody::Form(ref form) = view.sections[0].body {
+                                let form_layout = quadraui::tui::tui_form_layout(
+                                    form,
+                                    ratatui::layout::Rect {
+                                        x: 0,
+                                        y: 0,
+                                        width: sl.body_bounds.width as u16,
+                                        height: sl.body_bounds.height as u16,
+                                    },
+                                );
+                                let local_x = hx - sl.body_bounds.x;
+                                let local_y = hy - sl.body_bounds.y;
+                                if let quadraui::FormHit::Field(id) =
+                                    form_layout.hit_test(local_x, local_y)
+                                {
+                                    self.engine.borrow_mut().handle_search_form_hit(id.as_str());
+                                }
+                            }
+                        }
+                    }
+                    quadraui::MultiSectionViewHit::Body { section: 1, .. } => {
+                        if let Some(sl) = layout.sections.get(1) {
+                            if let quadraui::SectionBody::Tree(ref tree) = view.sections[1].body {
+                                let tree_layout = quadraui::tui::tui_tree_layout(
+                                    tree,
+                                    ratatui::layout::Rect {
+                                        x: 0,
+                                        y: 0,
+                                        width: sl.body_bounds.width as u16,
+                                        height: sl.body_bounds.height as u16,
+                                    },
+                                );
+                                let local_x = hx - sl.body_bounds.x;
+                                let local_y = hy - sl.body_bounds.y;
+                                if let quadraui::TreeViewHit::Row(row_idx) =
+                                    tree_layout.hit_test(local_x, local_y)
+                                {
+                                    let path = tree.rows[row_idx].path.clone();
+                                    self.engine.borrow_mut().handle_search_tree_hit(&path);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
                 self.draw_needed.set(true);
                 if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
                     da.queue_draw();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4810,55 +4810,20 @@ impl SimpleComponent for App {
                 if let Some(ref layout) = cached {
                     let root = self.engine.borrow().cwd.clone();
                     let view = render::build_search_panel_msv(&self.engine.borrow(), &root);
+                    use quadraui::Backend;
+                    let backend = self.backend.borrow();
                     match layout.hit_test(hx, hy) {
                         quadraui::MultiSectionViewHit::Body { section: 0, .. } => {
                             if let Some(sl) = layout.sections.first() {
                                 if let quadraui::SectionBody::Form(ref form) = view.sections[0].body
                                 {
-                                    let row_h =
-                                        sl.body_bounds.height / form.fields.len().max(1) as f32;
-                                    let form_layout = form.layout(
-                                        sl.body_bounds.width,
-                                        sl.body_bounds.height,
-                                        |i| {
-                                            use quadraui::primitives::form::{
-                                                FieldKind, FormFieldMeasure, FormItemMeasure,
-                                            };
-                                            let field = &form.fields[i];
-                                            match &field.kind {
-                                                FieldKind::ToggleGroup { toggles } => {
-                                                    let items = toggles
-                                                        .iter()
-                                                        .map(|t| FormItemMeasure {
-                                                            id: t.id.clone(),
-                                                            width: t.label.len() as f32 * 8.0,
-                                                        })
-                                                        .collect();
-                                                    FormFieldMeasure::with_items(
-                                                        row_h, 8.0, 8.0, items,
-                                                    )
-                                                }
-                                                FieldKind::ButtonRow { buttons } => {
-                                                    let items = buttons
-                                                        .iter()
-                                                        .map(|b| FormItemMeasure {
-                                                            id: b.id.clone(),
-                                                            width: (b.label.len() + 2) as f32 * 8.0,
-                                                        })
-                                                        .collect();
-                                                    FormFieldMeasure::with_items(
-                                                        row_h, 8.0, 8.0, items,
-                                                    )
-                                                }
-                                                _ => FormFieldMeasure::new(row_h),
-                                            }
-                                        },
-                                    );
+                                    let form_layout = backend.form_layout(sl.body_bounds, form);
                                     let local_x = hx - sl.body_bounds.x;
                                     let local_y = hy - sl.body_bounds.y;
                                     if let quadraui::FormHit::Field(id) =
                                         form_layout.hit_test(local_x, local_y)
                                     {
+                                        drop(backend);
                                         self.engine
                                             .borrow_mut()
                                             .handle_search_form_hit(id.as_str());
@@ -4870,19 +4835,14 @@ impl SimpleComponent for App {
                             if let Some(sl) = layout.sections.get(1) {
                                 if let quadraui::SectionBody::Tree(ref tree) = view.sections[1].body
                                 {
-                                    let row_h =
-                                        sl.body_bounds.height / tree.rows.len().max(1) as f32;
-                                    let tree_layout = tree.layout(
-                                        sl.body_bounds.width,
-                                        sl.body_bounds.height,
-                                        |_| quadraui::TreeRowMeasure { height: row_h },
-                                    );
+                                    let tree_layout = backend.tree_layout(sl.body_bounds, tree);
                                     let local_x = hx - sl.body_bounds.x;
                                     let local_y = hy - sl.body_bounds.y;
                                     if let quadraui::TreeViewHit::Row(row_idx) =
                                         tree_layout.hit_test(local_x, local_y)
                                     {
                                         let path = tree.rows[row_idx].path.clone();
+                                        drop(backend);
                                         self.engine.borrow_mut().handle_search_tree_hit(&path);
                                     }
                                 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2297,17 +2297,45 @@ impl SimpleComponent for App {
                     pango_layout.set_font_description(Some(&font_desc));
                     let area = quadraui::Rect::new(0.0, 0.0, w as f32, h as f32);
                     use quadraui::Backend;
+                    let line_height = {
+                        pango_layout.set_text("Xy");
+                        pango_layout.pixel_size().1 as f64
+                    };
                     backend_d
                         .borrow_mut()
                         .enter_frame_scope(cr, &pango_layout, |b| {
                             b.set_current_theme(q_theme);
-                            let line_height = {
-                                pango_layout.set_text("Xy");
-                                pango_layout.pixel_size().1 as f64
-                            };
                             b.set_current_line_height(line_height);
                             b.draw_multi_section_view(area, &view);
                         });
+                    let metrics = quadraui::MsvLayoutMetrics {
+                        header_size: line_height as f32,
+                        divider_size: 0.0,
+                        scrollbar_size: 12.0,
+                        cell_quantum: 0.0,
+                    };
+                    let layout = view.layout(area, metrics, |i| {
+                        let s = &view.sections[i];
+                        let aux_size = if s.aux.is_some() {
+                            metrics.header_size
+                        } else {
+                            0.0
+                        };
+                        let content_size = match &s.body {
+                            quadraui::SectionBody::Tree(t) => {
+                                t.rows.len() as f32 * line_height as f32
+                            }
+                            quadraui::SectionBody::Form(f) => {
+                                f.fields.len() as f32 * line_height as f32
+                            }
+                            _ => 0.0,
+                        };
+                        quadraui::SectionMeasure {
+                            content_size,
+                            aux_size,
+                        }
+                    });
+                    engine.search_panel_msv_layout.replace(Some(layout));
                 });
         }
         {
@@ -4771,96 +4799,67 @@ impl SimpleComponent for App {
                 self.draw_needed.set(true);
             }
             Msg::SearchPanelClick(x, y) => {
-                let root = self.engine.borrow().cwd.clone();
-                let view = render::build_search_panel_msv(&self.engine.borrow(), &root);
-                let da_w = self
-                    .search_sidebar_da_ref
-                    .borrow()
-                    .as_ref()
-                    .map(|da| da.width() as f32)
-                    .unwrap_or(200.0);
-                let da_h = self
-                    .search_sidebar_da_ref
-                    .borrow()
-                    .as_ref()
-                    .map(|da| da.height() as f32)
-                    .unwrap_or(400.0);
-                let bounds = quadraui::Rect::new(0.0, 0.0, da_w, da_h);
-                let line_height = 20.0_f32;
-                let metrics = quadraui::MsvLayoutMetrics {
-                    header_size: line_height,
-                    divider_size: 0.0,
-                    scrollbar_size: 12.0,
-                    cell_quantum: 0.0,
-                };
-                let layout = view.layout(bounds, metrics, |i| {
-                    let s = &view.sections[i];
-                    let aux_size = if s.aux.is_some() {
-                        metrics.header_size
-                    } else {
-                        0.0
-                    };
-                    let content_size = match &s.body {
-                        quadraui::SectionBody::Tree(t) => t.rows.len() as f32 * metrics.header_size,
-                        quadraui::SectionBody::Form(f) => {
-                            f.fields.len() as f32 * metrics.header_size
-                        }
-                        _ => 0.0,
-                    };
-                    quadraui::SectionMeasure {
-                        content_size,
-                        aux_size,
-                    }
-                });
                 let hx = x as f32;
                 let hy = y as f32;
-                match layout.hit_test(hx, hy) {
-                    quadraui::MultiSectionViewHit::Body { section: 0, .. } => {
-                        if let Some(sl) = layout.sections.first() {
-                            if let quadraui::SectionBody::Form(ref form) = view.sections[0].body {
-                                let form_layout = quadraui::tui::tui_form_layout(
-                                    form,
-                                    ratatui::layout::Rect {
-                                        x: 0,
-                                        y: 0,
-                                        width: sl.body_bounds.width as u16,
-                                        height: sl.body_bounds.height as u16,
-                                    },
-                                );
-                                let local_x = hx - sl.body_bounds.x;
-                                let local_y = hy - sl.body_bounds.y;
-                                if let quadraui::FormHit::Field(id) =
-                                    form_layout.hit_test(local_x, local_y)
+                let cached = self
+                    .engine
+                    .borrow()
+                    .search_panel_msv_layout
+                    .borrow()
+                    .clone();
+                if let Some(ref layout) = cached {
+                    let root = self.engine.borrow().cwd.clone();
+                    let view = render::build_search_panel_msv(&self.engine.borrow(), &root);
+                    match layout.hit_test(hx, hy) {
+                        quadraui::MultiSectionViewHit::Body { section: 0, .. } => {
+                            if let Some(sl) = layout.sections.first() {
+                                if let quadraui::SectionBody::Form(ref form) = view.sections[0].body
                                 {
-                                    self.engine.borrow_mut().handle_search_form_hit(id.as_str());
+                                    let row_h =
+                                        sl.body_bounds.height / form.fields.len().max(1) as f32;
+                                    let form_layout = form.layout(
+                                        sl.body_bounds.width,
+                                        sl.body_bounds.height,
+                                        |_| {
+                                            quadraui::primitives::form::FormFieldMeasure::new(row_h)
+                                        },
+                                    );
+                                    let local_x = hx - sl.body_bounds.x;
+                                    let local_y = hy - sl.body_bounds.y;
+                                    if let quadraui::FormHit::Field(id) =
+                                        form_layout.hit_test(local_x, local_y)
+                                    {
+                                        self.engine
+                                            .borrow_mut()
+                                            .handle_search_form_hit(id.as_str());
+                                    }
                                 }
                             }
                         }
-                    }
-                    quadraui::MultiSectionViewHit::Body { section: 1, .. } => {
-                        if let Some(sl) = layout.sections.get(1) {
-                            if let quadraui::SectionBody::Tree(ref tree) = view.sections[1].body {
-                                let tree_layout = quadraui::tui::tui_tree_layout(
-                                    tree,
-                                    ratatui::layout::Rect {
-                                        x: 0,
-                                        y: 0,
-                                        width: sl.body_bounds.width as u16,
-                                        height: sl.body_bounds.height as u16,
-                                    },
-                                );
-                                let local_x = hx - sl.body_bounds.x;
-                                let local_y = hy - sl.body_bounds.y;
-                                if let quadraui::TreeViewHit::Row(row_idx) =
-                                    tree_layout.hit_test(local_x, local_y)
+                        quadraui::MultiSectionViewHit::Body { section: 1, .. } => {
+                            if let Some(sl) = layout.sections.get(1) {
+                                if let quadraui::SectionBody::Tree(ref tree) = view.sections[1].body
                                 {
-                                    let path = tree.rows[row_idx].path.clone();
-                                    self.engine.borrow_mut().handle_search_tree_hit(&path);
+                                    let row_h =
+                                        sl.body_bounds.height / tree.rows.len().max(1) as f32;
+                                    let tree_layout = tree.layout(
+                                        sl.body_bounds.width,
+                                        sl.body_bounds.height,
+                                        |_| quadraui::TreeRowMeasure { height: row_h },
+                                    );
+                                    let local_x = hx - sl.body_bounds.x;
+                                    let local_y = hy - sl.body_bounds.y;
+                                    if let quadraui::TreeViewHit::Row(row_idx) =
+                                        tree_layout.hit_test(local_x, local_y)
+                                    {
+                                        let path = tree.rows[row_idx].path.clone();
+                                        self.engine.borrow_mut().handle_search_tree_hit(&path);
+                                    }
                                 }
                             }
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
                 self.draw_needed.set(true);
                 if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2315,33 +2315,7 @@ impl SimpleComponent for App {
                             b.set_current_char_width(char_width);
                             b.draw_multi_section_view(area, &view);
                         });
-                    let metrics = quadraui::MsvLayoutMetrics {
-                        header_size: line_height as f32,
-                        divider_size: 0.0,
-                        scrollbar_size: 12.0,
-                        cell_quantum: 0.0,
-                    };
-                    let layout = view.layout(area, metrics, |i| {
-                        let s = &view.sections[i];
-                        let aux_size = if s.aux.is_some() {
-                            metrics.header_size
-                        } else {
-                            0.0
-                        };
-                        let content_size = match &s.body {
-                            quadraui::SectionBody::Tree(t) => {
-                                t.rows.len() as f32 * line_height as f32
-                            }
-                            quadraui::SectionBody::Form(f) => {
-                                f.fields.len() as f32 * line_height as f32
-                            }
-                            _ => 0.0,
-                        };
-                        quadraui::SectionMeasure {
-                            content_size,
-                            aux_size,
-                        }
-                    });
+                    let layout = backend_d.borrow().msv_layout(area, &view);
                     engine.search_panel_msv_layout.replace(Some(layout));
                 });
         }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2297,15 +2297,16 @@ impl SimpleComponent for App {
                     pango_layout.set_font_description(Some(&font_desc));
                     let area = quadraui::Rect::new(0.0, 0.0, w as f32, h as f32);
                     use quadraui::Backend;
-                    let line_height = {
-                        pango_layout.set_text("Xy");
-                        pango_layout.pixel_size().1 as f64
-                    };
+                    pango_layout.set_text("Xy");
+                    let line_height = pango_layout.pixel_size().1 as f64;
+                    pango_layout.set_text("M");
+                    let char_width = pango_layout.pixel_size().0 as f64;
                     backend_d
                         .borrow_mut()
                         .enter_frame_scope(cr, &pango_layout, |b| {
                             b.set_current_theme(q_theme);
                             b.set_current_line_height(line_height);
+                            b.set_current_char_width(char_width);
                             b.draw_multi_section_view(area, &view);
                         });
                     let metrics = quadraui::MsvLayoutMetrics {

--- a/src/render.rs
+++ b/src/render.rs
@@ -3595,11 +3595,13 @@ pub fn build_search_panel_msv(
                     value: StyledText::plain(if results.is_empty() {
                         if engine.project_search_query.is_empty() {
                             "Type to search, Enter to run".to_string()
+                        } else if engine.project_search_status.is_empty() {
+                            String::new()
                         } else {
-                            engine.message.clone()
+                            engine.project_search_status.clone()
                         }
                     } else {
-                        engine.message.clone()
+                        engine.project_search_status.clone()
                     }),
                 },
                 hint: StyledText::default(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -17,6 +17,7 @@ use crate::core::dap::DapVariable;
 use crate::core::engine::{AlignedDiffEntry, DiffLine, Engine, SearchDirection};
 pub use crate::core::engine::{BottomPanelKind, DebugSidebarSection};
 use crate::core::lsp::SignatureHelpData;
+use crate::core::project_search::ProjectMatch;
 use crate::core::settings::LineNumberMode;
 use crate::core::terminal::TermSelection as CoreTermSelection;
 use crate::core::view::View;
@@ -3478,6 +3479,307 @@ pub fn build_command_center_view(
         forward_enabled: nav_forward_enabled,
         search_label,
     }
+}
+
+/// Build the search panel as a two-section `MultiSectionView`:
+/// Section 0 = Form (query, replace, toggles, buttons, status)
+/// Section 1 = TreeView (file-grouped results)
+pub fn build_search_panel_msv(
+    engine: &Engine,
+    root: &std::path::Path,
+) -> quadraui::MultiSectionView {
+    use quadraui::primitives::form::{ButtonRowItem, FieldKind, ToggleGroupItem};
+    use quadraui::{
+        Badge, Decoration, Form, FormField, MsvAxis, MultiSectionView, ScrollMode, Section,
+        SectionBody, SectionHeader, SectionSize, SelectionMode, StyledSpan, StyledText, TreeRow,
+        TreeStyle, TreeView, WidgetId,
+    };
+
+    let opts = &engine.project_search_options;
+    let results = &engine.project_search_results;
+
+    // ── Section 0: Form (search chrome) ─────────────────────────────────
+    let form_focus = engine.search_panel_form_focus.borrow();
+    let query_focused = form_focus.as_deref() == Some("search:query");
+    let replace_focused = form_focus.as_deref() == Some("search:replace");
+
+    let form = Form {
+        id: WidgetId::new("search-form"),
+        fields: vec![
+            FormField {
+                id: WidgetId::new("search:query"),
+                label: StyledText::default(),
+                kind: FieldKind::TextInput {
+                    value: engine.project_search_query.clone(),
+                    placeholder: "Search…".to_string(),
+                    cursor: if query_focused {
+                        Some(engine.search_query_caret.get())
+                    } else {
+                        None
+                    },
+                    selection_anchor: None,
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            },
+            FormField {
+                id: WidgetId::new("search:replace"),
+                label: StyledText::default(),
+                kind: FieldKind::TextInput {
+                    value: engine.project_replace_text.clone(),
+                    placeholder: "Replace…".to_string(),
+                    cursor: if replace_focused {
+                        Some(engine.replace_text_caret.get())
+                    } else {
+                        None
+                    },
+                    selection_anchor: None,
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            },
+            FormField {
+                id: WidgetId::new("search:toggles"),
+                label: StyledText::default(),
+                kind: FieldKind::ToggleGroup {
+                    toggles: vec![
+                        ToggleGroupItem {
+                            id: WidgetId::new("search:case"),
+                            label: "Aa".to_string(),
+                            value: opts.case_sensitive,
+                        },
+                        ToggleGroupItem {
+                            id: WidgetId::new("search:word"),
+                            label: "Ab|".to_string(),
+                            value: opts.whole_word,
+                        },
+                        ToggleGroupItem {
+                            id: WidgetId::new("search:regex"),
+                            label: ".*".to_string(),
+                            value: opts.use_regex,
+                        },
+                    ],
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            },
+            FormField {
+                id: WidgetId::new("search:buttons"),
+                label: StyledText::default(),
+                kind: FieldKind::ButtonRow {
+                    buttons: vec![
+                        ButtonRowItem {
+                            id: WidgetId::new("search:find_next"),
+                            label: "Find".to_string(),
+                            disabled: engine.project_search_query.is_empty(),
+                        },
+                        ButtonRowItem {
+                            id: WidgetId::new("search:replace_next"),
+                            label: "Repl".to_string(),
+                            disabled: results.is_empty(),
+                        },
+                        ButtonRowItem {
+                            id: WidgetId::new("search:replace_all"),
+                            label: "All".to_string(),
+                            disabled: results.is_empty(),
+                        },
+                    ],
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            },
+            FormField {
+                id: WidgetId::new("search:status"),
+                label: StyledText::default(),
+                kind: FieldKind::ReadOnly {
+                    value: StyledText::plain(if results.is_empty() {
+                        if engine.project_search_query.is_empty() {
+                            "Type to search, Enter to run".to_string()
+                        } else {
+                            engine.message.clone()
+                        }
+                    } else {
+                        engine.message.clone()
+                    }),
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            },
+        ],
+        focused_field: form_focus.as_deref().map(WidgetId::new),
+        scroll_offset: 0,
+        has_focus: query_focused || replace_focused,
+    };
+
+    // ── Section 1: TreeView (results grouped by file) ───────────────────
+    let mut tree_rows: Vec<TreeRow> = Vec::new();
+    let mut file_idx: usize = 0;
+    let mut last_file: Option<&std::path::Path> = None;
+    let mut match_within_file: usize = 0;
+
+    for (result_idx, m) in results.iter().enumerate() {
+        if last_file != Some(m.file.as_path()) {
+            if last_file.is_some() {
+                file_idx += 1;
+            }
+            last_file = Some(m.file.as_path());
+            match_within_file = 0;
+
+            let rel = m.file.strip_prefix(root).unwrap_or(&m.file);
+            let expanded = engine
+                .search_file_expanded
+                .get(file_idx)
+                .copied()
+                .unwrap_or(true);
+            tree_rows.push(TreeRow {
+                path: vec![file_idx as u16],
+                indent: 0,
+                icon: None,
+                text: StyledText {
+                    spans: vec![StyledSpan::plain(rel.display().to_string())],
+                },
+                badge: None,
+                is_expanded: Some(expanded),
+                decoration: Decoration::Header,
+            });
+        }
+
+        let expanded = engine
+            .search_file_expanded
+            .get(file_idx)
+            .copied()
+            .unwrap_or(true);
+        if expanded {
+            let line_prefix = format!("{:>4}: ", m.line + 1);
+            let is_selected = result_idx == engine.project_search_selected;
+            tree_rows.push(TreeRow {
+                path: vec![file_idx as u16, match_within_file as u16],
+                indent: 1,
+                icon: None,
+                text: StyledText {
+                    spans: vec![
+                        StyledSpan {
+                            text: line_prefix,
+                            fg: Some(quadraui::Color::rgb(100, 100, 100)),
+                            bg: None,
+                            bold: false,
+                            italic: false,
+                            underline: false,
+                        },
+                        StyledSpan::plain(m.line_text.trim().to_string()),
+                    ],
+                },
+                badge: if is_selected {
+                    Some(Badge::plain("←".to_string()))
+                } else {
+                    None
+                },
+                is_expanded: None,
+                decoration: Decoration::Normal,
+            });
+        }
+        match_within_file += 1;
+    }
+
+    let selected_path = if !results.is_empty() {
+        result_idx_to_tree_path(
+            results,
+            &engine.search_file_expanded,
+            engine.project_search_selected,
+        )
+    } else {
+        None
+    };
+
+    let tree = TreeView {
+        id: WidgetId::new("search-results"),
+        rows: tree_rows,
+        selection_mode: SelectionMode::Single,
+        selected_path,
+        scroll_offset: 0,
+        style: TreeStyle::default(),
+        has_focus: !query_focused && !replace_focused,
+    };
+
+    MultiSectionView {
+        id: WidgetId::new("search-panel"),
+        sections: vec![
+            Section {
+                id: "chrome".into(),
+                header: SectionHeader {
+                    icon: None,
+                    title: StyledText {
+                        spans: vec![StyledSpan::plain("SEARCH".to_string())],
+                    },
+                    badge: None,
+                    actions: vec![],
+                    show_chevron: false,
+                },
+                body: SectionBody::Form(form),
+                aux: None,
+                size: SectionSize::Content,
+                collapsed: false,
+                min_size: None,
+                max_size: None,
+            },
+            Section {
+                id: "results".into(),
+                header: SectionHeader {
+                    icon: None,
+                    title: StyledText::default(),
+                    badge: None,
+                    actions: vec![],
+                    show_chevron: false,
+                },
+                body: SectionBody::Tree(tree),
+                aux: None,
+                size: SectionSize::EqualShare,
+                collapsed: false,
+                min_size: None,
+                max_size: None,
+            },
+        ],
+        active_section: if query_focused || replace_focused {
+            Some(0)
+        } else {
+            Some(1)
+        },
+        axis: MsvAxis::Vertical,
+        allow_resize: false,
+        allow_collapse: false,
+        scroll_mode: ScrollMode::PerSection,
+        has_focus: true,
+        panel_scroll: 0.0,
+    }
+}
+
+/// Map a flat `project_search_selected` index to a tree path `[file_idx, match_within_file]`.
+fn result_idx_to_tree_path(
+    results: &[ProjectMatch],
+    _file_expanded: &[bool],
+    selected: usize,
+) -> Option<Vec<u16>> {
+    if selected >= results.len() {
+        return None;
+    }
+    let mut file_idx: usize = 0;
+    let mut last_file: Option<&std::path::Path> = None;
+    let mut match_within_file: usize = 0;
+
+    for (i, m) in results.iter().enumerate() {
+        if last_file != Some(m.file.as_path()) {
+            if last_file.is_some() {
+                file_idx += 1;
+            }
+            last_file = Some(m.file.as_path());
+            match_within_file = 0;
+        }
+        if i == selected {
+            return Some(vec![file_idx as u16, match_within_file as u16]);
+        }
+        match_within_file += 1;
+    }
+    None
 }
 
 /// A modal dialog displayed over the editor.

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2838,88 +2838,69 @@ pub(super) fn handle_mouse(
             return sidebar_width;
         } else if sidebar.active_panel == TuiPanel::Search {
             sidebar.has_focus = true;
-            // results_height = (total height - 2 status rows) - 5 panel header rows
-            let results_height = term_height.saturating_sub(7) as usize;
-            let results = &engine.project_search_results;
-
-            // Click on the scrollbar column in the results area → jump-scroll
-            if col == sb_col && !results.is_empty() && sidebar_row >= 5 {
-                // Count total display rows (result rows + file header rows)
-                let total_display = {
-                    let mut count = 0usize;
-                    let mut last_file: Option<&std::path::Path> = None;
-                    for m in results.iter() {
-                        if last_file != Some(m.file.as_path()) {
-                            last_file = Some(m.file.as_path());
-                            count += 1;
-                        }
-                        count += 1;
-                    }
-                    count
-                };
-                if total_display > results_height {
-                    // Phase B.4 Stage 5c: arm drag state via the shared
-                    // `quadraui::DragState`. `apply_scrollbar_drag` runs
-                    // dispatch_mouse_drag at click time so the click-time
-                    // offset matches subsequent drags (no thumb jump).
-                    let track_start = (5 + menu_rows) as f32;
-                    let grab_offset = scrollbar_grab_offset(
-                        row as f32,
-                        track_start,
-                        results_height as f32,
-                        results_height,
-                        total_display,
-                        sidebar.search_scroll_top,
-                    );
-                    drag_state.begin(quadraui::DragTarget::ScrollbarY {
-                        widget: quadraui::WidgetId::new("tui:search_results"),
-                        track_start,
-                        track_length: results_height as f32,
-                        visible_rows: results_height,
-                        total_items: total_display,
-                        grab_offset,
-                    });
-                    apply_scrollbar_drag(
-                        drag_state,
-                        quadraui::Point {
-                            x: col as f32,
-                            y: row as f32,
-                        },
-                        engine,
-                        sidebar,
-                    );
-                }
-                return sidebar_width;
-            }
-
-            // sidebar_rows 0-2: header + search + replace inputs — clicking enters input mode
-            if sidebar_row <= 2 {
-                sidebar.search_input_mode = true;
-                sidebar.replace_input_focused = sidebar_row == 2;
-            } else {
-                sidebar.search_input_mode = false;
-                sidebar.replace_input_focused = false;
-                // sidebar_row 3 = toggles, 4 = status line; 5+ = results area
-                // Add scroll offset so clicks map to the correct result.
-                let content_row =
-                    (sidebar_row as usize).saturating_sub(5) + sidebar.search_scroll_top;
-                if !results.is_empty() {
-                    let selected = visual_row_to_result_idx(results, content_row);
-                    if let Some(idx) = selected {
-                        engine.project_search_selected = idx;
-                        // Open the file immediately on click
-                        let result = engine
-                            .project_search_results
-                            .get(idx)
-                            .map(|m| (m.file.clone(), m.line));
-                        if let Some((file, line)) = result {
-                            engine.open_file_in_tab(&file);
-                            let win_id = engine.active_window_id();
-                            engine.set_cursor_for_window(win_id, line, 0);
-                            engine.ensure_cursor_visible();
-                            sidebar.has_focus = false;
+            let msv_layout = engine.search_panel_msv_layout.borrow();
+            if let Some(ref layout) = *msv_layout {
+                let hit_x = col as f32;
+                let hit_y = row as f32 + 0.5;
+                match layout.hit_test(hit_x, hit_y) {
+                    quadraui::MultiSectionViewHit::Body { section: 0, .. } => {
+                        if let Some(sl) = layout.sections.first() {
+                            let local_x = hit_x - sl.body_bounds.x;
+                            let local_y = hit_y - sl.body_bounds.y;
+                            let view = render::build_search_panel_msv(engine, &sidebar.root);
+                            if let quadraui::SectionBody::Form(ref form) = view.sections[0].body {
+                                let form_area = ratatui::layout::Rect {
+                                    x: 0,
+                                    y: 0,
+                                    width: sl.body_bounds.width as u16,
+                                    height: sl.body_bounds.height as u16,
+                                };
+                                let form_layout = quadraui::tui::tui_form_layout(form, form_area);
+                                if let quadraui::FormHit::Field(id) =
+                                    form_layout.hit_test(local_x, local_y)
+                                {
+                                    drop(msv_layout);
+                                    engine.handle_search_form_hit(id.as_str());
+                                    sidebar.search_input_mode = id.as_str() == "search:query"
+                                        || id.as_str() == "search:replace";
+                                    sidebar.replace_input_focused = id.as_str() == "search:replace";
+                                    return sidebar_width;
+                                }
+                            }
                         }
                     }
+                    quadraui::MultiSectionViewHit::Body { section: 1, .. } => {
+                        if let Some(sl) = layout.sections.get(1) {
+                            let local_x = hit_x - sl.body_bounds.x;
+                            let local_y = hit_y - sl.body_bounds.y;
+                            let view = render::build_search_panel_msv(engine, &sidebar.root);
+                            if let quadraui::SectionBody::Tree(ref tree) = view.sections[1].body {
+                                let tree_layout = quadraui::tui::tui_tree_layout(
+                                    tree,
+                                    ratatui::layout::Rect {
+                                        x: 0,
+                                        y: 0,
+                                        width: sl.body_bounds.width as u16,
+                                        height: sl.body_bounds.height as u16,
+                                    },
+                                );
+                                if let quadraui::TreeViewHit::Row(row_idx) =
+                                    tree_layout.hit_test(local_x, local_y)
+                                {
+                                    let path = tree.rows[row_idx].path.clone();
+                                    drop(msv_layout);
+                                    sidebar.search_input_mode = false;
+                                    engine.handle_search_tree_hit(&path);
+                                    if path.len() >= 2 {
+                                        sidebar.has_focus = false;
+                                    }
+                                    return sidebar_width;
+                                }
+                            }
+                        }
+                    }
+                    quadraui::MultiSectionViewHit::Header { .. } => {}
+                    _ => {}
                 }
             }
         } else if sidebar.active_panel == TuiPanel::Extensions {

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -1216,29 +1216,7 @@ pub(super) fn ensure_search_selection_visible(
 ///
 /// The results area interleaves file-header rows (not selectable) with result rows.
 /// Returns `None` if the row falls on a file header.
-pub(super) fn visual_row_to_result_idx(
-    results: &[crate::core::ProjectMatch],
-    visual_row: usize,
-) -> Option<usize> {
-    let mut row = 0usize;
-    let mut last_file: Option<&std::path::Path> = None;
-    for (idx, m) in results.iter().enumerate() {
-        if last_file != Some(m.file.as_path()) {
-            last_file = Some(m.file.as_path());
-            if row == visual_row {
-                return None; // file header row
-            }
-            row += 1;
-        }
-        if row == visual_row {
-            return Some(idx);
-        }
-        row += 1;
-    }
-    None
-}
-
-/// Render the project search panel.
+/// Render the project search panel via quadraui MSV + Form + TreeView.
 pub(super) fn render_search_panel(
     buf: &mut ratatui::buffer::Buffer,
     area: Rect,
@@ -1246,316 +1224,64 @@ pub(super) fn render_search_panel(
     engine: &Engine,
     theme: &Theme,
 ) {
-    let header_fg = rc(theme.status_fg);
-    let header_bg = rc(theme.status_bg);
-    let fg = rc(theme.foreground);
-    let bg = rc(theme.tab_bar_bg);
-    let dim_fg = rc(theme.line_number_fg);
-    let sel_fg = bg;
-    let sel_bg = fg;
-    let file_header_fg = rc(theme.keyword);
-
     if area.height == 0 {
         return;
     }
 
-    // Fill background
-    for y in area.y..area.y + area.height {
-        for x in area.x..area.x + area.width {
-            set_cell(buf, x, y, ' ', fg, bg);
-        }
-    }
-
-    // Row 0: panel header " SEARCH"
-    for x in area.x..area.x + area.width {
-        set_cell(buf, x, area.y, ' ', header_fg, header_bg);
-    }
-    let mut x = area.x;
-    for ch in " SEARCH".chars() {
-        if x >= area.x + area.width {
-            break;
-        }
-        set_cell(buf, x, area.y, ch, header_fg, header_bg);
-        x += 1;
-    }
-
-    if area.height < 2 {
-        return;
-    }
-
-    // Row 1: search input box  "[ query___ ]"
-    let input_y = area.y + 1;
-    let query = &engine.project_search_query;
-    let input_bg = rc(theme.active_background);
-    let input_fg = fg;
-    // Draw bracket prefix
-    set_cell(buf, area.x, input_y, '[', dim_fg, bg);
-    let end_bracket_x = if area.width > 1 {
-        area.x + area.width - 1
-    } else {
-        area.x
-    };
-    set_cell(buf, end_bracket_x, input_y, ']', dim_fg, bg);
-    // Fill input background
-    for x in (area.x + 1)..end_bracket_x {
-        set_cell(buf, x, input_y, ' ', input_fg, input_bg);
-    }
-    // Render query text
-    let mut x = area.x + 1;
-    for ch in query.chars() {
-        if x >= end_bracket_x {
-            break;
-        }
-        set_cell(buf, x, input_y, ch, input_fg, input_bg);
-        x += 1;
-    }
-    // Cursor blinking indicator: show │ at cursor position when in input mode
-    if sidebar.search_input_mode && !sidebar.replace_input_focused && x < end_bracket_x {
-        set_cell(buf, x, input_y, '\u{258f}', rc(theme.cursor), input_bg); // ▏
-    }
-
-    if area.height < 3 {
-        return;
-    }
-
-    // Row 2: replace input box  "[ replace_ ]"
-    let replace_y = area.y + 2;
-    let replace_text = &engine.project_replace_text;
-    let replace_bg = if sidebar.replace_input_focused && sidebar.search_input_mode {
-        input_bg
-    } else {
-        rc(theme.tab_bar_bg) // dimmer when unfocused
-    };
-    set_cell(buf, area.x, replace_y, '[', dim_fg, bg);
-    let rep_end_x = if area.width > 1 {
-        area.x + area.width - 1
-    } else {
-        area.x
-    };
-    set_cell(buf, rep_end_x, replace_y, ']', dim_fg, bg);
-    for x in (area.x + 1)..rep_end_x {
-        set_cell(buf, x, replace_y, ' ', input_fg, replace_bg);
-    }
-    // Placeholder or actual text
-    if replace_text.is_empty() && !(sidebar.replace_input_focused && sidebar.search_input_mode) {
-        let placeholder = "Replace…";
-        let mut x = area.x + 1;
-        for ch in placeholder.chars() {
-            if x >= rep_end_x {
-                break;
+    engine
+        .search_panel_form_focus
+        .replace(if sidebar.search_input_mode {
+            if sidebar.replace_input_focused {
+                Some("search:replace".to_string())
+            } else {
+                Some("search:query".to_string())
             }
-            set_cell(buf, x, replace_y, ch, dim_fg, replace_bg);
-            x += 1;
-        }
-    } else {
-        let mut x = area.x + 1;
-        for ch in replace_text.chars() {
-            if x >= rep_end_x {
-                break;
-            }
-            set_cell(buf, x, replace_y, ch, input_fg, replace_bg);
-            x += 1;
-        }
-        if sidebar.replace_input_focused && sidebar.search_input_mode && x < rep_end_x {
-            set_cell(buf, x, replace_y, '\u{258f}', rc(theme.cursor), replace_bg);
-        }
-    }
-
-    if area.height < 4 {
-        return;
-    }
-
-    // Row 3: toggle indicators (Aa / Ab| / .* ) + hint
-    let toggle_y = area.y + 3;
-    for x in area.x..area.x + area.width {
-        set_cell(buf, x, toggle_y, ' ', dim_fg, bg);
-    }
-    {
-        let opts = &engine.project_search_options;
-        let active_fg = rc(theme.keyword);
-        let mut tx = area.x;
-
-        // Helper: render a label with active/inactive coloring
-        let draw_toggle =
-            |buf: &mut ratatui::buffer::Buffer, label: &str, active: bool, x: &mut u16| {
-                let color = if active { active_fg } else { dim_fg };
-                for ch in label.chars() {
-                    if *x >= area.x + area.width {
-                        break;
-                    }
-                    set_cell(buf, *x, toggle_y, ch, color, bg);
-                    *x += 1;
-                }
-                // Space separator
-                if *x < area.x + area.width {
-                    set_cell(buf, *x, toggle_y, ' ', dim_fg, bg);
-                    *x += 1;
-                }
-            };
-
-        draw_toggle(buf, "Aa", opts.case_sensitive, &mut tx);
-        draw_toggle(buf, "Ab|", opts.whole_word, &mut tx);
-        draw_toggle(buf, ".*", opts.use_regex, &mut tx);
-
-        // Hint text
-        let hint = "Alt+C/W/R/H";
-        if tx + 1 < area.x + area.width {
-            // Small gap
-            tx += 1;
-            for ch in hint.chars() {
-                if tx >= area.x + area.width {
-                    break;
-                }
-                set_cell(buf, tx, toggle_y, ch, dim_fg, bg);
-                tx += 1;
-            }
-        }
-    }
-
-    if area.height < 5 {
-        return;
-    }
-
-    // Row 4: status / hint line
-    let status_y = area.y + 4;
-    let status_text = if engine.project_search_results.is_empty() {
-        if query.is_empty() {
-            " Type to search, Enter to run"
         } else {
-            &engine.message
-        }
-    } else {
-        &engine.message
-    };
-    // We borrow status_text potentially as &engine.message which is a &str reference,
-    // so we just render it directly.
-    let mut x = area.x;
-    for ch in status_text.chars() {
-        if x >= area.x + area.width {
-            break;
-        }
-        set_cell(buf, x, status_y, ch, dim_fg, bg);
-        x += 1;
-    }
-
-    if area.height < 6 {
-        return;
-    }
-
-    // Rows 5+: results
-    let results = &engine.project_search_results;
-    if results.is_empty() {
-        return;
-    }
-
-    let results_start_y = area.y + 5;
-    let results_height = area.height.saturating_sub(5) as usize;
-
-    // Build the flat display list (file headers + result rows)
-    struct DisplayRow {
-        text: String,
-        is_header: bool,
-        result_idx: Option<usize>,
-    }
-
-    let mut display_rows: Vec<DisplayRow> = Vec::new();
-    let root = &sidebar.root;
-    let mut last_file: Option<&std::path::Path> = None;
-
-    for (idx, m) in results.iter().enumerate() {
-        if last_file != Some(m.file.as_path()) {
-            last_file = Some(m.file.as_path());
-            let rel = m.file.strip_prefix(root).unwrap_or(&m.file);
-            display_rows.push(DisplayRow {
-                text: rel.display().to_string(),
-                is_header: true,
-                result_idx: None,
-            });
-        }
-        let snippet = format!("  {}: {}", m.line + 1, m.line_text.trim());
-        display_rows.push(DisplayRow {
-            text: snippet,
-            is_header: false,
-            result_idx: Some(idx),
+            None
         });
-    }
+    engine
+        .search_query_caret
+        .replace(engine.project_search_query.len());
+    engine
+        .replace_text_caret
+        .replace(engine.project_replace_text.len());
 
-    let total_display = display_rows.len();
-    let max_scroll = total_display.saturating_sub(results_height);
+    let view = render::build_search_panel_msv(engine, &sidebar.root);
+    let q_theme = super::quadraui_tui::q_theme(theme);
+    quadraui::tui::draw_multi_section_view(
+        buf,
+        area,
+        &view,
+        &q_theme,
+        crate::icons::nerd_fonts_enabled(),
+    );
 
-    // Viewport scrolls freely — only clamped to valid range.
-    // Selection-tracking happens in the keyboard / poll handlers, not here.
-    let scroll_top = sidebar.search_scroll_top.min(max_scroll);
-    sidebar.search_scroll_top = scroll_top;
-
-    for (i, dr) in display_rows
-        .iter()
-        .skip(scroll_top)
-        .take(results_height)
-        .enumerate()
-    {
-        let screen_y = results_start_y + i as u16;
-        if screen_y >= area.y + area.height {
-            break;
-        }
-
-        // Fill row background first
-        for x in area.x..area.x + area.width {
-            set_cell(buf, x, screen_y, ' ', fg, bg);
-        }
-
-        let is_selected = !dr.is_header
-            && dr.result_idx == Some(engine.project_search_selected)
-            && !sidebar.search_input_mode;
-
-        let (row_fg, row_bg) = if is_selected {
-            (sel_fg, sel_bg)
-        } else if dr.is_header {
-            (file_header_fg, bg)
-        } else {
-            (fg, bg)
+    let bounds = quadraui::Rect::new(
+        area.x as f32,
+        area.y as f32,
+        area.width as f32,
+        area.height as f32,
+    );
+    let metrics = quadraui::MsvLayoutMetrics {
+        header_size: 1.0,
+        divider_size: 0.0,
+        scrollbar_size: 1.0,
+        cell_quantum: 1.0,
+    };
+    let layout = view.layout(bounds, metrics, |i| {
+        let s = &view.sections[i];
+        let aux_size = if s.aux.is_some() { 1.0 } else { 0.0 };
+        let content_size = match &s.body {
+            quadraui::SectionBody::Tree(t) => t.rows.len() as f32,
+            quadraui::SectionBody::Form(f) => f.fields.len() as f32,
+            _ => 0.0,
         };
-
-        // Re-fill with correct bg for selected rows
-        if is_selected || dr.is_header {
-            for x in area.x..area.x + area.width {
-                set_cell(buf, x, screen_y, ' ', row_fg, row_bg);
-            }
+        quadraui::SectionMeasure {
+            content_size,
+            aux_size,
         }
-
-        let mut x = area.x;
-        for ch in dr.text.chars() {
-            if x >= area.x + area.width {
-                break;
-            }
-            set_cell(buf, x, screen_y, ch, row_fg, row_bg);
-            x += 1;
-        }
-    }
-
-    // Vertical scrollbar for results area
-    let total_display = display_rows.len();
-    if total_display > results_height && area.width >= 2 {
-        let track_fg = rc(theme.separator);
-        let thumb_fg = rc(theme.status_fg);
-        let sb_bg = bg;
-        let track_h = results_height as f64;
-        let thumb_size = ((results_height as f64 / total_display as f64) * track_h)
-            .ceil()
-            .max(1.0) as u16;
-        let thumb_top = ((scroll_top as f64 / total_display as f64) * track_h).floor() as u16;
-        let sb_x = area.x + area.width - 1;
-        for dy in 0..results_height as u16 {
-            let y = results_start_y + dy;
-            if y >= area.y + area.height {
-                break;
-            }
-            let in_thumb = dy >= thumb_top && dy < thumb_top + thumb_size;
-            let ch = if in_thumb { '█' } else { '░' };
-            let fg_color = if in_thumb { thumb_fg } else { track_fg };
-            set_cell(buf, sb_x, y, ch, fg_color, sb_bg);
-        }
-    }
+    });
+    engine.search_panel_msv_layout.replace(Some(layout));
 }
 
 // ─── Wildmenu (command Tab completion bar) ───────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace ~321 lines of bespoke TUI search panel paint (`render_search_panel`) with `quadraui::tui::draw_multi_section_view()` using Form (chrome) + TreeView (results)
- Replace ~86 lines of bespoke click handling with MSV/Form/Tree `hit_test()` dispatch
- Add `build_search_panel_msv()` adapter in render.rs (engine state → MSV descriptor)
- Add shared click dispatch: `handle_search_form_hit()` + `handle_search_tree_hit()` in engine
- Add per-file collapse state (`search_file_expanded`) for file header expand/collapse

## What's left for #302

GTK migration (replace native `search_panel_box` widgets with DrawingArea + same MSV) will be a follow-up commit on this branch or a separate PR.

## Follow-up issues filed

- #311 — Arrow key cursor movement in query/replace inputs
- #312 — Ctrl-Shift-F with visual selection prepopulates search query

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test --no-default-features` — 4,907 tests pass
- [x] Smoke test: search panel opens, query input works, Enter runs search
- [x] Smoke test: results appear grouped by file, clickable
- [x] Smoke test: toggle buttons (Aa/Ab|/.*) clickable
- [x] Smoke test: action buttons (Find/Repl/All) clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)