### PR TITLE
feat: search panel cursor movement + key dispatch consolidation (#311)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -4487,7 +4487,7 @@ mod panels;
 mod picker;
 mod plugins;
 mod search;
-pub use search::find_word_boundaries;
+pub use search::{find_word_boundaries, SearchInputAction};
 mod source_control;
 mod spell_ops;
 mod terminal_ops;

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+pub enum SearchInputAction {
+    Consumed,
+    StartSearch,
+    StartReplace,
+    Unfocused,
+    Ignored,
+}
+
 /// Find word boundaries around char position `pos` in `text`.
 /// Returns `(start, end)` where `start..end` is the word range.
 /// A "word" character is alphanumeric or underscore.
@@ -573,6 +581,151 @@ impl Engine {
     /// Move the project search selection up by one, clamped to 0.
     pub fn project_search_select_prev(&mut self) {
         self.project_search_selected = self.project_search_selected.saturating_sub(1);
+    }
+
+    pub fn handle_search_input_key(
+        &mut self,
+        key: &str,
+        unicode: Option<char>,
+    ) -> SearchInputAction {
+        let focus = self.search_panel_form_focus.borrow().clone();
+        let is_replace = focus.as_deref() == Some("search:replace");
+        let is_query = focus.as_deref() == Some("search:query");
+
+        match key {
+            "Return" => {
+                if is_replace {
+                    let cwd = self.cwd.clone();
+                    self.start_project_replace(cwd);
+                    return SearchInputAction::StartReplace;
+                }
+                let cwd = self.cwd.clone();
+                self.start_project_search(cwd);
+                SearchInputAction::StartSearch
+            }
+            "BackSpace" => {
+                self.search_input_backspace(is_replace);
+                SearchInputAction::Consumed
+            }
+            "Delete" => {
+                self.search_input_delete(is_replace);
+                SearchInputAction::Consumed
+            }
+            "Left" | "Right" | "Home" | "End" => {
+                self.search_input_move_caret(is_replace, key);
+                SearchInputAction::Consumed
+            }
+            "Tab" | "BackTab" => {
+                if is_query {
+                    self.search_panel_form_focus
+                        .replace(Some("search:replace".to_string()));
+                } else {
+                    self.search_panel_form_focus
+                        .replace(Some("search:query".to_string()));
+                }
+                SearchInputAction::Consumed
+            }
+            "Escape" => {
+                self.search_panel_form_focus.replace(None);
+                SearchInputAction::Unfocused
+            }
+            _ => {
+                if let Some(ch) = unicode {
+                    let target_replace = if !is_query && !is_replace {
+                        self.search_panel_form_focus
+                            .replace(Some("search:query".to_string()));
+                        false
+                    } else {
+                        is_replace
+                    };
+                    self.search_input_insert_char(target_replace, ch);
+                    SearchInputAction::Consumed
+                } else {
+                    SearchInputAction::Ignored
+                }
+            }
+        }
+    }
+
+    pub fn search_input_insert_char(&mut self, is_replace: bool, ch: char) {
+        let (text, caret) = if is_replace {
+            (&mut self.project_replace_text, &self.replace_text_caret)
+        } else {
+            (&mut self.project_search_query, &self.search_query_caret)
+        };
+        let pos = caret.get().min(text.len());
+        text.insert(pos, ch);
+        caret.set(pos + ch.len_utf8());
+    }
+
+    pub fn search_input_backspace(&mut self, is_replace: bool) {
+        let (text, caret) = if is_replace {
+            (&mut self.project_replace_text, &self.replace_text_caret)
+        } else {
+            (&mut self.project_search_query, &self.search_query_caret)
+        };
+        let pos = caret.get().min(text.len());
+        if pos == 0 {
+            return;
+        }
+        let prev = text[..pos]
+            .char_indices()
+            .next_back()
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        text.remove(prev);
+        caret.set(prev);
+    }
+
+    pub fn search_input_delete(&mut self, is_replace: bool) {
+        let (text, caret) = if is_replace {
+            (&mut self.project_replace_text, &self.replace_text_caret)
+        } else {
+            (&mut self.project_search_query, &self.search_query_caret)
+        };
+        let pos = caret.get().min(text.len());
+        if pos < text.len() {
+            text.remove(pos);
+        }
+    }
+
+    pub fn search_input_move_caret(&mut self, is_replace: bool, key: &str) {
+        let (text, caret) = if is_replace {
+            (&mut self.project_replace_text, &self.replace_text_caret)
+        } else {
+            (&mut self.project_search_query, &self.search_query_caret)
+        };
+        let pos = caret.get().min(text.len());
+        match key {
+            "Left" => {
+                let prev = text[..pos]
+                    .char_indices()
+                    .next_back()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                caret.set(prev);
+            }
+            "Right" => {
+                let next = text[pos..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(i, _)| pos + i)
+                    .unwrap_or(text.len());
+                caret.set(next);
+            }
+            "Home" => caret.set(0),
+            "End" => caret.set(text.len()),
+            _ => {}
+        }
+    }
+
+    pub fn search_input_paste(&mut self, is_replace: bool, clip: &str) {
+        let line = clip.lines().next().unwrap_or("");
+        for ch in line.chars() {
+            if !ch.is_control() {
+                self.search_input_insert_char(is_replace, ch);
+            }
+        }
     }
 
     /// Handle a click on a search-panel form element (toggle, button) by widget ID.

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -7515,6 +7515,116 @@ fn test_project_search_select_next_prev() {
 }
 
 #[test]
+fn test_search_input_insert_and_caret() {
+    let mut e = Engine::new();
+    e.project_search_query = "abc".to_string();
+    e.search_query_caret.set(3);
+    e.search_input_insert_char(false, 'X');
+    assert_eq!(e.project_search_query, "abcX");
+    assert_eq!(e.search_query_caret.get(), 4);
+    e.search_query_caret.set(1);
+    e.search_input_insert_char(false, 'Y');
+    assert_eq!(e.project_search_query, "aYbcX");
+    assert_eq!(e.search_query_caret.get(), 2);
+}
+
+#[test]
+fn test_search_input_backspace_mid() {
+    let mut e = Engine::new();
+    e.project_search_query = "hello".to_string();
+    e.search_query_caret.set(3);
+    e.search_input_backspace(false);
+    assert_eq!(e.project_search_query, "helo");
+    assert_eq!(e.search_query_caret.get(), 2);
+}
+
+#[test]
+fn test_search_input_backspace_at_start() {
+    let mut e = Engine::new();
+    e.project_search_query = "hi".to_string();
+    e.search_query_caret.set(0);
+    e.search_input_backspace(false);
+    assert_eq!(e.project_search_query, "hi");
+    assert_eq!(e.search_query_caret.get(), 0);
+}
+
+#[test]
+fn test_search_input_delete() {
+    let mut e = Engine::new();
+    e.project_search_query = "abcd".to_string();
+    e.search_query_caret.set(1);
+    e.search_input_delete(false);
+    assert_eq!(e.project_search_query, "acd");
+    assert_eq!(e.search_query_caret.get(), 1);
+}
+
+#[test]
+fn test_search_input_move_caret() {
+    let mut e = Engine::new();
+    e.project_search_query = "hello".to_string();
+    e.search_query_caret.set(3);
+    e.search_input_move_caret(false, "Left");
+    assert_eq!(e.search_query_caret.get(), 2);
+    e.search_input_move_caret(false, "Right");
+    assert_eq!(e.search_query_caret.get(), 3);
+    e.search_input_move_caret(false, "Home");
+    assert_eq!(e.search_query_caret.get(), 0);
+    e.search_input_move_caret(false, "End");
+    assert_eq!(e.search_query_caret.get(), 5);
+}
+
+#[test]
+fn test_search_input_move_caret_boundaries() {
+    let mut e = Engine::new();
+    e.project_search_query = "ab".to_string();
+    e.search_query_caret.set(0);
+    e.search_input_move_caret(false, "Left");
+    assert_eq!(e.search_query_caret.get(), 0);
+    e.search_query_caret.set(2);
+    e.search_input_move_caret(false, "Right");
+    assert_eq!(e.search_query_caret.get(), 2);
+}
+
+#[test]
+fn test_search_input_replace_field() {
+    let mut e = Engine::new();
+    e.project_replace_text = "old".to_string();
+    e.replace_text_caret.set(1);
+    e.search_input_insert_char(true, 'X');
+    assert_eq!(e.project_replace_text, "oXld");
+    assert_eq!(e.replace_text_caret.get(), 2);
+    e.search_input_backspace(true);
+    assert_eq!(e.project_replace_text, "old");
+    assert_eq!(e.replace_text_caret.get(), 1);
+}
+
+#[test]
+fn test_search_input_paste() {
+    let mut e = Engine::new();
+    e.project_search_query = "ab".to_string();
+    e.search_query_caret.set(1);
+    e.search_input_paste(false, "XY\nignored");
+    assert_eq!(e.project_search_query, "aXYb");
+    assert_eq!(e.search_query_caret.get(), 3);
+}
+
+#[test]
+fn test_search_input_unicode() {
+    let mut e = Engine::new();
+    e.project_search_query = "café".to_string();
+    let len = e.project_search_query.len();
+    e.search_query_caret.set(len);
+    e.search_input_insert_char(false, '!');
+    assert_eq!(e.project_search_query, "café!");
+    e.search_query_caret.set("caf".len());
+    e.search_input_backspace(false);
+    assert_eq!(e.project_search_query, "caé!");
+    e.search_input_move_caret(false, "Right");
+    e.search_input_move_caret(false, "Right");
+    assert_eq!(e.search_query_caret.get(), "caé!".len());
+}
+
+#[test]
 fn test_start_and_poll_project_search() {
     let dir = make_search_dir("engine_async");
     let mut engine = Engine::new();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4856,70 +4856,9 @@ impl SimpleComponent for App {
             }
             Msg::SearchPanelKey(key_name, unicode) => {
                 let mapped = map_gtk_key_name(key_name.as_str());
-                let mut engine = self.engine.borrow_mut();
-                let is_query =
-                    engine.search_panel_form_focus.borrow().as_deref() == Some("search:query");
-                let is_replace =
-                    engine.search_panel_form_focus.borrow().as_deref() == Some("search:replace");
-                match mapped {
-                    "Return" => {
-                        if is_replace {
-                            let cwd = engine.cwd.clone();
-                            engine.start_project_replace(cwd);
-                        } else {
-                            let cwd = engine.cwd.clone();
-                            engine.start_project_search(cwd);
-                        }
-                    }
-                    "BackSpace" => {
-                        if is_replace {
-                            engine.project_replace_text.pop();
-                            engine
-                                .replace_text_caret
-                                .set(engine.project_replace_text.len());
-                        } else if is_query {
-                            engine.project_search_query.pop();
-                            engine
-                                .search_query_caret
-                                .set(engine.project_search_query.len());
-                        }
-                    }
-                    "Tab" => {
-                        if is_query {
-                            engine
-                                .search_panel_form_focus
-                                .replace(Some("search:replace".to_string()));
-                        } else {
-                            engine
-                                .search_panel_form_focus
-                                .replace(Some("search:query".to_string()));
-                        }
-                    }
-                    "Escape" => {
-                        engine.search_panel_form_focus.replace(None);
-                    }
-                    _ => {
-                        if let Some(ch) = unicode {
-                            if is_replace {
-                                engine.project_replace_text.push(ch);
-                                engine
-                                    .replace_text_caret
-                                    .set(engine.project_replace_text.len());
-                            } else {
-                                if !is_query {
-                                    engine
-                                        .search_panel_form_focus
-                                        .replace(Some("search:query".to_string()));
-                                }
-                                engine.project_search_query.push(ch);
-                                engine
-                                    .search_query_caret
-                                    .set(engine.project_search_query.len());
-                            }
-                        }
-                    }
-                }
-                drop(engine);
+                self.engine
+                    .borrow_mut()
+                    .handle_search_input_key(mapped, unicode);
                 self.draw_needed.set(true);
                 if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
                     da.queue_draw();

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -2371,54 +2371,56 @@ fn event_loop(
                                 let _ = engine.session.save();
                             }
                             // Input mode: typing into the search or replace box
-                            _ if sidebar.search_input_mode => match key_event.code {
-                                KeyCode::Tab | KeyCode::BackTab => {
-                                    sidebar.replace_input_focused = !sidebar.replace_input_focused;
-                                }
-                                KeyCode::Enter => {
-                                    if sidebar.replace_input_focused {
-                                        let root = engine.cwd.clone();
-                                        engine.start_project_replace(root);
-                                    } else {
-                                        let root = engine.cwd.clone();
-                                        engine.start_project_search(root);
-                                        sidebar.search_scroll_top = 0;
-                                    }
-                                }
-                                KeyCode::Backspace => {
-                                    if sidebar.replace_input_focused {
-                                        engine.project_replace_text.pop();
-                                    } else {
-                                        engine.project_search_query.pop();
-                                    }
-                                }
-                                KeyCode::Char('v')
-                                    if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                            _ if sidebar.search_input_mode => {
+                                // Ctrl+V paste is backend-specific (clipboard access)
+                                if key_event.code == KeyCode::Char('v')
+                                    && key_event.modifiers.contains(KeyModifiers::CONTROL)
                                 {
+                                    let is_replace = sidebar.replace_input_focused;
                                     if let Some(text) = Engine::clipboard_paste() {
-                                        let line = text.lines().next().unwrap_or("");
-                                        for c in line.chars() {
-                                            if !c.is_control() {
-                                                if sidebar.replace_input_focused {
-                                                    engine.project_replace_text.push(c);
-                                                } else {
-                                                    engine.project_search_query.push(c);
-                                                }
-                                            }
+                                        engine.search_input_paste(is_replace, &text);
+                                    }
+                                } else {
+                                    let key = match key_event.code {
+                                        KeyCode::Enter => "Return",
+                                        KeyCode::Backspace => "BackSpace",
+                                        KeyCode::Delete => "Delete",
+                                        KeyCode::Left => "Left",
+                                        KeyCode::Right => "Right",
+                                        KeyCode::Home => "Home",
+                                        KeyCode::End => "End",
+                                        KeyCode::Tab => "Tab",
+                                        KeyCode::BackTab => "BackTab",
+                                        KeyCode::Esc => "Escape",
+                                        _ => "",
+                                    };
+                                    let unicode = match key_event.code {
+                                        KeyCode::Char(c)
+                                            if !key_event
+                                                .modifiers
+                                                .contains(KeyModifiers::CONTROL) =>
+                                        {
+                                            Some(c)
                                         }
+                                        _ => None,
+                                    };
+                                    use crate::core::engine::SearchInputAction;
+                                    let action = engine.handle_search_input_key(key, unicode);
+                                    match action {
+                                        SearchInputAction::StartSearch => {
+                                            sidebar.search_scroll_top = 0;
+                                        }
+                                        SearchInputAction::Unfocused => {
+                                            sidebar.search_input_mode = false;
+                                        }
+                                        _ => {}
                                     }
+                                    // Sync TUI-local focus flags from engine state
+                                    let focus = engine.search_panel_form_focus.borrow().clone();
+                                    sidebar.replace_input_focused =
+                                        focus.as_deref() == Some("search:replace");
                                 }
-                                KeyCode::Char(c)
-                                    if !key_event.modifiers.contains(KeyModifiers::CONTROL) =>
-                                {
-                                    if sidebar.replace_input_focused {
-                                        engine.project_replace_text.push(c);
-                                    } else {
-                                        engine.project_search_query.push(c);
-                                    }
-                                }
-                                _ => {}
-                            },
+                            }
                             // Results mode: navigating the results list
                             _ => {
                                 match key_event.code {
@@ -2472,7 +2474,10 @@ fn event_loop(
                                     {
                                         sidebar.search_input_mode = true;
                                         sidebar.replace_input_focused = false;
-                                        engine.project_search_query.push(c);
+                                        engine
+                                            .search_panel_form_focus
+                                            .replace(Some("search:query".to_string()));
+                                        engine.search_input_insert_char(false, c);
                                     }
                                     _ => {}
                                 }

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -772,12 +772,14 @@ pub(super) fn render_search_panel(
         } else {
             None
         });
-    engine
-        .search_query_caret
-        .replace(engine.project_search_query.len());
-    engine
-        .replace_text_caret
-        .replace(engine.project_replace_text.len());
+    let q_len = engine.project_search_query.len();
+    if engine.search_query_caret.get() > q_len {
+        engine.search_query_caret.set(q_len);
+    }
+    let r_len = engine.project_replace_text.len();
+    if engine.replace_text_caret.get() > r_len {
+        engine.replace_text_caret.set(r_len);
+    }
 
     let view = render::build_search_panel_msv(engine, &engine.cwd, sidebar.search_scroll_top);
     let q_theme = super::quadraui_tui::q_theme(theme);


### PR DESCRIPTION
## Summary

- Add Left/Right/Home/End cursor movement and mid-string insert/delete to search panel query and replace inputs
- Consolidate duplicated key dispatch logic from GTK (~50 lines) and TUI (~50 lines) into a single `Engine::handle_search_input_key()` returning `SearchInputAction`
- GTK handler shrinks to 5 lines; TUI syncs local focus flags from engine state after each call
- 9 new tests covering insert/backspace/delete/caret movement/paste/unicode/boundaries

## Test plan

- [x] `cargo test --no-default-features` — 1940 tests pass (9 new)
- [x] `cargo fmt` + `cargo build` clean
- [ ] Smoke test: Ctrl-Shift-F → type text → Left/Right/Home/End → insert in middle → Backspace/Delete at caret → Tab to switch fields → Escape to unfocus

Closes #311
Filed #333 (TUI focus state dedup) and #334 (results-mode behavior unification) for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)