### PR TITLE
GTK SC panel → SidebarSystem + cross-backend dedup (#340)

### DIFF
--- a/src/core/engine/buffers.rs
+++ b/src/core/engine/buffers.rs
@@ -913,6 +913,7 @@ impl Engine {
     /// Returns `true` if the action was fully handled synchronously (the
     /// caller should give focus back to the editor), `false` if a background
     /// diff was requested (the caller should keep SC focus and poll later).
+    #[cfg(feature = "win-gui")]
     pub fn sc_open_selected_async(&mut self) -> bool {
         let (section, idx) = self.sc_flat_to_section_idx(self.sc_selected);
         if section == 2 {

--- a/src/core/engine/source_control.rs
+++ b/src/core/engine/source_control.rs
@@ -551,8 +551,7 @@ impl Engine {
             }
             // Fully exit SC panel.
             "q" => {
-                self.sc_button_focused = None;
-                self.sc_has_focus = false;
+                self.sc_set_focus(false);
                 true
             }
             _ => true,
@@ -802,9 +801,7 @@ impl Engine {
                                 let _ = self
                                     .open_file_with_mode(&path, crate::core::OpenMode::Permanent);
                             }
-                            // Clear focus so the editor receives keys after opening.
-                            self.sc_has_focus = false;
-                            self.sc_button_focused = None;
+                            self.sc_set_focus(false);
                         }
                     }
                 }
@@ -812,8 +809,7 @@ impl Engine {
                 true
             }
             "q" | "Escape" => {
-                self.sc_has_focus = false;
-                self.sc_button_focused = None;
+                self.sc_set_focus(false);
                 true
             }
             "r" => {
@@ -1165,6 +1161,33 @@ impl Engine {
 
     // ─── SidebarSystem integration ───────────────────────────────────
 
+    /// Set SC panel keyboard focus on both the engine flag and the
+    /// SidebarSystem. Backends should call this instead of setting
+    /// `sc_has_focus` directly to keep the two in sync.
+    pub fn sc_set_focus(&mut self, focused: bool) {
+        self.sc_has_focus = focused;
+        self.sc_sidebar_system.borrow_mut().set_has_focus(focused);
+        if !focused {
+            self.sc_button_focused = None;
+        }
+    }
+
+    /// Compute which SC button (0=Commit, 1=Push, 2=Pull, 3=Sync) was
+    /// clicked given a relative x position and total button-row width.
+    /// Returns `None` if the position is outside the row.
+    pub fn sc_button_hit_test(rel_x: f64, total_width: f64) -> Option<usize> {
+        if rel_x < 0.0 || rel_x >= total_width || total_width <= 0.0 {
+            return None;
+        }
+        let commit_w = total_width / 2.0;
+        Some(if rel_x < commit_w {
+            0
+        } else {
+            let icon_w = (total_width - commit_w) / 3.0;
+            ((1.0 + (rel_x - commit_w) / icon_w) as usize).min(3)
+        })
+    }
+
     /// Read the active section index and selected item index from the
     /// SidebarSystem. Returns `(section, item_idx)` where section is
     /// 0=staged, 1=changes, 2=worktrees, 3=log. Returns `(0, usize::MAX)`
@@ -1245,9 +1268,7 @@ impl Engine {
                             let _ =
                                 self.open_file_with_mode(&path, crate::core::OpenMode::Permanent);
                         }
-                        self.sc_has_focus = false;
-                        self.sc_sidebar_system.borrow_mut().set_has_focus(false);
-                        self.sc_button_focused = None;
+                        self.sc_set_focus(false);
                     }
                 }
             }
@@ -1373,9 +1394,7 @@ impl Engine {
         // Domain action keys.
         match key {
             "Escape" | "q" => {
-                self.sc_has_focus = false;
-                self.sc_sidebar_system.borrow_mut().set_has_focus(false);
-                self.sc_button_focused = None;
+                self.sc_set_focus(false);
                 ScKeyResult::Unfocused
             }
             "Return" | "Enter" => {

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -2852,6 +2852,7 @@ pub(super) fn draw_source_control_panel(
     h: f64,
     line_height: f64,
     backend: &Rc<RefCell<super::backend::GtkBackend>>,
+    engine: &Engine,
 ) {
     let Some(ref sc) = screen.source_control else {
         return;
@@ -3069,25 +3070,17 @@ pub(super) fn draw_source_control_panel(
         y_commit = btn_y_base + btn_h + btn_pad;
     }
 
-    // Section rendering — migrated to the `quadraui::TreeView` primitive
-    // (Phase A.1b). Adapter builds a TreeView covering the four sections
-    // (Staged / Changes / Worktrees / Log); `quadraui_gtk::draw_tree` renders
-    // it with Cairo + Pango. Row heights match the previous layout
-    // (`line_height` for headers, `line_height * 1.4` for items) so the
-    // click-hit math in `src/gtk/mod.rs::Msg::ScSidebarClick` continues to work.
-    let _ = (add_r, add_g, add_b, del_r, del_g, del_b); // reserved for future diff-tint use
-    let sc_tree = render::source_control_to_tree_view(sc, theme);
+    // Section rendering — migrated to SidebarSystem (#321).
+    let _ = (add_r, add_g, add_b, del_r, del_g, del_b);
     let sections_h = (y + h - y_commit).max(0.0);
-    // Phase B.5b Stage 8: route through `Backend::draw_tree`.
+    let body_rect = quadraui::Rect::new(x as f32, y_commit as f32, w as f32, sections_h as f32);
+    engine.sc_sidebar_body_rect.set(body_rect);
+    render::populate_sc_sidebar_system(engine, theme);
     {
-        use quadraui::Backend;
         backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
             b.set_current_theme(super::quadraui_gtk::q_theme(theme));
             b.set_current_line_height(line_height);
-            b.draw_tree(
-                quadraui::Rect::new(x as f32, y_commit as f32, w as f32, sections_h as f32),
-                &sc_tree,
-            );
+            engine.sc_sidebar_system.borrow().render(b, body_rect);
         });
     }
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -955,6 +955,8 @@ enum Msg {
     ScSidebarMotion(f64, f64),
     /// Key press in the Source Control sidebar DrawingArea.
     ScKey(String, bool),
+    /// UiEvent (scroll, mouse) in the SC sidebar DrawingArea.
+    ScSidebarEvent(quadraui::UiEvent),
     /// Key press in the Extensions sidebar DrawingArea (key_name, unicode).
     ExtSidebarKey(String, Option<char>),
     ExtSidebarEvent(quadraui::UiEvent),
@@ -3228,6 +3230,12 @@ impl SimpleComponent for App {
             });
             widgets.git_sidebar_da.add_controller(motion);
         }
+        {
+            let sender_sc = sender.input_sender().clone();
+            quadraui::gtk::wire_da_events(&widgets.git_sidebar_da, move |ev| {
+                sender_sc.send(Msg::ScSidebarEvent(ev)).ok();
+            });
+        }
         *git_sidebar_da_ref.borrow_mut() = Some(widgets.git_sidebar_da.clone());
 
         // ── Extensions sidebar draw + key setup ───────────────────────────────
@@ -4847,7 +4855,10 @@ impl SimpleComponent for App {
             | Msg::DebugSidebarScroll(_) => {
                 self.handle_debug_sidebar_msg(msg);
             }
-            Msg::ScSidebarClick(_, _, _) | Msg::ScSidebarMotion(_, _) | Msg::ScKey(_, _) => {
+            Msg::ScSidebarClick(_, _, _)
+            | Msg::ScSidebarMotion(_, _)
+            | Msg::ScKey(_, _)
+            | Msg::ScSidebarEvent(_) => {
                 self.handle_sc_sidebar_msg(msg);
             }
             Msg::ExtSidebarKey(_, _) | Msg::ExtSidebarEvent(_) => {
@@ -9251,6 +9262,14 @@ impl App {
                 let still_focused = engine.sc_has_focus;
                 drop(engine);
                 self.focus_editor_if_needed(still_focused);
+                if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
+                    da.queue_draw();
+                }
+                self.draw_needed.set(true);
+            }
+            Msg::ScSidebarEvent(ev) => {
+                let mut engine = self.engine.borrow_mut();
+                engine.handle_sc_sidebar_ui_event(ev);
                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -9040,8 +9040,7 @@ impl App {
                 }
                 {
                     let mut engine = self.engine.borrow_mut();
-                    engine.sc_has_focus = true;
-                    engine.sc_sidebar_system.borrow_mut().set_has_focus(true);
+                    engine.sc_set_focus(true);
                     let gap = (lh * 0.3).round();
                     let commit_rows = engine.sc_commit_message.split('\n').count().max(1);
                     let commit_h = commit_rows as f64 * lh;
@@ -9064,15 +9063,8 @@ impl App {
                             let margin = 4.0;
                             let btn_w = da_w - margin * 2.0;
                             let rel_x = x_click - margin;
-                            if btn_w > 0.0 && rel_x >= 0.0 && rel_x < btn_w {
-                                let commit_w = btn_w / 2.0;
-                                let btn_idx = if rel_x < commit_w {
-                                    0
-                                } else {
-                                    let icon_w = (btn_w - commit_w) / 3.0;
-                                    ((1.0 + (rel_x - commit_w) / icon_w) as usize).min(3)
-                                };
-                                engine.sc_activate_button(btn_idx);
+                            if let Some(idx) = Engine::sc_button_hit_test(rel_x, btn_w) {
+                                engine.sc_activate_button(idx);
                             }
                         }
                     } else if y >= section_top {
@@ -9887,7 +9879,7 @@ impl App {
                     if self.sidebar_visible {
                         match panel {
                             SidebarPanel::Git => {
-                                self.engine.borrow_mut().sc_has_focus = true;
+                                self.engine.borrow_mut().sc_set_focus(true);
                             }
                             SidebarPanel::Extensions => {
                                 self.engine.borrow_mut().ext_sidebar_has_focus = true;
@@ -9923,7 +9915,7 @@ impl App {
                     if self.active_panel == SidebarPanel::Git {
                         let mut engine = self.engine.borrow_mut();
                         engine.sc_refresh();
-                        engine.sc_has_focus = true;
+                        engine.sc_set_focus(true);
                     }
                     // Focus + refresh when switching to Extensions panel
                     if self.active_panel == SidebarPanel::Extensions {

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -675,6 +675,11 @@ fn map_gtk_key_with_unicode(gdk_name: &str) -> (&str, Option<char>) {
         "Right" => ("Right", None),
         "Home" => ("Home", None),
         "End" => ("End", None),
+        "Tab" | "ISO_Left_Tab" => ("Tab", None),
+        "Page_Up" => ("Page_Up", None),
+        "Page_Down" => ("Page_Down", None),
+        "question" => ("?", Some('?')),
+        "slash" => ("/", Some('/')),
         other => {
             let mut chars = other.chars();
             if let (Some(ch), None) = (chars.next(), chars.next()) {

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -3191,6 +3191,7 @@ impl SimpleComponent for App {
                     h,
                     line_height,
                     &backend_d,
+                    &engine,
                 );
             });
         }
@@ -4571,19 +4572,22 @@ impl SimpleComponent for App {
                     self.cached_ui_line_height =
                         (fm.ascent() + fm.descent()) as f64 / pango::SCALE as f64;
                     let lh = self.cached_ui_line_height as f32;
+                    let metrics = quadraui::MsvLayoutMetrics {
+                        header_size: (lh * 1.2).round(),
+                        divider_size: 0.0,
+                        scrollbar_size: 8.0,
+                        cell_quantum: 0.0,
+                    };
                     self.engine
                         .borrow()
                         .ext_sidebar_system
                         .borrow_mut()
-                        .set_backend_info(
-                            lh,
-                            quadraui::MsvLayoutMetrics {
-                                header_size: (lh * 1.2).round(),
-                                divider_size: 0.0,
-                                scrollbar_size: 8.0,
-                                cell_quantum: 0.0,
-                            },
-                        );
+                        .set_backend_info(lh, metrics);
+                    self.engine
+                        .borrow()
+                        .sc_sidebar_system
+                        .borrow_mut()
+                        .set_backend_info(lh, metrics);
                 }
                 // Keep shared cells in sync so the resize callback can use accurate values.
                 self.line_height_cell.set(line_height);
@@ -5568,7 +5572,7 @@ impl App {
                 if engine.dialog.is_some() {
                     engine.handle_key(mapped, sc_unicode, ctrl);
                 } else {
-                    engine.handle_sc_key(mapped, ctrl, sc_unicode);
+                    engine.dispatch_sc_sidebar_key_unified(mapped, ctrl, sc_unicode);
                 }
                 let still_focused = engine.sc_has_focus;
                 drop(engine);
@@ -9018,19 +9022,10 @@ impl App {
                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
                     da.grab_focus();
                 }
-                // Update selection/focus in one borrow scope.
-                // Returns: Some("Return") = open file, Some("Tab") = toggle expand, None = no-op
-                let action: Option<&'static str> = {
+                {
                     let mut engine = self.engine.borrow_mut();
                     engine.sc_has_focus = true;
-                    // Pixel-based hit zones matching draw_source_control_panel layout:
-                    //   header:  0 .. lh
-                    //   gap:     lh .. lh+gap
-                    //   commit:  lh+gap .. lh+gap+commit_h
-                    //   gap:     .. + gap
-                    //   buttons: .. + lh
-                    //   gap:     .. + gap
-                    //   sections: item_height rows
+                    engine.sc_sidebar_system.borrow_mut().set_has_focus(true);
                     let gap = (lh * 0.3).round();
                     let commit_rows = engine.sc_commit_message.split('\n').count().max(1);
                     let commit_h = commit_rows as f64 * lh;
@@ -9040,20 +9035,14 @@ impl App {
                     let btn_top = commit_bottom + gap;
                     let btn_bottom = btn_top + lh;
                     let section_top = btn_bottom + gap;
-                    let item_height = (lh * 1.4).round();
 
                     if y < header_end {
-                        // Panel header — no-op
                         engine.sc_commit_input_active = false;
-                        None
                     } else if y >= commit_top && y < commit_bottom {
-                        // Commit input row(s)
                         engine.sc_commit_input_active = true;
                         engine.sc_commit_cursor = engine.sc_commit_message.len();
-                        None
                     } else if y >= btn_top && y < btn_bottom {
                         engine.sc_commit_input_active = false;
-                        // Button row: Commit (~50%), Push/Pull/Sync (~17% each, icon-only).
                         if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
                             let da_w = da.width() as f64;
                             let margin = 4.0;
@@ -9070,106 +9059,24 @@ impl App {
                                 engine.sc_activate_button(btn_idx);
                             }
                         }
-                        None
                     } else if y >= section_top {
                         engine.sc_commit_input_active = false;
-                        // Accumulator walk matching draw_source_control_panel layout:
-                        // headers use line_height, items use item_height (1.4×).
-                        let staged_count = engine
-                            .sc_file_statuses
-                            .iter()
-                            .filter(|f| f.staged.is_some())
-                            .count();
-                        let unstaged_count = engine
-                            .sc_file_statuses
-                            .iter()
-                            .filter(|f| f.unstaged.is_some())
-                            .count();
-                        let show_worktrees = engine.sc_worktrees.len() > 1;
-                        let wt_count = engine.sc_worktrees.len();
-                        let log_count = engine.sc_log.len();
-                        let expanded = engine.sc_sections_expanded;
-
-                        // Build section descriptors: (item_count, is_shown, expanded)
-                        let sections: [(usize, bool, bool); 4] = [
-                            (staged_count, true, expanded[0]),
-                            (unstaged_count, true, expanded[1]),
-                            (wt_count, show_worktrees, expanded[2]),
-                            (log_count, true, expanded[3]),
-                        ];
-
-                        let mut ry = section_top;
-                        let mut flat: usize = 0;
-                        let mut result: Option<(usize, bool)> = None;
-
-                        'walk: for &(count, shown, exp) in &sections {
-                            if !shown {
-                                continue;
-                            }
-                            // Section header (line_height)
-                            if y >= ry && y < ry + lh {
-                                result = Some((flat, true));
-                                break 'walk;
-                            }
-                            ry += lh;
-                            let header_flat = flat;
-                            flat += 1;
-                            if exp {
-                                for i in 0..count {
-                                    if y >= ry && y < ry + item_height {
-                                        result = Some((header_flat + 1 + i, false));
-                                        break 'walk;
-                                    }
-                                    ry += item_height;
-                                }
-                                flat += count;
-                            }
-                        }
-
-                        match result {
-                            Some((flat_idx, is_header)) => {
-                                engine.sc_selected = flat_idx;
-                                if is_header {
-                                    Some("Tab")
-                                } else if n_press >= 2 {
-                                    Some("Return")
-                                } else {
-                                    None // single-click: just select
-                                }
-                            }
-                            None => None,
+                        let click_ev = quadraui::UiEvent::MouseDown {
+                            widget: None,
+                            button: quadraui::MouseButton::Left,
+                            position: quadraui::Point::new(x_click as f32, y as f32),
+                            modifiers: quadraui::Modifiers::default(),
+                        };
+                        engine.handle_sc_sidebar_ui_event(click_ev);
+                        if n_press >= 2 {
+                            let double_ev = quadraui::UiEvent::DoubleClick {
+                                widget: None,
+                                position: quadraui::Point::new(x_click as f32, y as f32),
+                            };
+                            engine.handle_sc_sidebar_ui_event(double_ev);
                         }
                     } else {
-                        // Gap/padding area — no-op
                         engine.sc_commit_input_active = false;
-                        None
-                    }
-                };
-                if let Some(key) = action {
-                    if key == "Return" {
-                        // Defer all heavy work (file open + git show) so
-                        // the sidebar repaints the selection highlight first.
-                        let engine_rc = self.engine.clone();
-                        let git_da = self.git_sidebar_da_ref.clone();
-                        let drawing = self.drawing_area.clone();
-                        let draw_needed = self.draw_needed.clone();
-                        gtk4::glib::idle_add_local_once(move || {
-                            let done = engine_rc.borrow_mut().sc_open_selected_async();
-                            if done {
-                                let still_focused = engine_rc.borrow().sc_has_focus;
-                                if !still_focused {
-                                    if let Some(ref da) = *drawing.borrow() {
-                                        da.grab_focus();
-                                    }
-                                }
-                            }
-                            if let Some(ref da) = *git_da.borrow() {
-                                da.queue_draw();
-                            }
-                            draw_needed.set(true);
-                        });
-                    } else {
-                        self.engine.borrow_mut().handle_sc_key(key, false, None);
                     }
                 }
                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
@@ -9339,48 +9246,8 @@ impl App {
                     self.draw_needed.set(true);
                     return;
                 }
-                if engine.sc_commit_input_active
-                    || engine.sc_branch_picker_open
-                    || engine.sc_branch_create_mode
-                    || engine.sc_help_open
-                {
-                    // In input/popup mode, pass everything through.
-                    let (mapped_key, unicode) = map_gtk_key_with_unicode(key_name.as_str());
-                    engine.handle_sc_key(mapped_key, ctrl, unicode);
-                } else {
-                    // Normal navigation: map known keys only.
-                    let mapped = match key_name.as_str() {
-                        "Return" | "KP_Enter" => "Return",
-                        "Escape" => "Escape",
-                        "Tab" => "Tab",
-                        "Down" => "j",
-                        "Up" => "k",
-                        "Left" => "h",
-                        "Right" => "l",
-                        "BackSpace" => "BackSpace",
-                        "j" => "j",
-                        "k" => "k",
-                        "h" => "h",
-                        "l" => "l",
-                        "s" => "s",
-                        "S" => "S",
-                        "d" => "d",
-                        "D" => "D",
-                        "r" => "r",
-                        "q" => "q",
-                        "c" => "c",
-                        "p" => "p",
-                        "P" => "P",
-                        "f" => "f",
-                        "b" => "b",
-                        "B" => "B",
-                        "question" | "?" => "?",
-                        _ => "",
-                    };
-                    if !mapped.is_empty() {
-                        engine.handle_sc_key(mapped, ctrl, None);
-                    }
-                }
+                let (mapped, unicode) = map_gtk_key_with_unicode(key_name.as_str());
+                engine.dispatch_sc_sidebar_key_unified(mapped, ctrl, unicode);
                 let still_focused = engine.sc_has_focus;
                 drop(engine);
                 self.focus_editor_if_needed(still_focused);

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -2278,7 +2278,7 @@ fn event_loop(
                                 sidebar.replace_input_focused = false;
                             }
                             if panel == TuiPanel::Git {
-                                engine.sc_has_focus = true;
+                                engine.sc_set_focus(true);
                                 engine.sc_refresh();
                             }
                             if panel == TuiPanel::Debug {
@@ -2882,8 +2882,7 @@ fn event_loop(
                             && !engine.sc_help_open
                         {
                             sidebar.has_focus = false;
-                            engine.sc_has_focus = false;
-                            engine.sc_sidebar_system.borrow_mut().set_has_focus(false);
+                            engine.sc_set_focus(false);
                             sidebar.toolbar_focused = true;
                             sidebar.toolbar_selected = 4;
                             needs_redraw = true;
@@ -2894,8 +2893,7 @@ fn event_loop(
                             sidebar.visible = false;
                             sidebar.has_focus = false;
                             engine.session.explorer_visible = false;
-                            engine.sc_has_focus = false;
-                            engine.sc_sidebar_system.borrow_mut().set_has_focus(false);
+                            engine.sc_set_focus(false);
                             let _ = engine.session.save();
                             needs_redraw = true;
                             continue;
@@ -3525,7 +3523,7 @@ fn event_loop(
                                     TuiPanel::Explorer => {
                                         engine.explorer_has_focus = true;
                                     }
-                                    TuiPanel::Git => engine.sc_has_focus = true,
+                                    TuiPanel::Git => engine.sc_set_focus(true),
                                     TuiPanel::Debug => engine.dap_sidebar_has_focus = true,
                                     TuiPanel::Extensions => {
                                         engine.ext_sidebar_has_focus = true;

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2477,8 +2477,7 @@ pub(super) fn handle_mouse(
             return sidebar_width;
         } else if sidebar.active_panel == TuiPanel::Git {
             sidebar.has_focus = true;
-            engine.sc_has_focus = true;
-            engine.sc_sidebar_system.borrow_mut().set_has_focus(true);
+            engine.sc_set_focus(true);
 
             // sidebar_row layout:
             //   0 = header
@@ -2498,16 +2497,10 @@ pub(super) fn handle_mouse(
                 engine.sc_commit_cursor = engine.sc_commit_message.len();
             } else if sidebar_row == btn_row {
                 engine.sc_commit_input_active = false;
-                let rel_col = col.saturating_sub(ab_width);
-                let commit_w = sidebar_width / 2;
-                let btn_idx = if rel_col < commit_w {
-                    0
-                } else {
-                    let icon_w = (sidebar_width - commit_w) / 3;
-                    let x = rel_col - commit_w;
-                    (1 + (x / icon_w.max(1))).min(3) as usize
-                };
-                engine.sc_activate_button(btn_idx);
+                let rel_col = col.saturating_sub(ab_width) as f64;
+                if let Some(idx) = Engine::sc_button_hit_test(rel_col, sidebar_width as f64) {
+                    engine.sc_activate_button(idx);
+                }
             } else if sidebar_row >= section_start {
                 engine.sc_commit_input_active = false;
                 let click_ev = quadraui::UiEvent::MouseDown {
@@ -2649,7 +2642,7 @@ pub(super) fn handle_mouse(
     // ── Editor area ───────────────────────────────────────────────────────────
     sidebar.has_focus = false;
     sidebar.toolbar_focused = false;
-    engine.sc_has_focus = false;
+    engine.sc_set_focus(false);
     engine.dap_sidebar_has_focus = false;
     engine.ext_sidebar_has_focus = false;
     engine.ai_has_focus = false;


### PR DESCRIPTION
## Summary

- GTK SC section rendering replaced with `SidebarSystem.render()` — eliminates `source_control_to_tree_view()` + `draw_tree()` call
- GTK key routing replaced with `dispatch_sc_sidebar_key_unified()` — eliminates 40-line manual key→action mapping in `Msg::ScKey` and `Msg::KeyPress` handlers
- GTK section click replaced with `handle_sc_sidebar_ui_event()` — eliminates 60-line accumulator walk
- `wire_da_events` wired for SC DrawingArea — enables scroll wheel + scrollbar drag
- GDK `question`/`slash` key name mapping added to `map_gtk_key_with_unicode`
- `Engine::sc_set_focus(bool)` — single method keeps `sc_has_focus` and SidebarSystem in sync (replaces 10+ manual dual-set sites across TUI + GTK)
- `Engine::sc_button_hit_test()` — shared button layout math (replaces duplicate computation in both backends)
- `sc_open_selected_async` gated behind `#[cfg(feature = "win-gui")]`

Net ~200 lines removed across GTK + TUI.

Closes #340

## Test plan

- [x] `cargo test --no-default-features` — 1954 tests pass
- [x] `cargo clippy --lib -- -D warnings` — clean
- [ ] GTK smoke: j/k nav, Tab collapse, s/S stage, d discard, c commit, Enter open, q/Esc unfocus, b/B branch, ? help, scroll wheel, scrollbar drag, button click
- [ ] TUI regression: same interactions still work after dedup refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)