### PR TITLE
feat: collapse terminal rendering to quadraui draw_terminal (#123/#129/#131)

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -573,36 +573,71 @@ pub(super) fn draw_editor(
                     let content_h = (term_px - 2.0 * line_height).max(0.0);
                     if content_h > 0.0 {
                         let content_y = toolbar_y + line_height;
-                        draw_terminal_panel(
-                            cr,
-                            &layout,
-                            term_panel,
-                            &theme,
-                            0.0,
-                            content_y,
-                            width as f64,
-                            content_h,
-                            line_height,
-                            char_width,
-                        );
                         let visible_rows = (content_h / line_height) as usize;
+                        let q_theme = super::quadraui_gtk::q_theme(&theme);
+                        let (tbgr, tbgg, tbgb) = theme.terminal_bg.to_cairo();
+                        cr.set_source_rgb(tbgr, tbgg, tbgb);
+                        cr.rectangle(0.0, content_y, width as f64, content_h);
+                        cr.fill().ok();
+                        let q_area = quadraui::Rect::new(
+                            0.0,
+                            content_y as f32,
+                            width as f32,
+                            content_h as f32,
+                        );
+                        let td = render::build_terminal_draw_data(
+                            term_panel,
+                            q_area,
+                            char_width as f32,
+                            visible_rows,
+                            Some(6),
+                        );
+                        {
+                            let mut b = backend.borrow_mut();
+                            b.set_current_theme(q_theme);
+                            b.set_current_line_height(line_height);
+                            b.set_current_char_width(char_width);
+                        }
+                        if let Some(split) = &td.split {
+                            let left = td.left.as_ref().unwrap();
+                            let right = td.right.as_ref().unwrap();
+                            let sl = *split;
+                            backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
+                                use quadraui::Backend;
+                                b.draw_terminal(sl.left, left);
+                                b.draw_terminal(sl.right, right);
+                            });
+                            quadraui::gtk::draw_terminal_divider(
+                                cr,
+                                split.divider_x as f64,
+                                content_y,
+                                content_h,
+                                &q_theme,
+                            );
+                        } else if let Some(ref term) = td.single {
+                            backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
+                                use quadraui::Backend;
+                                b.draw_terminal(q_area, term);
+                            });
+                        }
+                        // Register scroll surface for dispatch.
                         let geom = render::terminal_scrollbar_geometry(term_panel, visible_rows);
-                        let scrollbar = geom.map(|g| {
-                            const SB_W: f64 = 6.0;
-                            let sb_x = width as f64 - SB_W;
+                        let surface_sb = geom.map(|g| {
+                            let sb_w = 6.0;
+                            let sb_x = width as f64 - sb_w;
                             let thumb_t = g.thumb_top_frac * content_h;
                             let thumb_h = (g.thumb_height_frac * content_h).max(4.0);
                             quadraui::SurfaceScrollbar {
                                 track_bounds: quadraui::Rect::new(
                                     sb_x as f32,
                                     content_y as f32,
-                                    SB_W as f32,
+                                    sb_w as f32,
                                     content_h as f32,
                                 ),
                                 thumb_bounds: quadraui::Rect::new(
                                     (sb_x + 1.0) as f32,
                                     (content_y + thumb_t) as f32,
-                                    (SB_W - 2.0) as f32,
+                                    (sb_w - 2.0) as f32,
                                     thumb_h as f32,
                                 ),
                                 total_items: g.total_items,
@@ -622,7 +657,7 @@ pub(super) fn draw_editor(
                                     width as f32,
                                     content_h as f32,
                                 ),
-                                scrollbar,
+                                scrollbar: surface_sb,
                             });
                     }
                 }
@@ -2549,150 +2584,6 @@ pub(super) fn draw_terminal_toolbar(
 
     layout.set_font_description(Some(&saved_font));
     result
-}
-
-/// Draw the integrated terminal bottom panel content (cells + scrollbar).
-/// The toolbar row is drawn separately by `draw_terminal_toolbar`.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn draw_terminal_panel(
-    cr: &Context,
-    layout: &pango::Layout,
-    panel: &render::TerminalPanel,
-    theme: &Theme,
-    x: f64,
-    y: f64,
-    w: f64,
-    term_px: f64,
-    line_height: f64,
-    char_width: f64,
-) {
-    const SB_W: f64 = 6.0;
-    let content_y = y;
-    let content_h = term_px;
-    let rows_to_draw = (term_px / line_height) as usize;
-    let geom = render::terminal_scrollbar_geometry(panel, rows_to_draw);
-    let (thumb_top_px, thumb_bot_px) = if let Some(g) = &geom {
-        let t = g.thumb_top_frac * content_h;
-        let h = (g.thumb_height_frac * content_h).max(4.0);
-        (t, t + h)
-    } else {
-        (0.0, content_h)
-    };
-
-    // Draw scrollbar track (right edge of whole panel)
-    let sb_x = x + w - SB_W;
-    let (tbr, tbg, tbb) = theme.status_bg.to_cairo();
-    cr.set_source_rgb(tbr * 1.4, tbg * 1.4, tbb * 1.4); // slightly lighter than header
-    cr.rectangle(sb_x, content_y, SB_W, content_h);
-    cr.fill().ok();
-    // Draw scrollbar thumb
-    let (fr, fg2, fb) = theme.status_fg.to_cairo();
-    cr.set_source_rgba(fr, fg2, fb, 0.5);
-    cr.rectangle(
-        sb_x + 1.0,
-        content_y + thumb_top_px,
-        SB_W - 2.0,
-        thumb_bot_px - thumb_top_px,
-    );
-    cr.fill().ok();
-
-    // ── Split view: draw left pane + divider + right pane ─────────────────────
-    if let Some(ref left_rows) = panel.split_left_rows {
-        let half_w = panel.split_left_cols as f64 * char_width;
-        let div_x = x + half_w;
-
-        // Fill both halves with terminal default bg.
-        let (tbgr, tbgg, tbgb) = theme.terminal_bg.to_cairo();
-        cr.set_source_rgb(tbgr, tbgg, tbgb);
-        cr.rectangle(x, content_y, w - SB_W, content_h);
-        cr.fill().ok();
-
-        // Draw left pane cells.
-        draw_terminal_cells(
-            cr,
-            layout,
-            left_rows,
-            x,
-            content_y,
-            half_w,
-            line_height,
-            char_width,
-            theme,
-        );
-
-        // Draw divider (1px vertical line).
-        let (dr, dg, db) = theme.separator.to_cairo();
-        cr.set_source_rgb(dr, dg, db);
-        cr.rectangle(div_x, content_y, 1.0, content_h);
-        cr.fill().ok();
-
-        // Draw right pane cells.
-        draw_terminal_cells(
-            cr,
-            layout,
-            &panel.rows,
-            div_x + 1.0,
-            content_y,
-            half_w - 1.0,
-            line_height,
-            char_width,
-            theme,
-        );
-        return;
-    }
-
-    // ── Normal single-pane view ────────────────────────────────────────────────
-    // Content rows (terminal cells)
-    let cell_area_w = w - SB_W;
-
-    // Fill the entire content area with the default terminal background first.
-    let (tbgr, tbgg, tbgb) = theme.terminal_bg.to_cairo();
-    cr.set_source_rgb(tbgr, tbgg, tbgb);
-    cr.rectangle(x, content_y, cell_area_w, content_h);
-    cr.fill().ok();
-
-    draw_terminal_cells(
-        cr,
-        layout,
-        &panel.rows,
-        x,
-        content_y,
-        cell_area_w,
-        line_height,
-        char_width,
-        theme,
-    );
-}
-
-/// Draw a grid of terminal cells into a rectangular region.
-/// A.7: GTK terminal cell rendering delegates to
-/// `quadraui_gtk::draw_terminal_cells` via the shared adapter. External
-/// signature preserved so callers in `src/gtk/draw.rs` (split + single
-/// pane terminal rendering) are untouched.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn draw_terminal_cells(
-    cr: &Context,
-    layout: &pango::Layout,
-    rows: &[Vec<render::TerminalCell>],
-    x: f64,
-    content_y: f64,
-    cell_area_w: f64,
-    line_height: f64,
-    char_width: f64,
-    theme: &Theme,
-) {
-    let term = render::terminal_cells_to_quadraui(rows, quadraui::WidgetId::new("terminal:gtk"));
-    quadraui::gtk::draw_terminal_cells(
-        cr,
-        layout,
-        &term,
-        x,
-        content_y,
-        cell_area_w,
-        line_height,
-        char_width,
-        &super::quadraui_gtk::q_theme(theme),
-    );
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6270,11 +6270,6 @@ impl App {
                         self.draw_needed.set(true);
                         return;
                     }
-                    quadraui::UiEvent::MouseDown {
-                        widget: Some(id), ..
-                    } if id.as_str() == "terminal_scrollback" => {
-                        return;
-                    }
                     _ => {}
                 }
             }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1662,6 +1662,55 @@ pub fn terminal_scrollbar_geometry(
     })
 }
 
+/// Pre-built terminal primitives ready for `Backend::draw_terminal`.
+/// Both backends call `build_terminal_draw_data` and then just do the
+/// backend-specific drawing (clear background, enter frame scope, divider).
+pub struct TerminalDrawData {
+    pub single: Option<quadraui::Terminal>,
+    pub left: Option<quadraui::Terminal>,
+    pub right: Option<quadraui::Terminal>,
+    pub split: Option<quadraui::TerminalSplitLayout>,
+}
+
+pub fn build_terminal_draw_data(
+    panel: &TerminalPanel,
+    area: quadraui::Rect,
+    cell_width: f32,
+    visible_rows: usize,
+    sb_width: Option<u16>,
+) -> TerminalDrawData {
+    let sb = Some(quadraui::TerminalScrollbar {
+        total_lines: panel.scrollback_rows + visible_rows,
+        visible_lines: visible_rows,
+        scroll_offset: panel.scroll_offset,
+        inverted: true,
+        width: sb_width,
+    });
+    if let Some(ref left_rows) = panel.split_left_rows {
+        let split =
+            quadraui::TerminalSplitLayout::new(area, panel.split_left_cols as usize, cell_width);
+        let left =
+            terminal_cells_to_quadraui(left_rows, quadraui::WidgetId::new("terminal:left"), None);
+        let right =
+            terminal_cells_to_quadraui(&panel.rows, quadraui::WidgetId::new("terminal:right"), sb);
+        TerminalDrawData {
+            single: None,
+            left: Some(left),
+            right: Some(right),
+            split: Some(split),
+        }
+    } else {
+        let term =
+            terminal_cells_to_quadraui(&panel.rows, quadraui::WidgetId::new("terminal:pane"), sb);
+        TerminalDrawData {
+            single: Some(term),
+            left: None,
+            right: None,
+            split: None,
+        }
+    }
+}
+
 // ─── Menu bar / debug toolbar ─────────────────────────────────────────────────
 
 /// One item in a menu dropdown.
@@ -10762,6 +10811,7 @@ pub fn resolve_status_bar_click(
 pub fn terminal_cells_to_quadraui(
     rows: &[Vec<TerminalCell>],
     id: quadraui::WidgetId,
+    scrollbar: Option<quadraui::TerminalScrollbar>,
 ) -> quadraui::Terminal {
     let cells = rows
         .iter()
@@ -10782,7 +10832,11 @@ pub fn terminal_cells_to_quadraui(
                 .collect()
         })
         .collect();
-    quadraui::Terminal { id, cells }
+    quadraui::Terminal {
+        id,
+        cells,
+        scrollbar,
+    }
 }
 
 // ─── quadraui::TabBar adapter (A.6c / A.6d) ──────────────────────────────────

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -2505,10 +2505,10 @@ pub(super) fn render_terminal_toolbar(
     }
 }
 
-/// Render the terminal panel content (cells + scrollbar + split view).
-/// The toolbar row is drawn separately by `render_terminal_toolbar`.
+/// Render the terminal panel content via quadraui's `draw_terminal`.
 pub(super) fn render_terminal_panel(
-    buf: &mut ratatui::buffer::Buffer,
+    frame: &mut ratatui::Frame,
+    backend: &mut quadraui::tui::TuiBackend,
     area: Rect,
     panel: &render::TerminalPanel,
     theme: &Theme,
@@ -2516,142 +2516,46 @@ pub(super) fn render_terminal_panel(
     if area.height == 0 {
         return;
     }
-    let fg = RColor::Rgb(theme.status_fg.r, theme.status_fg.g, theme.status_fg.b);
-
     let content_rows = area.height as usize;
-    let sb_col = area.x + area.width.saturating_sub(1);
-    let geom = render::terminal_scrollbar_geometry(panel, content_rows);
-    let (thumb_start, thumb_end) = if let Some(g) = &geom {
-        let ts = (g.thumb_top_frac * content_rows as f64) as usize;
-        let th = (g.thumb_height_frac * content_rows as f64).max(1.0) as usize;
-        (ts, (ts + th).min(content_rows))
-    } else {
-        (0, content_rows)
-    };
+    let fg = RColor::Rgb(theme.status_fg.r, theme.status_fg.g, theme.status_fg.b);
+    let term_bg = rc(theme.terminal_bg);
+    let q_theme = super::quadraui_tui::q_theme(theme);
 
-    // ── Split view: left pane | divider | right pane ─────────────────────────
-    if let Some(ref left_rows) = panel.split_left_rows {
-        let half_w = panel.split_left_cols; // left-pane column count (may reflect drag state)
-        let div_col = area.x + half_w;
-
-        // A.7: build both panes' `quadraui::Terminal` primitives once before
-        // the row loop. The per-row drawer reads from the primitive's owned
-        // cell vec; building once avoids N allocations per frame for an
-        // N-row terminal.
-        let left_term = render::terminal_cells_to_quadraui(
-            left_rows,
-            quadraui::WidgetId::new("terminal:split-left"),
-        );
-        let right_term = render::terminal_cells_to_quadraui(
-            &panel.rows,
-            quadraui::WidgetId::new("terminal:split-right"),
-        );
-
-        for row_idx in 0..content_rows {
-            let screen_row = area.y + row_idx as u16;
-            if screen_row >= area.y + area.height {
-                break;
-            }
-            let term_bg = rc(theme.terminal_bg);
-
-            // Clear both halves.
-            for x in area.x..area.x + area.width.saturating_sub(1) {
-                set_cell(buf, x, screen_row, ' ', fg, term_bg);
-            }
-
-            // Left pane cells.
-            render_terminal_pane_cells(buf, &left_term, area.x, screen_row, half_w, row_idx, theme);
-
-            // Divider column.
-            let div_fg = rc(theme.separator);
-            set_cell(buf, div_col, screen_row, '│', div_fg, term_bg);
-
-            // Right pane cells.
-            render_terminal_pane_cells(
-                buf,
-                &right_term,
-                div_col + 1,
-                screen_row,
-                half_w,
-                row_idx,
-                theme,
-            );
-
-            // Scrollbar in the last column.
-            let (sb_char, sb_fg) = if row_idx >= thumb_start && row_idx < thumb_end {
-                ('█', rc(theme.scrollbar_thumb))
-            } else {
-                ('░', rc(theme.separator))
-            };
-            set_cell(
-                buf,
-                sb_col,
-                screen_row,
-                sb_char,
-                sb_fg,
-                rc(theme.background),
-            );
+    // Clear with terminal background.
+    for row in 0..area.height {
+        for col in area.x..area.x + area.width {
+            set_cell(frame.buffer_mut(), col, area.y + row, ' ', fg, term_bg);
         }
-
-        return;
     }
 
-    // ── Normal single-pane content rows ──────────────────────────────────────
-    let cell_width = area.width.saturating_sub(1); // leave last col for scrollbar
-    let term =
-        render::terminal_cells_to_quadraui(&panel.rows, quadraui::WidgetId::new("terminal:pane"));
-    for row_idx in 0..content_rows {
-        let screen_row = area.y + row_idx as u16;
-        if screen_row >= area.y + area.height {
-            break;
-        }
-        let term_bg_default = rc(theme.terminal_bg);
-        // Clear row with terminal default background (excluding scrollbar col).
-        for x in area.x..area.x + cell_width {
-            set_cell(buf, x, screen_row, ' ', fg, term_bg_default);
-        }
-
-        render_terminal_pane_cells(buf, &term, area.x, screen_row, cell_width, row_idx, theme);
-
-        // Scrollbar column — same colors as the editor scrollbar.
-        let (sb_char, sb_fg) = if row_idx >= thumb_start && row_idx < thumb_end {
-            ('█', rc(theme.scrollbar_thumb))
-        } else {
-            ('░', rc(theme.separator))
-        };
-        set_cell(
-            buf,
-            sb_col,
-            screen_row,
-            sb_char,
-            sb_fg,
-            rc(theme.background),
-        );
-    }
-}
-
-/// Render one row of terminal pane cells into a ratatui buffer.
-pub(super) fn render_terminal_pane_cells(
-    buf: &mut ratatui::buffer::Buffer,
-    term: &quadraui::Terminal,
-    start_x: u16,
-    screen_row: u16,
-    max_cols: u16,
-    row_idx: usize,
-    theme: &Theme,
-) {
-    // A.7: dispatch into the `quadraui::Terminal` row drawer. The primitive
-    // is built once per terminal per frame in the caller (above), so this
-    // inner loop just walks pre-converted cells.
-    if row_idx >= term.cells.len() {
-        return;
-    }
-    super::quadraui_tui::draw_terminal_row(
-        buf,
-        &term.cells[row_idx],
-        start_x,
-        screen_row,
-        max_cols,
-        theme,
+    let q_area = quadraui::Rect::new(
+        area.x as f32,
+        area.y as f32,
+        area.width as f32,
+        area.height as f32,
     );
+    let td = render::build_terminal_draw_data(panel, q_area, 1.0, content_rows, None);
+    backend.set_current_theme(q_theme);
+    if let Some(split) = &td.split {
+        let left = td.left.as_ref().unwrap();
+        let right = td.right.as_ref().unwrap();
+        let sl = *split;
+        backend.enter_frame_scope(frame, |b| {
+            use quadraui::Backend;
+            b.draw_terminal(sl.left, left);
+            b.draw_terminal(sl.right, right);
+        });
+        quadraui::tui::draw_terminal_divider(
+            frame.buffer_mut(),
+            split.divider_x as u16,
+            area.y,
+            area.height,
+            &q_theme,
+        );
+    } else if let Some(ref term) = td.single {
+        backend.enter_frame_scope(frame, |b| {
+            use quadraui::Backend;
+            b.draw_terminal(q_area, term);
+        });
+    }
 }

--- a/src/tui_main/quadraui_tui.rs
+++ b/src/tui_main/quadraui_tui.rs
@@ -257,55 +257,6 @@ pub(super) fn draw_activity_bar(
 /// `max_cols` clips the row to the visible width. `theme` supplies
 /// fallback colours for find-match overlays — the cell's own `fg` / `bg`
 /// win for normal cells and cursor/selection (which use inverted colours).
-///
-/// Caller iterates rows externally so the per-row terminal panel
-/// decoration (gutter / focus bar / scroll padding) layers naturally.
-/// Building the full `quadraui::Terminal` primitive once per frame and
-/// dispatching here per row keeps allocations bounded — every cell is
-/// drawn from already-owned data.
-pub(super) fn draw_terminal_row(
-    buf: &mut Buffer,
-    row: &[quadraui::TerminalCell],
-    start_x: u16,
-    screen_row: u16,
-    max_cols: u16,
-    theme: &Theme,
-) {
-    for (col_idx, cell) in row.iter().enumerate() {
-        let x = start_x + col_idx as u16;
-        if x >= start_x + max_cols {
-            break;
-        }
-        let fg = qc(cell.fg);
-        let bg = qc(cell.bg);
-        let (draw_fg, draw_bg) = if cell.is_cursor || cell.selected {
-            (bg, fg)
-        } else if cell.is_find_active {
-            (rc(theme.search_match_fg), rc(theme.search_current_match_bg))
-        } else if cell.is_find_match {
-            (rc(theme.search_match_fg), rc(theme.search_match_bg))
-        } else {
-            (fg, bg)
-        };
-        let ch = if cell.ch == '\0' { ' ' } else { cell.ch };
-        let mut modifier = ratatui::style::Modifier::empty();
-        if cell.bold {
-            modifier |= ratatui::style::Modifier::BOLD;
-        }
-        if cell.italic {
-            modifier |= ratatui::style::Modifier::ITALIC;
-        }
-        if cell.underline {
-            modifier |= ratatui::style::Modifier::UNDERLINED;
-        }
-        if modifier.is_empty() {
-            set_cell(buf, x, screen_row, ch, draw_fg, draw_bg);
-        } else {
-            super::set_cell_styled(buf, x, screen_row, ch, draw_fg, draw_bg, modifier, None);
-        }
-    }
-}
-
 /// Draw the find/replace overlay by walking `panel.hit_regions` (the
 /// shared cross-backend layout source-of-truth from
 /// `core::engine::compute_find_replace_hit_regions`). Painting and

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -720,7 +720,7 @@ pub(super) fn draw_frame(
                         width: content_area.width,
                         height: content_area.height.saturating_sub(1),
                     };
-                    render_terminal_panel(frame.buffer_mut(), term_content, term, theme);
+                    render_terminal_panel(frame, backend, term_content, term, theme);
                     // Register terminal content area as a scroll surface.
                     engine
                         .scroll_surfaces


### PR DESCRIPTION
## Summary

- Replace bespoke terminal renderers in both GTK (109 lines) and TUI (122 lines) with quadraui's `Backend::draw_terminal` + `TerminalSplitLayout`
- Extract `render::build_terminal_draw_data()` so both backends share one function for Terminal primitive construction (scrollbar, split layout, cell conversion)
- Delete GTK `draw_terminal_panel`, `draw_terminal_cells` wrapper, TUI `render_terminal_pane_cells`, `draw_terminal_row` — all replaced by quadraui
- Terminal scrollbar now uses quadraui's themed `Scrollbar` primitive with `inverted: true` and `width: Some(6)` for GTK
- Fix GTK `dispatch_click` consuming all terminal clicks (was blocking text selection and focus)
- Set `char_width`/`line_height` on GTK backend before `draw_terminal` (was using wrong default)

Depends on: quadraui#123 (TerminalSplitLayout), quadraui#129 (Terminal scrollbar), quadraui#131 (inverted + configurable width)

Net: **-205 lines** of bespoke per-backend terminal rendering.

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --no-default-features` — 2048 tests pass
- [x] `cargo fmt -- --check` clean
- [x] GTK smoke: terminal renders, scrollbar themed, scroll wheel + track-click + thumb-drag work, text selection works, focus works
- [x] TUI smoke: terminal renders, scrollbar renders, split works

## Follow-up issues filed

- #351 — Terminal: shared key dispatch (Ctrl-C copies when selection active)
- #352 — GTK: click near line end places caret to the right (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)