### PR TITLE
feat: factor tab drop-zone computation + overlay into render.rs (#345)

### DIFF
--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -405,14 +405,16 @@ pub(super) fn handle_mouse_click(
     }
 }
 
-/// Build `TabDropGroup`s for GTK's pixel coordinate system.
-pub(super) fn build_gtk_tab_drop_groups(
+type TabSlotsMap = std::collections::HashMap<usize, Vec<(f32, f32)>>;
+
+/// Build tab slot positions (absolute pixel coords) for each group.
+pub(super) fn build_gtk_tab_slots(
     engine: &Engine,
     width: f64,
     height: f64,
     line_height: f64,
     tab_slot_positions: &TabSlotMap,
-) -> (Vec<render_mod::TabDropGroup>, f32) {
+) -> (Vec<render_mod::DropGroupBounds>, f32, TabSlotsMap) {
     use crate::core::window::WindowRect;
 
     let tbh = render_mod::tab_bar_height_px(line_height, engine.settings.breadcrumbs);
@@ -423,53 +425,37 @@ pub(super) fn build_gtk_tab_drop_groups(
         .calculate_group_rects(content_bounds, tbh);
     engine.adjust_group_rects_for_hidden_tabs(&mut group_rects, tbh);
 
-    let mut groups = Vec::new();
-    for (gid, grect) in &group_rects {
-        let hidden = engine.is_tab_bar_hidden(*gid);
-        let eff_tbh = if hidden {
-            if engine.settings.breadcrumbs {
-                tbh / 2.0
-            } else {
-                0.0
+    let bounds: Vec<render_mod::DropGroupBounds> = group_rects
+        .iter()
+        .map(|(gid, grect)| {
+            let scroll_off = engine
+                .editor_groups
+                .get(gid)
+                .map(|g| g.tab_scroll_offset)
+                .unwrap_or(0);
+            render_mod::DropGroupBounds {
+                group_id: *gid,
+                x: grect.x as f32,
+                y: grect.y as f32,
+                width: grect.width as f32,
+                content_height: grect.height as f32,
+                tab_scroll_offset: scroll_off,
             }
-        } else {
-            tbh
-        };
-        let tab_slots: Vec<(f32, f32)> = if hidden {
-            Vec::new()
-        } else if let Some(slots) = tab_slot_positions.get(&gid.0) {
-            slots
+        })
+        .collect();
+
+    let mut slots_map = std::collections::HashMap::new();
+    for gb in &bounds {
+        if let Some(slots) = tab_slot_positions.get(&gb.group_id.0) {
+            let abs_slots: Vec<(f32, f32)> = slots
                 .iter()
-                .map(|&(s, e)| ((grect.x + s) as f32, (grect.x + e) as f32))
-                .collect()
-        } else {
-            Vec::new()
-        };
-        let scroll_off = engine
-            .editor_groups
-            .get(gid)
-            .map(|g| g.tab_scroll_offset)
-            .unwrap_or(0);
-        groups.push(render_mod::TabDropGroup {
-            group_id: *gid,
-            rect: quadraui::DropGroupRect {
-                bounds: quadraui::Rect::new(
-                    grect.x as f32,
-                    (grect.y - eff_tbh) as f32,
-                    grect.width as f32,
-                    (eff_tbh + grect.height) as f32,
-                ),
-                tab_slots,
-            },
-            tab_scroll_offset: scroll_off,
-        });
+                .map(|&(s, e)| (gb.x + s as f32, gb.x + e as f32))
+                .collect();
+            slots_map.insert(gb.group_id.0, abs_slots);
+        }
     }
-    let effective_tbh = if groups.iter().any(|g| engine.is_tab_bar_hidden(g.group_id)) {
-        0.0
-    } else {
-        tbh as f32
-    };
-    (groups, effective_tbh)
+
+    (bounds, tbh as f32, slots_map)
 }
 
 /// Compute the drop zone for a tab drag based on cursor position.
@@ -484,9 +470,10 @@ pub(super) fn compute_tab_drop_zone(
     _char_width: f64,
     tab_slot_positions: &TabSlotMap,
 ) -> crate::core::window::DropZone {
-    let (groups, tbh) =
-        build_gtk_tab_drop_groups(engine, width, height, line_height, tab_slot_positions);
-    render_mod::compute_tab_drop_zone(x as f32, y as f32, &groups, tbh)
+    let (bounds, tbh, slots_map) =
+        build_gtk_tab_slots(engine, width, height, line_height, tab_slot_positions);
+    let (groups, eff_tbh) = render_mod::build_tab_drop_groups(&bounds, engine, tbh, &slots_map);
+    render_mod::compute_tab_drop_zone(x as f32, y as f32, &groups, eff_tbh)
 }
 
 /// Handle mouse double-click — select word at position.

--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -405,6 +405,73 @@ pub(super) fn handle_mouse_click(
     }
 }
 
+/// Build `TabDropGroup`s for GTK's pixel coordinate system.
+pub(super) fn build_gtk_tab_drop_groups(
+    engine: &Engine,
+    width: f64,
+    height: f64,
+    line_height: f64,
+    tab_slot_positions: &TabSlotMap,
+) -> (Vec<render_mod::TabDropGroup>, f32) {
+    use crate::core::window::WindowRect;
+
+    let tbh = render_mod::tab_bar_height_px(line_height, engine.settings.breadcrumbs);
+    let editor_bottom = gtk_editor_bottom(engine, width, height, line_height);
+    let content_bounds = WindowRect::new(0.0, 0.0, width, editor_bottom);
+    let mut group_rects = engine
+        .group_layout
+        .calculate_group_rects(content_bounds, tbh);
+    engine.adjust_group_rects_for_hidden_tabs(&mut group_rects, tbh);
+
+    let mut groups = Vec::new();
+    for (gid, grect) in &group_rects {
+        let hidden = engine.is_tab_bar_hidden(*gid);
+        let eff_tbh = if hidden {
+            if engine.settings.breadcrumbs {
+                tbh / 2.0
+            } else {
+                0.0
+            }
+        } else {
+            tbh
+        };
+        let tab_slots: Vec<(f32, f32)> = if hidden {
+            Vec::new()
+        } else if let Some(slots) = tab_slot_positions.get(&gid.0) {
+            slots
+                .iter()
+                .map(|&(s, e)| ((grect.x + s) as f32, (grect.x + e) as f32))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let scroll_off = engine
+            .editor_groups
+            .get(gid)
+            .map(|g| g.tab_scroll_offset)
+            .unwrap_or(0);
+        groups.push(render_mod::TabDropGroup {
+            group_id: *gid,
+            rect: quadraui::DropGroupRect {
+                bounds: quadraui::Rect::new(
+                    grect.x as f32,
+                    (grect.y - eff_tbh) as f32,
+                    grect.width as f32,
+                    (eff_tbh + grect.height) as f32,
+                ),
+                tab_slots,
+            },
+            tab_scroll_offset: scroll_off,
+        });
+    }
+    let effective_tbh = if groups.iter().any(|g| engine.is_tab_bar_hidden(g.group_id)) {
+        0.0
+    } else {
+        tbh as f32
+    };
+    (groups, effective_tbh)
+}
+
 /// Compute the drop zone for a tab drag based on cursor position.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn compute_tab_drop_zone(
@@ -414,84 +481,12 @@ pub(super) fn compute_tab_drop_zone(
     width: f64,
     height: f64,
     line_height: f64,
-    char_width: f64,
+    _char_width: f64,
     tab_slot_positions: &TabSlotMap,
 ) -> crate::core::window::DropZone {
-    use crate::core::window::{DropZone, SplitDirection, WindowRect};
-
-    let tab_row_height = (line_height * 1.6).ceil();
-    let tab_bar_height = if engine.settings.breadcrumbs {
-        tab_row_height + line_height
-    } else {
-        tab_row_height
-    };
-    let editor_bottom = gtk_editor_bottom(engine, width, height, line_height);
-    let content_bounds = WindowRect::new(0.0, 0.0, width, editor_bottom);
-    let mut group_rects = engine
-        .group_layout
-        .calculate_group_rects(content_bounds, tab_bar_height);
-    engine.adjust_group_rects_for_hidden_tabs(&mut group_rects, tab_bar_height);
-
-    for (gid, grect) in &group_rects {
-        let tab_hidden = engine.is_tab_bar_hidden(*gid);
-        let tab_x = grect.x;
-        let group_id = *gid;
-
-        // Check tab bar region (for reorder/center drop) — skip if tab bar is hidden
-        let tab_y = grect.y - tab_bar_height;
-        if !tab_hidden
-            && y >= tab_y
-            && y < tab_y + tab_row_height
-            && x >= tab_x
-            && x < tab_x + grect.width
-        {
-            // Determine insertion index from tab slot positions
-            let local_x = x - tab_x;
-            if let Some(slots) = tab_slot_positions.get(&group_id.0) {
-                for (i, &(slot_start, slot_end)) in slots.iter().enumerate() {
-                    let mid = (slot_start + slot_end) / 2.0;
-                    if local_x < mid {
-                        return DropZone::TabReorder(group_id, i);
-                    }
-                }
-                return DropZone::TabReorder(group_id, slots.len());
-            }
-            return DropZone::Center(group_id);
-        }
-
-        // Check content area with edge margins
-        let content_top = grect.y;
-        let content_left = grect.x;
-        let content_right = grect.x + grect.width;
-        let content_bottom = grect.y + grect.height;
-        if x >= content_left && x < content_right && y >= content_top && y < content_bottom {
-            let w = grect.width;
-            let h = grect.height;
-            let rel_x = x - content_left;
-            let rel_y = y - content_top;
-            let margin = 0.2;
-
-            // Minimum 40px or char_width*5 for edge zones
-            let edge_w = (w * margin).min(char_width * 10.0).max(40.0);
-            let edge_h = (h * margin).min(line_height * 3.0).max(40.0);
-
-            if rel_x < edge_w {
-                return DropZone::Split(group_id, SplitDirection::Vertical, true);
-            }
-            if rel_x > w - edge_w {
-                return DropZone::Split(group_id, SplitDirection::Vertical, false);
-            }
-            if rel_y < edge_h {
-                return DropZone::Split(group_id, SplitDirection::Horizontal, true);
-            }
-            if rel_y > h - edge_h {
-                return DropZone::Split(group_id, SplitDirection::Horizontal, false);
-            }
-            return DropZone::Center(group_id);
-        }
-    }
-
-    DropZone::None
+    let (groups, tbh) =
+        build_gtk_tab_drop_groups(engine, width, height, line_height, tab_slot_positions);
+    render_mod::compute_tab_drop_zone(x as f32, y as f32, &groups, tbh)
 }
 
 /// Handle mouse double-click — select word at position.

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -392,6 +392,7 @@ pub(super) fn draw_editor(
             line_height,
             char_width,
             &layout,
+            &tab_slot_positions_out.borrow(),
         );
     }
 
@@ -964,110 +965,60 @@ pub(super) fn draw_tab_drag_overlay(
     height: f64,
     line_height: f64,
     _char_width: f64,
-    layout: &pango::Layout,
+    pango_layout: &pango::Layout,
+    tab_slot_positions: &TabSlotMap,
 ) {
-    use crate::core::window::{DropZone, SplitDirection, WindowRect};
-
-    let tab_row_height = (line_height * 1.6).ceil();
-    let tab_bar_height = if engine.settings.breadcrumbs {
-        tab_row_height + line_height
-    } else {
-        tab_row_height
-    };
-    let wildmenu_px = if engine.wildmenu_items.is_empty() {
-        0.0
-    } else {
-        line_height
-    };
-    let per_window_status = engine.settings.window_status_line;
-    let global_status_rows = if per_window_status { 1.0 } else { 2.0 }; // cmd only vs status+cmd
-    let status_bar_height = line_height * global_status_rows + wildmenu_px;
-    let qf_px = if engine.quickfix_open {
-        let n = engine.quickfix_items.len().clamp(1, 10) as f64;
-        (n + 1.0) * line_height
-    } else {
-        0.0
-    };
-    let term_px = if engine.terminal_open || engine.bottom_panel_open {
-        let target = super::gtk_terminal_target_maximize_rows(engine, height, line_height);
-        (engine.effective_terminal_panel_rows(target) as usize + 2) as f64 * line_height
-    } else {
-        0.0
-    };
-    let debug_toolbar_px = if engine.debug_toolbar_visible {
-        line_height
-    } else {
-        0.0
-    };
-    let editor_bottom = height - status_bar_height - debug_toolbar_px - qf_px - term_px;
-    let content_bounds = WindowRect::new(0.0, 0.0, width, editor_bottom);
-    let mut group_rects = engine
-        .group_layout
-        .calculate_group_rects(content_bounds, tab_bar_height);
-    engine.adjust_group_rects_for_hidden_tabs(&mut group_rects, tab_bar_height);
-
-    // Helper: effective tab bar height for a group (0 if hidden).
-    let eff_tbh = |gid: crate::core::window::GroupId| -> f64 {
-        if engine.is_tab_bar_hidden(gid) {
-            if engine.settings.breadcrumbs {
-                tab_bar_height / 2.0
-            } else {
-                0.0
-            }
-        } else {
-            tab_bar_height
-        }
+    let (groups, tbh) = super::click::build_gtk_tab_drop_groups(
+        engine,
+        width,
+        height,
+        line_height,
+        tab_slot_positions,
+    );
+    let cursor = engine
+        .tab_drag_mouse
+        .map(|(mx, my)| (mx as f32, my as f32))
+        .unwrap_or((0.0, 0.0));
+    let overlay = match render::compute_tab_drop_overlay(
+        &engine.tab_drop_zone,
+        &groups,
+        cursor,
+        tbh,
+        2.0,
+        12.0,
+    ) {
+        Some(o) => o,
+        None => return,
     };
 
-    // Compute highlight rect from the drop zone.
-    let zone = engine.tab_drop_zone;
-    let highlight: Option<(f64, f64, f64, f64)> = match zone {
-        DropZone::Center(gid) => group_rects.iter().find(|(g, _)| *g == gid).map(|(_, r)| {
-            let tbh = eff_tbh(gid);
-            (r.x, r.y - tbh, r.width, r.height + tbh)
-        }),
-        DropZone::Split(gid, dir, new_first) => {
-            group_rects.iter().find(|(g, _)| *g == gid).map(|(_, r)| {
-                let tbh = eff_tbh(gid);
-                let full_y = r.y - tbh;
-                let full_h = r.height + tbh;
-                match (dir, new_first) {
-                    (SplitDirection::Vertical, true) => (r.x, full_y, r.width / 2.0, full_h),
-                    (SplitDirection::Vertical, false) => {
-                        (r.x + r.width / 2.0, full_y, r.width / 2.0, full_h)
-                    }
-                    (SplitDirection::Horizontal, true) => (r.x, full_y, r.width, full_h / 2.0),
-                    (SplitDirection::Horizontal, false) => {
-                        (r.x, full_y + full_h / 2.0, r.width, full_h / 2.0)
-                    }
-                }
-            })
-        }
-        DropZone::TabReorder(gid, _idx) => group_rects
-            .iter()
-            .find(|(g, _)| *g == gid)
-            .map(|(_, r)| (r.x, r.y - eff_tbh(gid), r.width, line_height)),
-        DropZone::None => None,
-    };
-
-    // Draw the highlight rectangle.
-    if let Some((hx, hy, hw, hh)) = highlight {
+    if let Some(h) = overlay.highlight {
         let (cr_r, cr_g, cr_b) = theme.cursor.to_cairo();
         cr.set_source_rgba(cr_r, cr_g, cr_b, 0.15);
-        cr.rectangle(hx, hy, hw, hh);
+        cr.rectangle(h.x as f64, h.y as f64, h.width as f64, h.height as f64);
         cr.fill().ok();
         cr.set_source_rgba(cr_r, cr_g, cr_b, 0.5);
         cr.set_line_width(2.0);
-        cr.rectangle(hx, hy, hw, hh);
+        cr.rectangle(h.x as f64, h.y as f64, h.width as f64, h.height as f64);
         cr.stroke().ok();
     }
 
-    // Draw a small ghost label near the cursor.
+    if let Some(bar) = overlay.insertion_bar {
+        let (cr_r, cr_g, cr_b) = theme.cursor.to_cairo();
+        cr.set_source_rgb(cr_r, cr_g, cr_b);
+        cr.rectangle(
+            bar.x as f64,
+            bar.y as f64,
+            bar.width as f64,
+            bar.height as f64,
+        );
+        cr.fill().ok();
+    }
+
     if let (Some((mx, my)), Some(ref drag)) = (engine.tab_drag_mouse, &engine.tab_drag) {
         let label = &drag.tab_name;
         if !label.is_empty() {
-            layout.set_text(label);
-            let (tw, th) = layout.pixel_size();
+            pango_layout.set_text(label);
+            let (tw, th) = pango_layout.pixel_size();
             let gx = mx + 12.0;
             let gy = my - th as f64 / 2.0;
             let pad = 4.0;
@@ -1083,7 +1034,7 @@ pub(super) fn draw_tab_drag_overlay(
             let (gfr, gfg, gfb) = theme.foreground.to_cairo();
             cr.set_source_rgba(gfr, gfg, gfb, 0.9);
             cr.move_to(gx, gy);
-            pangocairo::show_layout(cr, layout);
+            pangocairo::show_layout(cr, pango_layout);
         }
     }
 }

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -968,13 +968,10 @@ pub(super) fn draw_tab_drag_overlay(
     pango_layout: &pango::Layout,
     tab_slot_positions: &TabSlotMap,
 ) {
-    let (groups, tbh) = super::click::build_gtk_tab_drop_groups(
-        engine,
-        width,
-        height,
-        line_height,
-        tab_slot_positions,
-    );
+    let (bounds, tbh, slots_map) =
+        super::click::build_gtk_tab_slots(engine, width, height, line_height, tab_slot_positions);
+    let (groups, eff_tbh) = render::build_tab_drop_groups(&bounds, engine, tbh, &slots_map);
+    let tbh = eff_tbh;
     let cursor = engine
         .tab_drag_mouse
         .map(|(mx, my)| (mx as f32, my as f32))

--- a/src/render.rs
+++ b/src/render.rs
@@ -11555,6 +11555,109 @@ pub struct TabDropOverlay {
     pub ghost_position: (f32, f32),
 }
 
+/// Lightweight group-bounds descriptor for [`build_tab_drop_groups`].
+pub struct DropGroupBounds {
+    pub group_id: GroupId,
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub content_height: f32,
+    pub tab_scroll_offset: usize,
+}
+
+/// Build `TabDropGroup`s from a set of group bounds.
+///
+/// `tab_bar_height` is in the same units as the bounds (cells for TUI,
+/// pixels for GTK/Win-GUI). Each group's bounds describe the
+/// **content area** — the function prepends `tab_bar_height` above.
+///
+/// `tab_slots_map` maps `GroupId.0` → visible tab slot positions in
+/// the same coordinate system as the bounds.
+pub fn build_tab_drop_groups(
+    group_bounds: &[DropGroupBounds],
+    engine: &crate::core::engine::Engine,
+    tab_bar_height: f32,
+    tab_slots_map: &std::collections::HashMap<usize, Vec<(f32, f32)>>,
+) -> (Vec<TabDropGroup>, f32) {
+    let mut groups = Vec::new();
+    let breadcrumbs = engine.settings.breadcrumbs;
+
+    for gb in group_bounds {
+        let hidden = engine.is_tab_bar_hidden(gb.group_id);
+        let eff_tbh = if hidden {
+            if breadcrumbs {
+                tab_bar_height / 2.0
+            } else {
+                0.0
+            }
+        } else {
+            tab_bar_height
+        };
+        let tab_slots = if hidden {
+            Vec::new()
+        } else {
+            tab_slots_map
+                .get(&gb.group_id.0)
+                .cloned()
+                .unwrap_or_default()
+        };
+        groups.push(TabDropGroup {
+            group_id: gb.group_id,
+            rect: quadraui::DropGroupRect {
+                bounds: quadraui::Rect::new(
+                    gb.x,
+                    gb.y - eff_tbh,
+                    gb.width,
+                    eff_tbh + gb.content_height,
+                ),
+                tab_slots,
+            },
+            tab_scroll_offset: gb.tab_scroll_offset,
+        });
+    }
+
+    let effective_tbh = if groups.iter().any(|g| engine.is_tab_bar_hidden(g.group_id)) {
+        0.0
+    } else {
+        tab_bar_height
+    };
+    (groups, effective_tbh)
+}
+
+/// Build [`DropGroupBounds`] from a `ScreenLayout`, applying an
+/// editor-area offset. Both TUI and GTK call this when the
+/// `ScreenLayout` is available (draw path, or TUI's cached layout).
+pub fn screen_to_drop_group_bounds(
+    screen: &ScreenLayout,
+    engine: &crate::core::engine::Engine,
+    editor_origin: (f32, f32),
+    editor_size: (f32, f32),
+) -> Vec<DropGroupBounds> {
+    if let Some(ref split) = screen.editor_group_split {
+        split
+            .group_tab_bars
+            .iter()
+            .map(|gtb| DropGroupBounds {
+                group_id: gtb.group_id,
+                x: editor_origin.0 + gtb.bounds.x as f32,
+                y: editor_origin.1 + gtb.bounds.y as f32,
+                width: gtb.bounds.width as f32,
+                content_height: gtb.bounds.height as f32,
+                tab_scroll_offset: gtb.tab_scroll_offset,
+            })
+            .collect()
+    } else {
+        vec![DropGroupBounds {
+            group_id: engine.active_group,
+            x: editor_origin.0,
+            y: editor_origin.1,
+            width: editor_size.0,
+            content_height: editor_size.1,
+            tab_scroll_offset: screen.tab_scroll_offset,
+        }]
+    }
+}
+
 pub fn compute_tab_drop_zone(
     cursor_x: f32,
     cursor_y: f32,

--- a/src/render.rs
+++ b/src/render.rs
@@ -11541,6 +11541,123 @@ pub fn editor_bottom_px(
         - separated_status_height_px(line_height, has_separated_status)
 }
 
+// ─── Tab drop-zone (shared) ─────────────────────────────────────────────────
+
+pub struct TabDropGroup {
+    pub group_id: GroupId,
+    pub rect: quadraui::DropGroupRect,
+    pub tab_scroll_offset: usize,
+}
+
+pub struct TabDropOverlay {
+    pub highlight: Option<quadraui::Rect>,
+    pub insertion_bar: Option<quadraui::Rect>,
+    pub ghost_position: (f32, f32),
+}
+
+pub fn compute_tab_drop_zone(
+    cursor_x: f32,
+    cursor_y: f32,
+    groups: &[TabDropGroup],
+    tab_bar_height: f32,
+) -> crate::core::window::DropZone {
+    use crate::core::window::DropZone;
+
+    let rects: Vec<quadraui::DropGroupRect> = groups.iter().map(|g| g.rect.clone()).collect();
+    match quadraui::compute_drop_zone(cursor_x, cursor_y, &rects, tab_bar_height) {
+        Some(qz) => {
+            let g = &groups[qz.group_idx];
+            match qz.kind {
+                quadraui::DropZoneKind::Center => DropZone::Center(g.group_id),
+                quadraui::DropZoneKind::Split(edge) => {
+                    let (dir, new_first) = match edge {
+                        quadraui::DropEdge::Left => (SplitDirection::Vertical, true),
+                        quadraui::DropEdge::Right => (SplitDirection::Vertical, false),
+                        quadraui::DropEdge::Top => (SplitDirection::Horizontal, true),
+                        quadraui::DropEdge::Bottom => (SplitDirection::Horizontal, false),
+                    };
+                    DropZone::Split(g.group_id, dir, new_first)
+                }
+                quadraui::DropZoneKind::TabReorder(idx) => {
+                    DropZone::TabReorder(g.group_id, g.tab_scroll_offset + idx)
+                }
+            }
+        }
+        None => DropZone::None,
+    }
+}
+
+pub fn compute_tab_drop_overlay(
+    drop_zone: &crate::core::window::DropZone,
+    groups: &[TabDropGroup],
+    cursor: (f32, f32),
+    tab_bar_height: f32,
+    bar_thickness: f32,
+    ghost_offset: f32,
+) -> Option<TabDropOverlay> {
+    use crate::core::window::DropZone;
+
+    let ghost_position = (cursor.0 + ghost_offset, cursor.1);
+
+    match drop_zone {
+        DropZone::None => None,
+        DropZone::Center(gid) => {
+            let g = groups.iter().find(|g| g.group_id == *gid)?;
+            let b = &g.rect.bounds;
+            Some(TabDropOverlay {
+                highlight: Some(quadraui::Rect::new(b.x, b.y, b.width, b.height)),
+                insertion_bar: None,
+                ghost_position,
+            })
+        }
+        DropZone::Split(gid, dir, new_first) => {
+            let g = groups.iter().find(|g| g.group_id == *gid)?;
+            let b = &g.rect.bounds;
+            let h = match (dir, new_first) {
+                (SplitDirection::Vertical, true) => {
+                    quadraui::Rect::new(b.x, b.y, b.width / 2.0, b.height)
+                }
+                (SplitDirection::Vertical, false) => {
+                    quadraui::Rect::new(b.x + b.width / 2.0, b.y, b.width / 2.0, b.height)
+                }
+                (SplitDirection::Horizontal, true) => {
+                    quadraui::Rect::new(b.x, b.y, b.width, b.height / 2.0)
+                }
+                (SplitDirection::Horizontal, false) => {
+                    quadraui::Rect::new(b.x, b.y + b.height / 2.0, b.width, b.height / 2.0)
+                }
+            };
+            Some(TabDropOverlay {
+                highlight: Some(h),
+                insertion_bar: None,
+                ghost_position,
+            })
+        }
+        DropZone::TabReorder(gid, abs_idx) => {
+            let g = groups.iter().find(|g| g.group_id == *gid)?;
+            let b = &g.rect.bounds;
+            let vis_idx = abs_idx.saturating_sub(g.tab_scroll_offset);
+            let bar_x = if vis_idx < g.rect.tab_slots.len() {
+                g.rect.tab_slots[vis_idx].0
+            } else if let Some(last) = g.rect.tab_slots.last() {
+                last.1
+            } else {
+                b.x
+            };
+            Some(TabDropOverlay {
+                highlight: Some(quadraui::Rect::new(b.x, b.y, b.width, tab_bar_height)),
+                insertion_bar: Some(quadraui::Rect::new(
+                    bar_x - bar_thickness / 2.0,
+                    b.y,
+                    bar_thickness,
+                    tab_bar_height,
+                )),
+                ghost_position,
+            })
+        }
+    }
+}
+
 /// Compute the scrollbar-to-scroll-top mapping from a click position.
 /// Returns the new `scroll_top` value.
 ///

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -1335,68 +1335,45 @@ pub(super) fn tab_tooltip_at_col(
 }
 
 /// Draw the tab drag-and-drop overlay (highlight drop zone + ghost label).
-fn build_tui_tab_drop_groups(
-    engine: &Engine,
-    editor_area: Rect,
+fn build_tui_tab_slots(
     screen: &render::ScreenLayout,
-) -> (Vec<render::TabDropGroup>, f32) {
-    let tbh: u16 = if engine.settings.breadcrumbs { 2 } else { 1 };
-    let mut groups = Vec::new();
-
+    engine: &Engine,
+    editor_x: f32,
+) -> std::collections::HashMap<usize, Vec<(f32, f32)>> {
+    let mut map = std::collections::HashMap::new();
     if let Some(ref split) = screen.editor_group_split {
         for gtb in &split.group_tab_bars {
-            let gx = gtb.bounds.x as f32;
-            let gw = gtb.bounds.width as f32;
-            let content_h = gtb.bounds.height as f32;
-            let tab_bar_rel = (gtb.bounds.y as u16).saturating_sub(tbh);
-            let abs_x = editor_area.x as f32 + gx;
-            let abs_y = editor_area.y as f32 + tab_bar_rel as f32;
-            let scroll_off = gtb.tab_scroll_offset;
-            let ov = if scroll_off > 0 { 2.0f32 } else { 0.0 };
+            let abs_x = editor_x + gtb.bounds.x as f32;
+            let ov = if gtb.tab_scroll_offset > 0 {
+                2.0f32
+            } else {
+                0.0
+            };
             let mut x = abs_x + ov;
-            let mut tab_slots = Vec::new();
-            for tab in gtb.tabs.iter().skip(scroll_off) {
+            let mut slots = Vec::new();
+            for tab in gtb.tabs.iter().skip(gtb.tab_scroll_offset) {
                 let tw = tab.name.chars().count() as f32 + TAB_CLOSE_COLS as f32;
-                tab_slots.push((x, x + tw));
+                slots.push((x, x + tw));
                 x += tw;
             }
-            groups.push(render::TabDropGroup {
-                group_id: gtb.group_id,
-                rect: quadraui::DropGroupRect {
-                    bounds: quadraui::Rect::new(abs_x, abs_y, gw, tbh as f32 + content_h),
-                    tab_slots,
-                },
-                tab_scroll_offset: scroll_off,
-            });
+            map.insert(gtb.group_id.0, slots);
         }
     } else {
-        let group_id = engine.active_group;
-        let scroll_off = screen.tab_scroll_offset;
-        let ov = if scroll_off > 0 { 2.0f32 } else { 0.0 };
-        let abs_x = editor_area.x as f32;
-        let mut x = abs_x + ov;
-        let mut tab_slots = Vec::new();
-        for tab in screen.tab_bar.iter().skip(scroll_off) {
+        let ov = if screen.tab_scroll_offset > 0 {
+            2.0f32
+        } else {
+            0.0
+        };
+        let mut x = editor_x + ov;
+        let mut slots = Vec::new();
+        for tab in screen.tab_bar.iter().skip(screen.tab_scroll_offset) {
             let tw = tab.name.chars().count() as f32 + TAB_CLOSE_COLS as f32;
-            tab_slots.push((x, x + tw));
+            slots.push((x, x + tw));
             x += tw;
         }
-        groups.push(render::TabDropGroup {
-            group_id,
-            rect: quadraui::DropGroupRect {
-                bounds: quadraui::Rect::new(
-                    abs_x,
-                    editor_area.y as f32,
-                    editor_area.width as f32,
-                    editor_area.height as f32,
-                ),
-                tab_slots,
-            },
-            tab_scroll_offset: scroll_off,
-        });
+        map.insert(engine.active_group.0, slots);
     }
-
-    (groups, tbh as f32)
+    map
 }
 
 pub(super) fn render_tab_drag_overlay(
@@ -1406,7 +1383,19 @@ pub(super) fn render_tab_drag_overlay(
     screen: &render::ScreenLayout,
     theme: &render::Theme,
 ) {
-    let (groups, tbh) = build_tui_tab_drop_groups(engine, editor_area, screen);
+    let tab_slots = build_tui_tab_slots(screen, engine, editor_area.x as f32);
+    let tbh_f = if engine.settings.breadcrumbs {
+        2.0f32
+    } else {
+        1.0
+    };
+    let bounds = render::screen_to_drop_group_bounds(
+        screen,
+        engine,
+        (editor_area.x as f32, editor_area.y as f32),
+        (editor_area.width as f32, editor_area.height as f32),
+    );
+    let (groups, tbh) = render::build_tab_drop_groups(&bounds, engine, tbh_f, &tab_slots);
     let cursor = engine
         .tab_drag_mouse
         .map(|(mx, my)| (mx as f32, my as f32))
@@ -1497,8 +1486,19 @@ pub(super) fn compute_tui_tab_drop_zone(
     let menu_rows: u16 = if engine.menu_bar_visible { 1 } else { 0 };
     let editor_w = ts.width.saturating_sub(editor_left);
     let editor_h = ts.height.saturating_sub(menu_rows + 2);
-    let editor_area = Rect::new(editor_left, menu_rows, editor_w, editor_h);
-    let (groups, tbh) = build_tui_tab_drop_groups(engine, editor_area, layout);
+    let tab_slots = build_tui_tab_slots(layout, engine, editor_left as f32);
+    let tbh_f = if engine.settings.breadcrumbs {
+        2.0f32
+    } else {
+        1.0
+    };
+    let bounds = render::screen_to_drop_group_bounds(
+        layout,
+        engine,
+        (editor_left as f32, menu_rows as f32),
+        (editor_w as f32, editor_h as f32),
+    );
+    let (groups, tbh) = render::build_tab_drop_groups(&bounds, engine, tbh_f, &tab_slots);
     render::compute_tab_drop_zone(col as f32, row as f32, &groups, tbh)
 }
 

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -1335,6 +1335,70 @@ pub(super) fn tab_tooltip_at_col(
 }
 
 /// Draw the tab drag-and-drop overlay (highlight drop zone + ghost label).
+fn build_tui_tab_drop_groups(
+    engine: &Engine,
+    editor_area: Rect,
+    screen: &render::ScreenLayout,
+) -> (Vec<render::TabDropGroup>, f32) {
+    let tbh: u16 = if engine.settings.breadcrumbs { 2 } else { 1 };
+    let mut groups = Vec::new();
+
+    if let Some(ref split) = screen.editor_group_split {
+        for gtb in &split.group_tab_bars {
+            let gx = gtb.bounds.x as f32;
+            let gw = gtb.bounds.width as f32;
+            let content_h = gtb.bounds.height as f32;
+            let tab_bar_rel = (gtb.bounds.y as u16).saturating_sub(tbh);
+            let abs_x = editor_area.x as f32 + gx;
+            let abs_y = editor_area.y as f32 + tab_bar_rel as f32;
+            let scroll_off = gtb.tab_scroll_offset;
+            let ov = if scroll_off > 0 { 2.0f32 } else { 0.0 };
+            let mut x = abs_x + ov;
+            let mut tab_slots = Vec::new();
+            for tab in gtb.tabs.iter().skip(scroll_off) {
+                let tw = tab.name.chars().count() as f32 + TAB_CLOSE_COLS as f32;
+                tab_slots.push((x, x + tw));
+                x += tw;
+            }
+            groups.push(render::TabDropGroup {
+                group_id: gtb.group_id,
+                rect: quadraui::DropGroupRect {
+                    bounds: quadraui::Rect::new(abs_x, abs_y, gw, tbh as f32 + content_h),
+                    tab_slots,
+                },
+                tab_scroll_offset: scroll_off,
+            });
+        }
+    } else {
+        let group_id = engine.active_group;
+        let scroll_off = screen.tab_scroll_offset;
+        let ov = if scroll_off > 0 { 2.0f32 } else { 0.0 };
+        let abs_x = editor_area.x as f32;
+        let mut x = abs_x + ov;
+        let mut tab_slots = Vec::new();
+        for tab in screen.tab_bar.iter().skip(scroll_off) {
+            let tw = tab.name.chars().count() as f32 + TAB_CLOSE_COLS as f32;
+            tab_slots.push((x, x + tw));
+            x += tw;
+        }
+        groups.push(render::TabDropGroup {
+            group_id,
+            rect: quadraui::DropGroupRect {
+                bounds: quadraui::Rect::new(
+                    abs_x,
+                    editor_area.y as f32,
+                    editor_area.width as f32,
+                    editor_area.height as f32,
+                ),
+                tab_slots,
+            },
+            tab_scroll_offset: scroll_off,
+        });
+    }
+
+    (groups, tbh as f32)
+}
+
 pub(super) fn render_tab_drag_overlay(
     frame: &mut ratatui::Frame,
     engine: &Engine,
@@ -1342,82 +1406,30 @@ pub(super) fn render_tab_drag_overlay(
     screen: &render::ScreenLayout,
     theme: &render::Theme,
 ) {
-    use crate::core::window::{DropZone, SplitDirection};
-
-    let tui_tbh: u16 = if engine.settings.breadcrumbs { 2 } else { 1 };
-    let zone = engine.tab_drop_zone;
-
-    // Accent color for the drop zone highlight.
-    let highlight_bg = RColor::Indexed(24); // dark blue
-
-    // Compute the highlight rectangle in absolute terminal coordinates.
-    let highlight: Option<(u16, u16, u16, u16)> = if let Some(ref split) = screen.editor_group_split
-    {
-        match zone {
-            DropZone::Center(gid) => {
-                split
-                    .group_tab_bars
-                    .iter()
-                    .find(|g| g.group_id == gid)
-                    .map(|g| {
-                        let x = editor_area.x + g.bounds.x as u16;
-                        let y = editor_area.y + (g.bounds.y as u16).saturating_sub(tui_tbh);
-                        let w = g.bounds.width as u16;
-                        let h = g.bounds.height as u16 + tui_tbh;
-                        (x, y, w, h)
-                    })
-            }
-            DropZone::Split(gid, dir, new_first) => split
-                .group_tab_bars
-                .iter()
-                .find(|g| g.group_id == gid)
-                .map(|g| {
-                    let x = editor_area.x + g.bounds.x as u16;
-                    let full_y = editor_area.y + (g.bounds.y as u16).saturating_sub(tui_tbh);
-                    let w = g.bounds.width as u16;
-                    let full_h = g.bounds.height as u16 + tui_tbh;
-                    match (dir, new_first) {
-                        (SplitDirection::Vertical, true) => (x, full_y, w / 2, full_h),
-                        (SplitDirection::Vertical, false) => (x + w / 2, full_y, w - w / 2, full_h),
-                        (SplitDirection::Horizontal, true) => (x, full_y, w, full_h / 2),
-                        (SplitDirection::Horizontal, false) => {
-                            (x, full_y + full_h / 2, w, full_h - full_h / 2)
-                        }
-                    }
-                }),
-            DropZone::TabReorder(gid, _) => split
-                .group_tab_bars
-                .iter()
-                .find(|g| g.group_id == gid)
-                .map(|g| {
-                    let x = editor_area.x + g.bounds.x as u16;
-                    let y = editor_area.y + (g.bounds.y as u16).saturating_sub(tui_tbh);
-                    let w = g.bounds.width as u16;
-                    (x, y, w, 1)
-                }),
-            DropZone::None => None,
-        }
-    } else {
-        let x = editor_area.x;
-        let y = editor_area.y;
-        let w = editor_area.width;
-        let h = editor_area.height;
-        match zone {
-            DropZone::Center(_) => Some((x, y, w, h)),
-            DropZone::Split(_, dir, new_first) => Some(match (dir, new_first) {
-                (SplitDirection::Vertical, true) => (x, y, w / 2, h),
-                (SplitDirection::Vertical, false) => (x + w / 2, y, w - w / 2, h),
-                (SplitDirection::Horizontal, true) => (x, y, w, h / 2),
-                (SplitDirection::Horizontal, false) => (x, y + h / 2, w, h - h / 2),
-            }),
-            DropZone::TabReorder(_, _) => Some((x, y, w, 1)),
-            DropZone::None => None,
-        }
+    let (groups, tbh) = build_tui_tab_drop_groups(engine, editor_area, screen);
+    let cursor = engine
+        .tab_drag_mouse
+        .map(|(mx, my)| (mx as f32, my as f32))
+        .unwrap_or((0.0, 0.0));
+    let overlay = match render::compute_tab_drop_overlay(
+        &engine.tab_drop_zone,
+        &groups,
+        cursor,
+        tbh,
+        1.0,
+        2.0,
+    ) {
+        Some(o) => o,
+        None => return,
     };
 
-    // Draw the highlight area.
-    if let Some((hx, hy, hw, hh)) = highlight {
+    let highlight_bg = RColor::Indexed(24);
+    if let Some(h) = overlay.highlight {
         let buf = frame.buffer_mut();
+        let hx = h.x as u16;
+        let hy = h.y as u16;
+        let hw = h.width as u16;
+        let hh = h.height as u16;
         for dy in 0..hh {
             for dx in 0..hw {
                 let cx = hx + dx;
@@ -1430,57 +1442,24 @@ pub(super) fn render_tab_drag_overlay(
         }
     }
 
-    // For TabReorder, draw a vertical insertion bar at the target position.
-    if let DropZone::TabReorder(gid, idx) = zone {
-        let tab_bar_info: Option<(u16, u16, &[render::TabInfo], usize)> =
-            if let Some(ref split) = screen.editor_group_split {
-                split
-                    .group_tab_bars
-                    .iter()
-                    .find(|g| g.group_id == gid)
-                    .map(|g| {
-                        let x = editor_area.x + g.bounds.x as u16;
-                        let y = editor_area.y + (g.bounds.y as u16).saturating_sub(tui_tbh);
-                        (x, y, g.tabs.as_slice(), g.tab_scroll_offset)
-                    })
-            } else {
-                Some((
-                    editor_area.x,
-                    editor_area.y,
-                    screen.tab_bar.as_slice(),
-                    screen.tab_scroll_offset,
-                ))
-            };
-
-        if let Some((bar_x, bar_y, tabs, scroll_off)) = tab_bar_info {
-            let ov_cols: u16 = if scroll_off > 0 { 2 } else { 0 };
-            let mut insert_x: u16 = ov_cols;
-            for (i, tab) in tabs.iter().enumerate().skip(scroll_off) {
-                if i == idx {
-                    break;
-                }
-                insert_x += tab.name.chars().count() as u16 + TAB_CLOSE_COLS;
-            }
-            let abs_x = bar_x + insert_x;
-            set_cell_styled(
-                frame.buffer_mut(),
-                abs_x,
-                bar_y,
-                '▎',
-                RColor::Indexed(39),
-                rc(theme.tab_bar_bg),
-                Modifier::empty(),
-                None,
-            );
-        }
+    if let Some(bar) = overlay.insertion_bar {
+        set_cell_styled(
+            frame.buffer_mut(),
+            bar.x as u16,
+            bar.y as u16,
+            '▎',
+            RColor::Indexed(39),
+            rc(theme.tab_bar_bg),
+            Modifier::empty(),
+            None,
+        );
     }
 
-    // Draw ghost label near cursor.
-    if let (Some((mx, my)), Some(ref drag)) = (engine.tab_drag_mouse, &engine.tab_drag) {
+    if let (Some(ref drag), Some(_)) = (&engine.tab_drag, engine.tab_drag_mouse) {
         let label = &drag.tab_name;
         if !label.is_empty() {
-            let gx = (mx as u16) + 2;
-            let gy = my as u16;
+            let gx = overlay.ghost_position.0 as u16;
+            let gy = overlay.ghost_position.1 as u16;
             let ghost_fg = RColor::White;
             let ghost_bg = RColor::Indexed(238);
             let buf = frame.buffer_mut();
@@ -1504,132 +1483,23 @@ pub(super) fn compute_tui_tab_drop_zone(
     last_layout: Option<&render::ScreenLayout>,
     terminal_size: Option<Size>,
 ) -> crate::core::window::DropZone {
-    use crate::core::window::{DropZone, SplitDirection};
-
     let layout = match last_layout {
         Some(l) => l,
-        None => return DropZone::None,
+        None => return crate::core::window::DropZone::None,
     };
-
-    let menu_rows: u16 = if engine.menu_bar_visible { 1 } else { 0 };
-    let click_tbh: u16 = if engine.settings.breadcrumbs { 2 } else { 1 };
-
     if col < editor_left {
-        return DropZone::None;
+        return crate::core::window::DropZone::None;
     }
-    let rel_col = col - editor_left;
-
-    if let Some(ref split) = layout.editor_group_split {
-        // Multi-group mode: check each group's tab bar and content area.
-        for gtb in split.group_tab_bars.iter() {
-            let tab_bar_row = menu_rows + (gtb.bounds.y as u16).saturating_sub(click_tbh);
-            let gx = gtb.bounds.x as u16;
-            let gw = gtb.bounds.width as u16;
-            let group_id = gtb.group_id;
-
-            // Tab bar region — determine reorder insertion index.
-            if row == tab_bar_row && rel_col >= gx && rel_col < gx + gw {
-                let local_col = rel_col - gx;
-                let ov_cols: u16 = if gtb.tab_scroll_offset > 0 { 2 } else { 0 };
-                let mut x: u16 = ov_cols;
-                for (i, tab) in gtb.tabs.iter().enumerate().skip(gtb.tab_scroll_offset) {
-                    let name_w = tab.name.chars().count() as u16;
-                    let tab_w = name_w + TAB_CLOSE_COLS;
-                    let mid = x + tab_w / 2;
-                    if local_col < mid {
-                        return DropZone::TabReorder(group_id, i);
-                    }
-                    x += tab_w;
-                }
-                return DropZone::TabReorder(group_id, gtb.tabs.len());
-            }
-
-            // Content area — edge zones for split, center for merge.
-            let content_top = menu_rows + gtb.bounds.y as u16;
-            let content_left = gx;
-            let content_right = gx + gw;
-            let content_h = gtb.bounds.height as u16;
-            let content_bottom = content_top + content_h;
-            if rel_col >= content_left
-                && rel_col < content_right
-                && row >= content_top
-                && row < content_bottom
-            {
-                let w = gw;
-                let h = content_h;
-                let rx = rel_col - content_left;
-                let ry = row - content_top;
-                // Edge zones: ~20% of each dimension, minimum 3 cells.
-                let edge_w = (w / 5).max(3).min(w / 2);
-                let edge_h = (h / 5).max(2).min(h / 2);
-
-                if rx < edge_w {
-                    return DropZone::Split(group_id, SplitDirection::Vertical, true);
-                }
-                if rx >= w - edge_w {
-                    return DropZone::Split(group_id, SplitDirection::Vertical, false);
-                }
-                if ry < edge_h {
-                    return DropZone::Split(group_id, SplitDirection::Horizontal, true);
-                }
-                if ry >= h - edge_h {
-                    return DropZone::Split(group_id, SplitDirection::Horizontal, false);
-                }
-                return DropZone::Center(group_id);
-            }
-        }
-    } else {
-        // Single-group mode: tab bar reorder + content area edge zones for split.
-        let group_id = engine.active_group;
-        if row == menu_rows {
-            let local_col = rel_col;
-            let sg_offset = layout.tab_scroll_offset;
-            let ov_cols: u16 = if sg_offset > 0 { 2 } else { 0 };
-            let mut x: u16 = ov_cols;
-            for (i, tab) in layout.tab_bar.iter().enumerate().skip(sg_offset) {
-                let name_w = tab.name.chars().count() as u16;
-                let tab_w = name_w + TAB_CLOSE_COLS;
-                let mid = x + tab_w / 2;
-                if local_col < mid {
-                    return DropZone::TabReorder(group_id, i);
-                }
-                x += tab_w;
-            }
-            return DropZone::TabReorder(group_id, layout.tab_bar.len());
-        }
-
-        // Content area — edge zones for split, center for merge.
-        if let Some(ts) = terminal_size {
-            let content_top = menu_rows + click_tbh;
-            let editor_w = ts.width.saturating_sub(editor_left);
-            // status + command = 2 rows at bottom
-            let content_bottom = ts.height.saturating_sub(2);
-            if row >= content_top && row < content_bottom && rel_col < editor_w {
-                let w = editor_w;
-                let h = content_bottom - content_top;
-                let rx = rel_col;
-                let ry = row - content_top;
-                let edge_w = (w / 5).max(3).min(w / 2);
-                let edge_h = (h / 5).max(2).min(h / 2);
-
-                if rx < edge_w {
-                    return DropZone::Split(group_id, SplitDirection::Vertical, true);
-                }
-                if rx >= w - edge_w {
-                    return DropZone::Split(group_id, SplitDirection::Vertical, false);
-                }
-                if ry < edge_h {
-                    return DropZone::Split(group_id, SplitDirection::Horizontal, true);
-                }
-                if ry >= h - edge_h {
-                    return DropZone::Split(group_id, SplitDirection::Horizontal, false);
-                }
-                return DropZone::Center(group_id);
-            }
-        }
-    }
-
-    DropZone::None
+    let ts = match terminal_size {
+        Some(s) => s,
+        None => return crate::core::window::DropZone::None,
+    };
+    let menu_rows: u16 = if engine.menu_bar_visible { 1 } else { 0 };
+    let editor_w = ts.width.saturating_sub(editor_left);
+    let editor_h = ts.height.saturating_sub(menu_rows + 2);
+    let editor_area = Rect::new(editor_left, menu_rows, editor_w, editor_h);
+    let (groups, tbh) = build_tui_tab_drop_groups(engine, editor_area, layout);
+    render::compute_tab_drop_zone(col as f32, row as f32, &groups, tbh)
 }
 
 /// Render the tab bar via `Backend::draw_tab_bar`. Returns the

--- a/src/win_gui/draw.rs
+++ b/src/win_gui/draw.rs
@@ -990,154 +990,50 @@ impl<'a> DrawContext<'a> {
 
     pub fn draw_tab_drag_overlay(
         &self,
-        layout: &ScreenLayout,
         engine: &crate::core::engine::Engine,
+        state: &super::AppState,
     ) {
-        use crate::core::window::{DropZone, SplitDirection};
-
         let drag = match &engine.tab_drag {
             Some(td) => td,
             None => return,
         };
 
-        let zone = &engine.tab_drop_zone;
+        let (groups, tbh) = super::build_win_tab_drop_groups(state);
         let lh = self.line_height;
-        let tab_h = lh * super::TAB_BAR_HEIGHT_MULT;
+        let cursor = engine
+            .tab_drag_mouse
+            .map(|(mx, my)| (mx as f32, my as f32))
+            .unwrap_or((0.0, 0.0));
+        let overlay = match render::compute_tab_drop_overlay(
+            &engine.tab_drop_zone,
+            &groups,
+            cursor,
+            tbh,
+            2.0,
+            10.0,
+        ) {
+            Some(o) => o,
+            None => return,
+        };
 
-        // Blue overlay for drop zone
         let overlay_color = Color::from_rgb(30, 60, 120);
         let overlay_brush = self.solid_brush(overlay_color);
 
-        // Determine the highlight rectangle based on drop zone
-        if let Some(ref split) = layout.editor_group_split {
-            for gtb in &split.group_tab_bars {
-                let bx = gtb.bounds.x as f32;
-                let by = gtb.bounds.y as f32;
-                let bw = gtb.bounds.width as f32;
-                let bh = gtb.bounds.height as f32;
-                // Account for breadcrumb row when positioning tab bar overlay
-                let has_bc = layout
-                    .breadcrumbs
-                    .iter()
-                    .any(|bc| bc.group_id == gtb.group_id && !bc.segments.is_empty());
-                let bc_offset = if has_bc { lh } else { 0.0 };
-                let tab_bar_y = by - tab_h - bc_offset;
-
-                match zone {
-                    DropZone::Center(gid) if *gid == gtb.group_id => unsafe {
-                        self.rt.FillRectangle(
-                            &rect_f(bx, tab_bar_y, bw, bh + tab_h + bc_offset),
-                            &overlay_brush,
-                        );
-                    },
-                    DropZone::Split(gid, dir, new_first) if *gid == gtb.group_id => {
-                        let (rx, ry, rw, rh) = match (dir, new_first) {
-                            (SplitDirection::Vertical, true) => (bx, by, bw / 2.0, bh),
-                            (SplitDirection::Vertical, false) => (bx + bw / 2.0, by, bw / 2.0, bh),
-                            (SplitDirection::Horizontal, true) => (bx, by, bw, bh / 2.0),
-                            (SplitDirection::Horizontal, false) => {
-                                (bx, by + bh / 2.0, bw, bh / 2.0)
-                            }
-                        };
-                        unsafe {
-                            self.rt
-                                .FillRectangle(&rect_f(rx, ry, rw, rh), &overlay_brush);
-                        }
-                    }
-                    DropZone::TabReorder(gid, idx) if *gid == gtb.group_id => {
-                        // Highlight the tab bar
-                        unsafe {
-                            self.rt
-                                .FillRectangle(&rect_f(bx, tab_bar_y, bw, tab_h), &overlay_brush);
-                        }
-                        // Draw insertion bar
-                        let cw = self.char_width;
-                        let mut x = bx;
-                        for (i, tab) in gtb.tabs.iter().enumerate() {
-                            if i == *idx {
-                                break;
-                            }
-                            x += (tab.name.chars().count() as f32 + 3.0) * cw;
-                        }
-                        let bar_brush = self.solid_brush(self.theme.cursor);
-                        unsafe {
-                            self.rt
-                                .FillRectangle(&rect_f(x - 1.0, tab_bar_y, 2.0, tab_h), &bar_brush);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        } else {
-            // Single group — handle TabReorder insertion bar + Split/Center overlay
-            match zone {
-                DropZone::TabReorder(_, idx) => {
-                    let tab_y = if layout.menu_bar.is_some() {
-                        super::TITLE_BAR_TOP_INSET + lh * super::TITLE_BAR_HEIGHT_MULT
-                    } else {
-                        0.0
-                    };
-                    let cw = self.char_width;
-                    let mut x = self.editor_left;
-                    for (i, tab) in layout.tab_bar.iter().enumerate() {
-                        if i == *idx {
-                            break;
-                        }
-                        x += (tab.name.chars().count() as f32 + 3.0) * cw;
-                    }
-                    let bar_brush = self.solid_brush(self.theme.cursor);
-                    unsafe {
-                        self.rt
-                            .FillRectangle(&rect_f(x - 1.0, tab_y, 2.0, tab_h), &bar_brush);
-                    }
-                }
-                DropZone::Split(_, dir, new_first) => {
-                    // Use the first window rect as the editor area
-                    if let Some(rw) = layout.windows.first() {
-                        let bx = rw.rect.x as f32;
-                        let by = rw.rect.y as f32;
-                        let bw = rw.rect.width as f32;
-                        let bh = rw.rect.height as f32;
-                        let (rx, ry, rw_f, rh_f) = match (dir, new_first) {
-                            (SplitDirection::Vertical, true) => (bx, by, bw / 2.0, bh),
-                            (SplitDirection::Vertical, false) => (bx + bw / 2.0, by, bw / 2.0, bh),
-                            (SplitDirection::Horizontal, true) => (bx, by, bw, bh / 2.0),
-                            (SplitDirection::Horizontal, false) => {
-                                (bx, by + bh / 2.0, bw, bh / 2.0)
-                            }
-                        };
-                        unsafe {
-                            self.rt
-                                .FillRectangle(&rect_f(rx, ry, rw_f, rh_f), &overlay_brush);
-                        }
-                    }
-                }
-                DropZone::Center(_) => {
-                    // Highlight entire editor area
-                    if let Some(rw) = layout.windows.first() {
-                        let tab_y = if layout.menu_bar.is_some() {
-                            super::TITLE_BAR_TOP_INSET + lh * super::TITLE_BAR_HEIGHT_MULT
-                        } else {
-                            0.0
-                        };
-                        unsafe {
-                            self.rt.FillRectangle(
-                                &rect_f(
-                                    rw.rect.x as f32,
-                                    tab_y,
-                                    rw.rect.width as f32,
-                                    rw.rect.height as f32 + rw.rect.y as f32 - tab_y,
-                                ),
-                                &overlay_brush,
-                            );
-                        }
-                    }
-                }
-                DropZone::None => {}
+        if let Some(h) = overlay.highlight {
+            unsafe {
+                self.rt
+                    .FillRectangle(&rect_f(h.x, h.y, h.width, h.height), &overlay_brush);
             }
         }
 
-        // Ghost label near mouse cursor
+        if let Some(bar) = overlay.insertion_bar {
+            let bar_brush = self.solid_brush(self.theme.cursor);
+            unsafe {
+                self.rt
+                    .FillRectangle(&rect_f(bar.x, bar.y, bar.width, bar.height), &bar_brush);
+            }
+        }
+
         if let Some((mx, my)) = engine.tab_drag_mouse {
             let mx = mx as f32;
             let my = my as f32;

--- a/src/win_gui/mod.rs
+++ b/src/win_gui/mod.rs
@@ -6276,52 +6276,37 @@ fn build_win_tab_drop_groups(state: &AppState) -> (Vec<render::TabDropGroup>, f3
     let lh = state.line_height;
     let tab_h = lh * TAB_BAR_HEIGHT_MULT;
 
-    let mut slot_map: HashMap<GroupId, Vec<(f32, f32)>> = HashMap::new();
+    let mut slots_map: HashMap<usize, Vec<(f32, f32)>> = HashMap::new();
     for slot in &state.tab_slots {
-        slot_map
-            .entry(slot.group_id)
+        slots_map
+            .entry(slot.group_id.0)
             .or_default()
             .push((slot.x_start, slot.x_end));
     }
 
     let mut seen = std::collections::HashSet::new();
-    let mut groups = Vec::new();
-
+    let mut bounds = Vec::new();
     for cwr in &state.cached_window_rects {
         if !seen.insert(cwr.group_id) {
             continue;
         }
-        let rx = cwr.rect.x as f32;
-        let ry = cwr.rect.y as f32;
-        let rw = cwr.rect.width as f32;
-        let rh = cwr.rect.height as f32;
-        let tab_slots = slot_map.remove(&cwr.group_id).unwrap_or_default();
-        let tab_y = if !tab_slots.is_empty() {
-            state
-                .tab_slots
-                .iter()
-                .find(|s| s.group_id == cwr.group_id)
-                .map_or(ry - tab_h, |s| s.y)
-        } else {
-            ry - tab_h
-        };
         let scroll_off = state
             .engine
             .editor_groups
             .get(&cwr.group_id)
             .map(|g| g.tab_scroll_offset)
             .unwrap_or(0);
-        groups.push(render::TabDropGroup {
+        bounds.push(render::DropGroupBounds {
             group_id: cwr.group_id,
-            rect: quadraui::DropGroupRect {
-                bounds: quadraui::Rect::new(rx, tab_y, rw, (ry + rh) - tab_y),
-                tab_slots,
-            },
+            x: cwr.rect.x as f32,
+            y: cwr.rect.y as f32,
+            width: cwr.rect.width as f32,
+            content_height: cwr.rect.height as f32,
             tab_scroll_offset: scroll_off,
         });
     }
 
-    (groups, tab_h)
+    render::build_tab_drop_groups(&bounds, &state.engine, tab_h, &slots_map)
 }
 
 fn compute_win_tab_drop_zone(state: &AppState, px: f32, py: f32) -> DropZone {

--- a/src/win_gui/mod.rs
+++ b/src/win_gui/mod.rs
@@ -1255,7 +1255,7 @@ fn on_paint(hwnd: HWND) {
                 ctx.draw_context_menu(ctxm);
             }
             // Tab drag overlay (drop zone highlight + ghost label)
-            ctx.draw_tab_drag_overlay(&screen, &state.engine);
+            ctx.draw_tab_drag_overlay(&state.engine, state);
             // Menu dropdown on top of sidebar
             if let Some(ref menu) = screen.menu_bar {
                 ctx.draw_menu_dropdown(menu);
@@ -6270,79 +6270,66 @@ fn handle_context_action(
     state.sidebar.dirty = true;
 }
 
-fn compute_win_tab_drop_zone(state: &AppState, px: f32, py: f32) -> DropZone {
-    let source = match &state.engine.tab_drag {
-        Some(td) => (td.source_group, td.source_tab_index),
-        None => return DropZone::None,
-    };
+fn build_win_tab_drop_groups(state: &AppState) -> (Vec<render::TabDropGroup>, f32) {
+    use std::collections::HashMap;
 
     let lh = state.line_height;
     let tab_h = lh * TAB_BAR_HEIGHT_MULT;
 
-    // Check if cursor is over a tab bar → TabReorder
+    let mut slot_map: HashMap<GroupId, Vec<(f32, f32)>> = HashMap::new();
     for slot in &state.tab_slots {
-        if py >= slot.y && py < slot.y + slot.height {
-            if px >= slot.x_start && px < slot.x_end {
-                // Over this tab — insert before or after based on midpoint
-                let mid = (slot.x_start + slot.x_end) / 2.0;
-                let idx = if px < mid {
-                    slot.tab_idx
-                } else {
-                    slot.tab_idx + 1
-                };
-                return DropZone::TabReorder(slot.group_id, idx);
-            }
-            // Over this group's tab bar but past the last tab — append
-            // Use the number of tabs in this group (if available) as the insertion index.
-            let tab_count = state
-                .engine
-                .editor_groups
-                .get(&slot.group_id)
-                .map_or(0, |g| g.tabs.len());
-            return DropZone::TabReorder(slot.group_id, tab_count);
-        }
+        slot_map
+            .entry(slot.group_id)
+            .or_default()
+            .push((slot.x_start, slot.x_end));
     }
 
-    // Check if cursor is over an editor area → Center or Split
-    let multi_group = state.engine.editor_groups.len() > 1;
+    let mut seen = std::collections::HashSet::new();
+    let mut groups = Vec::new();
 
     for cwr in &state.cached_window_rects {
+        if !seen.insert(cwr.group_id) {
+            continue;
+        }
         let rx = cwr.rect.x as f32;
         let ry = cwr.rect.y as f32;
         let rw = cwr.rect.width as f32;
         let rh = cwr.rect.height as f32;
-
-        if px >= rx && px < rx + rw && py >= ry && py < ry + rh {
-            let gid = cwr.group_id;
-
-            // Edge zone = 20% of dimension, min 30px
-            let edge_x = (rw * 0.2).max(30.0);
-            let edge_y = (rh * 0.2).max(30.0);
-
-            let rel_x = px - rx;
-            let rel_y = py - ry;
-
-            if rel_x < edge_x {
-                return DropZone::Split(gid, SplitDirection::Vertical, true);
-            }
-            if rel_x > rw - edge_x {
-                return DropZone::Split(gid, SplitDirection::Vertical, false);
-            }
-            if rel_y < edge_y {
-                return DropZone::Split(gid, SplitDirection::Horizontal, true);
-            }
-            if rel_y > rh - edge_y {
-                return DropZone::Split(gid, SplitDirection::Horizontal, false);
-            }
-
-            // Center — merge into group (only if multi-group or different group)
-            if multi_group || gid != source.0 {
-                return DropZone::Center(gid);
-            }
-        }
+        let tab_slots = slot_map.remove(&cwr.group_id).unwrap_or_default();
+        let tab_y = if !tab_slots.is_empty() {
+            state
+                .tab_slots
+                .iter()
+                .find(|s| s.group_id == cwr.group_id)
+                .map_or(ry - tab_h, |s| s.y)
+        } else {
+            ry - tab_h
+        };
+        let scroll_off = state
+            .engine
+            .editor_groups
+            .get(&cwr.group_id)
+            .map(|g| g.tab_scroll_offset)
+            .unwrap_or(0);
+        groups.push(render::TabDropGroup {
+            group_id: cwr.group_id,
+            rect: quadraui::DropGroupRect {
+                bounds: quadraui::Rect::new(rx, tab_y, rw, (ry + rh) - tab_y),
+                tab_slots,
+            },
+            tab_scroll_offset: scroll_off,
+        });
     }
 
-    DropZone::None
+    (groups, tab_h)
+}
+
+fn compute_win_tab_drop_zone(state: &AppState, px: f32, py: f32) -> DropZone {
+    if state.engine.tab_drag.is_none() {
+        return DropZone::None;
+    }
+    let (groups, tbh) = build_win_tab_drop_groups(state);
+    render::compute_tab_drop_zone(px, py, &groups, tbh)
 }
 
 // ─── Clipboard ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace 3 bespoke per-backend drop-zone implementations (TUI/GTK/Win-GUI) with shared `render::compute_tab_drop_zone()` that delegates to `quadraui::compute_drop_zone()`
- Centralise overlay geometry computation (`render::compute_tab_drop_overlay()`) — each backend now only does the final paint (~15-20 lines each vs 130-170 before)
- Fix pre-existing GTK bug where tab reorder indices ignored scroll offset
- Add insertion-bar rendering to GTK tab drag (previously only TUI and Win-GUI had it)
- Net -184 lines across 6 files

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --no-default-features` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] TUI smoke: tab reorder, edge-split, center-merge, ghost label, scrolled tab bars
- [x] GTK smoke: same + insertion bar now visible + breadcrumb area drag

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)