### PR TITLE
Factor shared screen-level hit-test into render.rs (#344)

### DIFF
--- a/src/core/engine/ext_panel.rs
+++ b/src/core/engine/ext_panel.rs
@@ -890,7 +890,7 @@ impl Engine {
         self.show_editor_hover_at(line, col, true, true);
     }
 
-    /// Check if any diagnostic touches the given line.
+    #[allow(dead_code)]
     pub fn has_diagnostic_on_line(&self, line: usize) -> bool {
         if let Some(path) = self.active_buffer_path() {
             if let Some(diags) = self.lsp_diagnostics.get(&path) {

--- a/src/core/engine/panels.rs
+++ b/src/core/engine/panels.rs
@@ -1566,7 +1566,7 @@ impl Engine {
         serde_json::Value::Array(arr)
     }
 
-    /// Whether any code actions are available on the given line.
+    #[allow(dead_code)]
     pub fn has_code_actions_on_line(&self, line: usize) -> bool {
         let Some(path) = self.active_buffer_path() else {
             return false;

--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -66,7 +66,9 @@ pub(super) fn pixel_to_click_target(
                 }
             }
 
-            let rw = &cached_layout.windows[window_idx];
+            let Some(rw) = cached_layout.windows.get(window_idx) else {
+                return ClickTarget::None;
+            };
             match render_mod::window_zone_hit_test(rw, rel_x, rel_y, line_height, char_width) {
                 WindowZone::StatusBar { local_x, .. } => {
                     if let Some(zones) = status_segment_map.get(&window_id.0) {

--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -1,20 +1,26 @@
 use super::*;
-use crate::render::{self as render_mod, view_row_to_buf_line, view_row_to_buf_pos_wrap};
+use crate::core::window::GroupId;
+use crate::core::WindowId;
+use crate::render::{self as render_mod, GutterAction, ScreenZone, WindowZone};
 
 /// Re-export the shared ClickTarget enum.
 pub(super) use render_mod::ClickTarget;
 
-/// Convert pixel (x, y) to a buffer position (window_id, line, col).
-/// Also handles tab-bar clicks and gutter fold toggles.
+/// Convert pixel (x, y) to a click target using the cached ScreenLayout from
+/// the last paint pass (#344). Zone detection delegates to the shared
+/// `screen_zone_hit_test` / `window_zone_hit_test` / `resolve_gutter_action`
+/// functions in render.rs so both backends use one source of truth.
+///
+/// Tab bar inner hit-testing (which specific tab/button) stays here because it
+/// uses Pango-measured pixel slot positions from `draw_tab_bar`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn pixel_to_click_target(
     engine: &mut Engine,
     x: f64,
     y: f64,
-    width: f64,
-    height: f64,
     line_height: f64,
     char_width: f64,
+    cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
     split_btn_map: &SplitBtnMap,
@@ -22,284 +28,240 @@ pub(super) fn pixel_to_click_target(
     status_segment_map: &StatusSegmentMap,
 ) -> ClickTarget {
     let tab_bar_height = render_mod::tab_bar_height_px(line_height, engine.settings.breadcrumbs);
+    let single_tab_hidden = engine.is_tab_bar_hidden(engine.active_group);
 
-    // Check if click is in a group's tab bar region.
-    // Use the group layout tree to find group bounds (must match draw_editor layout).
-    {
-        let editor_bottom = gtk_editor_bottom(engine, width, height, line_height);
-        let content_bounds = WindowRect::new(0.0, 0.0, width, editor_bottom);
-        let mut group_rects = engine
-            .group_layout
-            .calculate_group_rects(content_bounds, tab_bar_height);
-        engine.adjust_group_rects_for_hidden_tabs(&mut group_rects, tab_bar_height);
-
-        // Check if click is in any group's tab bar row.
-        for (gid, grect) in &group_rects {
-            if engine.is_tab_bar_hidden(*gid) {
-                continue;
-            }
-            let tab_y = grect.y - tab_bar_height;
-            let tab_x_start = grect.x;
-            let bar_width = grect.width;
-            if y >= tab_y
-                && y < tab_y + tab_bar_height
-                && x >= tab_x_start
-                && x < tab_x_start + bar_width
-            {
-                let group_id = *gid;
-                engine.active_group = group_id;
-                let local_x = x - tab_x_start;
-
-                // Hit-test diff toolbar buttons FIRST (they sit left of split
-                // buttons, so check them before split to avoid boundary overlap).
-                if let Some(&(prev_start, prev_end, next_start, next_end, fold_start, fold_end)) =
-                    diff_btn_map.get(&group_id.0)
+    match render_mod::screen_zone_hit_test(cached_layout, x, y, tab_bar_height, single_tab_hidden) {
+        ScreenZone::TabBar {
+            group_id,
+            local_x,
+            bar_width,
+        } => {
+            engine.active_group = group_id;
+            tab_bar_inner_hit_test(
+                engine,
+                group_id,
+                local_x,
+                bar_width,
+                tab_slot_positions,
+                diff_btn_map,
+                split_btn_map,
+                action_btn_map,
+            )
+        }
+        ScreenZone::Window {
+            window_id,
+            window_idx,
+            rel_x,
+            rel_y,
+        } => {
+            // Update active_group for the clicked window.
+            for (&gid, group) in &engine.editor_groups {
+                if group
+                    .tabs
+                    .iter()
+                    .any(|t| t.window_ids().contains(&window_id))
                 {
-                    if local_x >= prev_start && local_x < prev_end {
-                        return ClickTarget::DiffToolbarPrev;
-                    } else if local_x >= next_start && local_x < next_end {
-                        return ClickTarget::DiffToolbarNext;
-                    } else if local_x >= fold_start && local_x < fold_end {
-                        return ClickTarget::DiffToolbarToggleFold;
-                    }
+                    engine.active_group = gid;
+                    break;
                 }
+            }
 
-                // Hit-test split buttons using cached Pango-measured widths.
-                // Split buttons sit to the left of the action menu button.
-                if let Some(&(both_btns_px, btn_right_px)) = split_btn_map.get(&group_id.0) {
-                    let action_offset = action_btn_map
-                        .get(&group_id.0)
-                        .map(|&(start, end)| end - start)
-                        .unwrap_or(0.0);
-                    let btn_down_px = both_btns_px - btn_right_px;
-                    if local_x >= bar_width - btn_down_px - action_offset
-                        && local_x < bar_width - action_offset
-                    {
-                        return ClickTarget::SplitButton(
-                            group_id,
-                            crate::core::window::SplitDirection::Horizontal,
-                        );
-                    }
-                    if local_x >= bar_width - both_btns_px - action_offset
-                        && local_x < bar_width - btn_down_px - action_offset
-                    {
-                        return ClickTarget::SplitButton(
-                            group_id,
-                            crate::core::window::SplitDirection::Vertical,
-                        );
-                    }
-                }
-
-                // Hit-test action menu button ("…") at the far right.
-                if let Some(&(start_x, end_x)) = action_btn_map.get(&group_id.0) {
-                    if local_x >= start_x && local_x < end_x {
-                        return ClickTarget::ActionMenuButton(group_id);
-                    }
-                }
-
-                // Hit-test tabs using cached Pango-measured positions from draw_tab_bar.
-                let hit =
-                    tab_slot_positions
-                        .get(&group_id.0)
-                        .and_then(|slots: &Vec<(f64, f64)>| {
-                            for (i, &(slot_start, slot_end)) in slots.iter().enumerate() {
-                                if local_x >= slot_start && local_x < slot_end {
-                                    // Close button is in the last ~20% of the slot
-                                    let close_zone = (slot_end - slot_start) * 0.2;
-                                    let is_close = local_x >= slot_end - close_zone;
-                                    return Some((i, is_close));
-                                }
+            let rw = &cached_layout.windows[window_idx];
+            match render_mod::window_zone_hit_test(rw, rel_x, rel_y, line_height, char_width) {
+                WindowZone::StatusBar { local_x, .. } => {
+                    if let Some(zones) = status_segment_map.get(&window_id.0) {
+                        for (start, end, action) in zones {
+                            if local_x >= *start && local_x < *end {
+                                return ClickTarget::StatusBarAction(action.clone());
                             }
-                            None
-                        });
-                if let Some((tab_idx, is_close)) = hit {
-                    if is_close {
-                        // For close, just set active_tab directly (tab will be removed)
-                        if let Some(g) = engine.editor_groups.get_mut(&group_id) {
-                            g.active_tab = tab_idx;
                         }
-                        engine.line_annotations.clear();
-                        return ClickTarget::CloseTab(group_id, tab_idx);
                     }
-                    // For tab switch, use goto_tab which also updates MRU
-                    engine.goto_tab(tab_idx);
-                    return ClickTarget::TabBar;
+                    ClickTarget::None
                 }
-                return ClickTarget::TabBar;
+                WindowZone::Gutter {
+                    line_idx,
+                    gutter_col,
+                    ..
+                } => {
+                    execute_gutter_action(engine, rw, window_id, line_idx, gutter_col);
+                    ClickTarget::Gutter
+                }
+                WindowZone::TextArea {
+                    buf_line,
+                    seg_col_offset,
+                    text_rel_x,
+                    ..
+                } => {
+                    let col = gtk_text_column(
+                        engine,
+                        window_id,
+                        buf_line,
+                        seg_col_offset,
+                        text_rel_x,
+                        char_width,
+                    );
+                    ClickTarget::BufferPos(window_id, buf_line, col)
+                }
+                _ => ClickTarget::None,
             }
         }
+        _ => ClickTarget::None,
     }
+}
 
-    let editor_bottom = gtk_editor_bottom(engine, width, height, line_height);
-
-    if y >= editor_bottom {
-        return ClickTarget::None;
-    }
-
-    let editor_bounds = WindowRect::new(0.0, 0.0, width, editor_bottom);
-    let (window_rects, _dividers) =
-        engine.calculate_group_window_rects(editor_bounds, tab_bar_height);
-    let clicked_window = window_rects.iter().find(|(_, rect)| {
-        x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height
-    });
-
-    let (window_id, rect) = match clicked_window {
-        Some((id, r)) => (*id, r),
-        None => return ClickTarget::None,
-    };
-
-    // Update active_group if the clicked window belongs to a different group.
-    for (&gid, group) in &engine.editor_groups {
-        if group
-            .tabs
-            .iter()
-            .any(|t| t.window_ids().contains(&window_id))
-        {
-            engine.active_group = gid;
-            break;
+/// Tab bar inner hit-test using cached Pango-measured pixel positions.
+#[allow(clippy::too_many_arguments)]
+fn tab_bar_inner_hit_test(
+    engine: &mut Engine,
+    group_id: GroupId,
+    local_x: f64,
+    bar_width: f64,
+    tab_slot_positions: &TabSlotMap,
+    diff_btn_map: &DiffBtnMap,
+    split_btn_map: &SplitBtnMap,
+    action_btn_map: &ActionBtnMap,
+) -> ClickTarget {
+    // Diff toolbar buttons (left of split buttons).
+    if let Some(&(prev_start, prev_end, next_start, next_end, fold_start, fold_end)) =
+        diff_btn_map.get(&group_id.0)
+    {
+        if local_x >= prev_start && local_x < prev_end {
+            return ClickTarget::DiffToolbarPrev;
+        } else if local_x >= next_start && local_x < next_end {
+            return ClickTarget::DiffToolbarNext;
+        } else if local_x >= fold_start && local_x < fold_end {
+            return ClickTarget::DiffToolbarToggleFold;
         }
     }
 
-    let window = match engine.windows.get(&window_id) {
-        Some(w) => w,
-        None => return ClickTarget::None,
-    };
-
-    let buffer_state = match engine.buffer_manager.get(window.buffer_id) {
-        Some(s) => s,
-        None => return ClickTarget::None,
-    };
-
-    let buffer = &buffer_state.buffer;
-    let view = &window.view;
-
-    let total_lines = buffer.content.len_lines();
-    let has_git = !buffer_state.git_diff.is_empty();
-    let has_bp_click = {
-        let key = buffer_state
-            .file_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        #[allow(clippy::unnecessary_map_or)] // is_none_or requires Rust 1.82+
+    // Split buttons (left of action menu button).
+    if let Some(&(both_btns_px, btn_right_px)) = split_btn_map.get(&group_id.0) {
+        let action_offset = action_btn_map
+            .get(&group_id.0)
+            .map(|&(start, end)| end - start)
+            .unwrap_or(0.0);
+        let btn_down_px = both_btns_px - btn_right_px;
+        if local_x >= bar_width - btn_down_px - action_offset && local_x < bar_width - action_offset
         {
-            !engine
-                .dap_breakpoints
-                .get(&key)
-                .map_or(true, |v| v.is_empty())
-                || engine.dap_session_active
+            return ClickTarget::SplitButton(
+                group_id,
+                crate::core::window::SplitDirection::Horizontal,
+            );
         }
-    };
-    let gutter_char_width = render::calculate_gutter_cols(
-        engine.settings.line_numbers,
-        total_lines,
-        char_width,
-        has_git,
-        has_bp_click,
-    );
-    let gutter_width = gutter_char_width as f64 * char_width;
+        if local_x >= bar_width - both_btns_px - action_offset
+            && local_x < bar_width - btn_down_px - action_offset
+        {
+            return ClickTarget::SplitButton(
+                group_id,
+                crate::core::window::SplitDirection::Vertical,
+            );
+        }
+    }
 
-    let per_window_status_px = if engine.settings.window_status_line {
-        line_height
-    } else {
-        0.0
-    };
-    let text_area_height = rect.height - per_window_status_px;
+    // Action menu button ("…") at far right.
+    if let Some(&(start_x, end_x)) = action_btn_map.get(&group_id.0) {
+        if local_x >= start_x && local_x < end_x {
+            return ClickTarget::ActionMenuButton(group_id);
+        }
+    }
 
-    if y >= rect.y + text_area_height {
-        // Click is in the per-window status bar area — use Pango-measured cached zones
-        if engine.settings.window_status_line {
-            let local_x = x - rect.x;
-            if let Some(zones) = status_segment_map.get(&window_id.0) {
-                for (start, end, action) in zones {
-                    if local_x >= *start && local_x < *end {
-                        return ClickTarget::StatusBarAction(action.clone());
-                    }
+    // Tab slots (Pango-measured positions from draw_tab_bar).
+    let hit = tab_slot_positions
+        .get(&group_id.0)
+        .and_then(|slots: &Vec<(f64, f64)>| {
+            for (i, &(slot_start, slot_end)) in slots.iter().enumerate() {
+                if local_x >= slot_start && local_x < slot_end {
+                    let close_zone = (slot_end - slot_start) * 0.2;
+                    let is_close = local_x >= slot_end - close_zone;
+                    return Some((i, is_close));
                 }
             }
+            None
+        });
+    if let Some((tab_idx, is_close)) = hit {
+        if is_close {
+            if let Some(g) = engine.editor_groups.get_mut(&group_id) {
+                g.active_tab = tab_idx;
+            }
+            engine.line_annotations.clear();
+            return ClickTarget::CloseTab(group_id, tab_idx);
         }
-        return ClickTarget::None;
+        engine.goto_tab(tab_idx);
+        return ClickTarget::TabBar;
     }
+    ClickTarget::TabBar
+}
 
-    let relative_y = y - rect.y;
-    let view_row = (relative_y / line_height).floor() as usize;
-
-    // Compute the buffer line and segment column offset, accounting for wrapping.
-    let (line, seg_col_offset) = if engine.settings.wrap {
-        // Compute viewport_cols the same way render.rs does for word-wrap segments.
-        let scrollbar_px: f64 = if char_width > 1.0 { 8.0 } else { 0.0 };
-        let render_viewport_cols = if char_width > 0.0 {
-            let total_chars = ((rect.width - scrollbar_px) / char_width).floor() as usize;
-            total_chars.saturating_sub(gutter_char_width).max(1)
-        } else {
-            1
-        };
-        view_row_to_buf_pos_wrap(
-            view,
-            buffer,
-            view.scroll_top,
-            view_row,
-            total_lines,
-            render_viewport_cols,
-        )
-    } else {
-        (
-            view_row_to_buf_line(view, view.scroll_top, view_row, total_lines),
-            0,
-        )
-    };
-
-    // Gutter click
-    if x >= rect.x && x < rect.x + gutter_width && gutter_width > 0.0 {
-        // Determine which gutter column was clicked.
-        let gutter_col = ((x - rect.x) / char_width).floor() as usize;
-        let bp_offset = if has_bp_click { 1 } else { 0 };
-        let git_col = if has_git { bp_offset } else { usize::MAX };
-
-        if has_bp_click && gutter_col == 0 {
-            // Breakpoint column (leftmost).
-            let file = buffer_state
-                .file_path
-                .as_ref()
+/// Execute the engine-side action for a gutter click using shared resolution.
+fn execute_gutter_action(
+    engine: &mut Engine,
+    rw: &render::RenderedWindow,
+    window_id: WindowId,
+    line_idx: usize,
+    gutter_col: usize,
+) {
+    match render_mod::resolve_gutter_action(rw, line_idx, gutter_col) {
+        Some(GutterAction::ToggleBreakpoint(line)) => {
+            let file = engine
+                .windows
+                .get(&window_id)
+                .and_then(|w| engine.buffer_manager.get(w.buffer_id))
+                .and_then(|bs| bs.file_path.as_ref())
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_default();
             engine.dap_toggle_breakpoint(&file, line as u64 + 1);
-        } else if gutter_col == git_col {
-            // Git diff column — open diff peek popup.
+        }
+        Some(GutterAction::DiffPeek(line)) => {
             engine.active_tab_mut().active_window = window_id;
             engine.view_mut().cursor.line = line;
             engine.open_diff_peek();
-        } else if engine.has_diagnostic_on_line(line) {
-            // Diagnostic gutter indicator — show hover popup with details.
+        }
+        Some(GutterAction::DiagnosticHover(line)) => {
             engine.active_tab_mut().active_window = window_id;
             engine.view_mut().cursor.line = line;
             engine.trigger_editor_hover_for_line(line);
-        } else if engine.has_code_actions_on_line(line) {
-            // Code action lightbulb — show code actions popup.
+        }
+        Some(GutterAction::CodeAction(line)) => {
             engine.active_tab_mut().active_window = window_id;
             engine.view_mut().cursor.line = line;
             engine.show_code_actions_popup();
-        } else {
+        }
+        Some(GutterAction::ToggleFold(line)) => {
             engine.toggle_fold_at_line(line);
         }
-        return ClickTarget::Gutter;
+        None => {}
     }
+}
 
-    let relative_x = x - (rect.x + gutter_width);
-    let line = line.min(buffer.content.len_lines().saturating_sub(1));
+/// Compute the buffer column for a text area click (GTK tab-expansion walk).
+fn gtk_text_column(
+    engine: &Engine,
+    window_id: WindowId,
+    buf_line: usize,
+    seg_col_offset: usize,
+    text_rel_x: f64,
+    char_width: f64,
+) -> usize {
+    let line = engine
+        .windows
+        .get(&window_id)
+        .and_then(|w| engine.buffer_manager.get(w.buffer_id))
+        .map(|bs| buf_line.min(bs.buffer.content.len_lines().saturating_sub(1)))
+        .unwrap_or(buf_line);
 
-    // For a monospace font, column = floor(relative_x / char_width).
-    // Tabs are displayed as 4 spaces, so we walk the line chars mapping
-    // display columns to logical columns without any Pango calls.
-    let display_col = if char_width > 0.0 && relative_x >= 0.0 {
-        (relative_x / char_width) as usize
+    let display_col = if char_width > 0.0 && text_rel_x >= 0.0 {
+        (text_rel_x / char_width) as usize
     } else {
         0
     };
 
-    // Walk the line text starting from segment_col_offset to find the
-    // logical column corresponding to the clicked display column.
-    let line_text = buffer.content.line(line).to_string();
+    let line_text = engine
+        .windows
+        .get(&window_id)
+        .and_then(|w| engine.buffer_manager.get(w.buffer_id))
+        .map(|bs| bs.buffer.content.line(line).to_string())
+        .unwrap_or_default();
+
     let mut col = seg_col_offset;
     let mut display_pos = 0;
     for ch in line_text.chars().skip(seg_col_offset) {
@@ -313,8 +275,7 @@ pub(super) fn pixel_to_click_target(
         }
         col += 1;
     }
-
-    ClickTarget::BufferPos(window_id, line, col)
+    col
 }
 
 /// Handle mouse click by converting coordinates to buffer position.
@@ -326,11 +287,10 @@ pub(super) fn handle_mouse_click(
     engine: &mut Engine,
     x: f64,
     y: f64,
-    width: f64,
-    height: f64,
     alt: bool,
     line_height: f64,
     char_width: f64,
+    cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
     split_btn_map: &SplitBtnMap,
@@ -341,10 +301,9 @@ pub(super) fn handle_mouse_click(
         engine,
         x,
         y,
-        width,
-        height,
         line_height,
         char_width,
+        cached_layout,
         tab_slot_positions,
         diff_btn_map,
         split_btn_map,
@@ -482,10 +441,9 @@ pub(super) fn handle_mouse_double_click(
     engine: &mut Engine,
     x: f64,
     y: f64,
-    width: f64,
-    height: f64,
     line_height: f64,
     char_width: f64,
+    cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
     split_btn_map: &SplitBtnMap,
@@ -496,10 +454,9 @@ pub(super) fn handle_mouse_double_click(
         engine,
         x,
         y,
-        width,
-        height,
         line_height,
         char_width,
+        cached_layout,
         tab_slot_positions,
         diff_btn_map,
         split_btn_map,
@@ -516,10 +473,9 @@ pub(super) fn handle_mouse_drag(
     engine: &mut Engine,
     x: f64,
     y: f64,
-    width: f64,
-    height: f64,
     line_height: f64,
     char_width: f64,
+    cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
     split_btn_map: &SplitBtnMap,
@@ -530,10 +486,9 @@ pub(super) fn handle_mouse_drag(
         engine,
         x,
         y,
-        width,
-        height,
         line_height,
         char_width,
+        cached_layout,
         tab_slot_positions,
         diff_btn_map,
         split_btn_map,

--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -30,7 +30,14 @@ pub(super) fn pixel_to_click_target(
     let tab_bar_height = render_mod::tab_bar_height_px(line_height, engine.settings.breadcrumbs);
     let single_tab_hidden = engine.is_tab_bar_hidden(engine.active_group);
 
-    match render_mod::screen_zone_hit_test(cached_layout, x, y, tab_bar_height, single_tab_hidden) {
+    match render_mod::screen_zone_hit_test(
+        cached_layout,
+        x,
+        y,
+        tab_bar_height,
+        single_tab_hidden,
+        engine.active_group,
+    ) {
         ScreenZone::TabBar {
             group_id,
             local_x,

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -59,6 +59,7 @@ pub(super) fn draw_editor(
     mouse_pos: (f64, f64),
     tab_visible_counts_out: &Rc<RefCell<Vec<(crate::core::window::GroupId, usize, usize)>>>,
     status_segment_map_out: &Rc<RefCell<StatusSegmentMap>>,
+    screen_layout_out: &Rc<RefCell<Option<render::ScreenLayout>>>,
     breadcrumb_hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
     breadcrumb_y_offset_out: &Rc<Cell<f64>>,
     debug_toolbar_hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
@@ -911,6 +912,9 @@ pub(super) fn draw_editor(
         line_height,
         mouse_pos,
     );
+
+    // Cache the ScreenLayout for click handlers (#344). Moves, not clones.
+    *screen_layout_out.borrow_mut() = Some(screen);
 }
 
 /// Draw thin Cairo horizontal scrollbars that overlay the bottom of each editor

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -379,6 +379,9 @@ struct App {
     action_btn_map: Rc<RefCell<ActionBtnMap>>,
     /// Cached per-window status bar segment hit zones from draw_window_status_bar.
     status_segment_map: Rc<RefCell<StatusSegmentMap>>,
+    /// Cached ScreenLayout from the last draw_editor paint pass. Click handlers
+    /// read this instead of recomputing geometry from engine state (#344).
+    cached_screen_layout: Rc<RefCell<Option<render::ScreenLayout>>>,
     /// Cached breadcrumb segment pixel hit regions from `draw_breadcrumb_bar`.
     /// Click handler walks this list to translate (x, y) → segment index.
     breadcrumb_hit_regions: Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
@@ -2256,6 +2259,7 @@ impl SimpleComponent for App {
             split_btn_map: split_btn_map_cell.clone(),
             action_btn_map: action_btn_map_cell.clone(),
             status_segment_map: status_segment_map_cell.clone(),
+            cached_screen_layout: Rc::new(RefCell::new(None)),
             breadcrumb_hit_regions: Rc::new(RefCell::new(Vec::new())),
             breadcrumb_y_offset: Rc::new(Cell::new(0.0)),
             debug_toolbar_hit_regions: Rc::new(RefCell::new(Vec::new())),
@@ -3862,6 +3866,7 @@ impl SimpleComponent for App {
         let mouse_pos_for_draw = mouse_pos_cell.clone();
         let tab_vis_for_draw = tab_visible_counts_cell.clone();
         let status_seg_for_draw = model.status_segment_map.clone();
+        let screen_layout_for_draw = model.cached_screen_layout.clone();
         let bc_hits_for_draw = model.breadcrumb_hit_regions.clone();
         let bc_y_for_draw = model.breadcrumb_y_offset.clone();
         let dbg_hits_for_draw = model.debug_toolbar_hit_regions.clone();
@@ -3904,6 +3909,7 @@ impl SimpleComponent for App {
                             mouse_pos_for_draw.get(),
                             &tab_vis_for_draw,
                             &status_seg_for_draw,
+                            &screen_layout_for_draw,
                             &bc_hits_for_draw,
                             &bc_y_for_draw,
                             &dbg_hits_for_draw,
@@ -4031,22 +4037,24 @@ impl SimpleComponent for App {
             let split_btn_rc = split_btn_map_cell.clone();
             let action_btn_rc = action_btn_map_cell.clone();
             let status_seg_rc = status_segment_map_cell.clone();
+            let screen_layout_rc = model.cached_screen_layout.clone();
             let rc_gesture = gtk4::GestureClick::new();
             rc_gesture.set_button(3);
             rc_gesture.connect_pressed(move |gesture, _n_press, x, y| {
-                let widget = gesture.widget();
-                let width = widget.width() as f64;
-                let height = widget.height() as f64;
+                let _widget = gesture.widget();
                 let lh = lh_rc.get().max(1.0);
+                let layout_ref = screen_layout_rc.borrow();
+                let Some(ref layout) = *layout_ref else {
+                    return;
+                };
                 let mut engine = engine_rc.borrow_mut();
                 let target = pixel_to_click_target(
                     &mut engine,
                     x,
                     y,
-                    width,
-                    height,
                     lh,
                     0.0, // char_width not needed for tab bar detection
+                    layout,
                     &tab_slots_rc.borrow(),
                     &diff_btn_rc.borrow(),
                     &split_btn_rc.borrow(),
@@ -4274,26 +4282,28 @@ impl SimpleComponent for App {
             Msg::CtrlMouseClick {
                 x,
                 y,
-                width,
-                height,
+                width: _,
+                height: _,
             } => {
-                let mut engine = self.engine.borrow_mut();
-                if !engine.picker_open {
-                    if let ClickTarget::BufferPos(_, line, col) = pixel_to_click_target(
-                        &mut engine,
-                        x,
-                        y,
-                        width,
-                        height,
-                        self.cached_line_height,
-                        self.cached_char_width,
-                        &self.tab_slot_positions.borrow(),
-                        &self.diff_btn_map.borrow(),
-                        &self.split_btn_map.borrow(),
-                        &self.action_btn_map.borrow(),
-                        &self.status_segment_map.borrow(),
-                    ) {
-                        engine.add_cursor_at_pos(line, col);
+                let layout_ref = self.cached_screen_layout.borrow();
+                if let Some(ref layout) = *layout_ref {
+                    let mut engine = self.engine.borrow_mut();
+                    if !engine.picker_open {
+                        if let ClickTarget::BufferPos(_, line, col) = pixel_to_click_target(
+                            &mut engine,
+                            x,
+                            y,
+                            self.cached_line_height,
+                            self.cached_char_width,
+                            layout,
+                            &self.tab_slot_positions.borrow(),
+                            &self.diff_btn_map.borrow(),
+                            &self.split_btn_map.borrow(),
+                            &self.action_btn_map.borrow(),
+                            &self.status_segment_map.borrow(),
+                        ) {
+                            engine.add_cursor_at_pos(line, col);
+                        }
                     }
                 }
                 self.draw_needed.set(true);
@@ -4301,12 +4311,11 @@ impl SimpleComponent for App {
             Msg::MouseDoubleClick {
                 x,
                 y,
-                width,
-                height,
+                width: _,
+                height: _,
             } => {
                 let mut engine = self.engine.borrow_mut();
                 if engine.picker_open {
-                    // Double-click on picker: toggle expand for tree items, or confirm
                     let in_tree_mode = engine.picker_source
                         == crate::core::engine::PickerSource::CommandCenter
                         && engine.picker_query == "@";
@@ -4317,7 +4326,6 @@ impl SimpleComponent for App {
                     }
                     self.draw_needed.set(true);
                 } else {
-                    // Check breadcrumb double-click before falling through
                     let mut bc_handled = false;
                     if engine.settings.breadcrumbs {
                         let lh = self.cached_line_height.max(1.0);
@@ -4326,7 +4334,7 @@ impl SimpleComponent for App {
                             let segments =
                                 crate::render::build_breadcrumbs_for_active_group(&engine);
                             let sep_w = " › ".chars().count() as f64 * cw;
-                            let mut seg_x = cw; // left padding
+                            let mut seg_x = cw;
                             for seg in &segments {
                                 let label_w = seg.label.chars().count() as f64 * cw;
                                 if x >= seg_x && x < seg_x + label_w {
@@ -4343,20 +4351,22 @@ impl SimpleComponent for App {
                         }
                     }
                     if !bc_handled {
-                        handle_mouse_double_click(
-                            &mut engine,
-                            x,
-                            y,
-                            width,
-                            height,
-                            self.cached_line_height,
-                            self.cached_char_width,
-                            &self.tab_slot_positions.borrow(),
-                            &self.diff_btn_map.borrow(),
-                            &self.split_btn_map.borrow(),
-                            &self.action_btn_map.borrow(),
-                            &self.status_segment_map.borrow(),
-                        );
+                        let layout_ref = self.cached_screen_layout.borrow();
+                        if let Some(ref layout) = *layout_ref {
+                            handle_mouse_double_click(
+                                &mut engine,
+                                x,
+                                y,
+                                self.cached_line_height,
+                                self.cached_char_width,
+                                layout,
+                                &self.tab_slot_positions.borrow(),
+                                &self.diff_btn_map.borrow(),
+                                &self.split_btn_map.borrow(),
+                                &self.action_btn_map.borrow(),
+                                &self.status_segment_map.borrow(),
+                            );
+                        }
                     }
                 }
                 self.draw_needed.set(true);
@@ -7504,25 +7514,30 @@ impl App {
                     }
 
                     if !toolbar_handled {
-                        // Clear selection on click in VSCode mode.
                         if engine.is_vscode_mode() {
                             engine.vscode_clear_selection();
                         }
-                        let (click_result, engine_action) = handle_mouse_click(
-                            &mut engine,
-                            x,
-                            y,
-                            width,
-                            height,
-                            alt,
-                            self.cached_line_height,
-                            self.cached_char_width,
-                            &self.tab_slot_positions.borrow(),
-                            &self.diff_btn_map.borrow(),
-                            &self.split_btn_map.borrow(),
-                            &self.action_btn_map.borrow(),
-                            &self.status_segment_map.borrow(),
-                        );
+                        let (click_result, engine_action) = {
+                            let layout_ref = self.cached_screen_layout.borrow();
+                            if let Some(ref layout) = *layout_ref {
+                                handle_mouse_click(
+                                    &mut engine,
+                                    x,
+                                    y,
+                                    alt,
+                                    self.cached_line_height,
+                                    self.cached_char_width,
+                                    layout,
+                                    &self.tab_slot_positions.borrow(),
+                                    &self.diff_btn_map.borrow(),
+                                    &self.split_btn_map.borrow(),
+                                    &self.action_btn_map.borrow(),
+                                    &self.status_segment_map.borrow(),
+                                )
+                            } else {
+                                (None, None)
+                            }
+                        };
                         match engine_action {
                             Some(core::engine::EngineAction::ToggleSidebar) => {
                                 drop(engine);
@@ -7814,16 +7829,19 @@ impl App {
             let dx = x - sx;
             let dy = y - sy;
             if dx * dx + dy * dy > 64.0 {
-                // Determine which tab was clicked using pixel_to_click_target.
+                let layout_ref = self.cached_screen_layout.borrow();
+                let Some(ref layout) = *layout_ref else {
+                    self.tab_drag_start = None;
+                    return;
+                };
                 let mut engine = self.engine.borrow_mut();
                 let target = pixel_to_click_target(
                     &mut engine,
                     sx,
                     sy,
-                    width,
-                    height,
                     self.cached_line_height,
                     self.cached_char_width,
+                    layout,
                     &self.tab_slot_positions.borrow(),
                     &self.diff_btn_map.borrow(),
                     &self.split_btn_map.borrow(),
@@ -7971,21 +7989,23 @@ impl App {
                 }
                 self.draw_needed.set(true);
             } else {
-                let mut engine = self.engine.borrow_mut();
-                handle_mouse_drag(
-                    &mut engine,
-                    x,
-                    y,
-                    width,
-                    height,
-                    self.cached_line_height,
-                    self.cached_char_width,
-                    &self.tab_slot_positions.borrow(),
-                    &self.diff_btn_map.borrow(),
-                    &self.split_btn_map.borrow(),
-                    &self.action_btn_map.borrow(),
-                    &self.status_segment_map.borrow(),
-                );
+                let layout_ref = self.cached_screen_layout.borrow();
+                if let Some(ref layout) = *layout_ref {
+                    let mut engine = self.engine.borrow_mut();
+                    handle_mouse_drag(
+                        &mut engine,
+                        x,
+                        y,
+                        self.cached_line_height,
+                        self.cached_char_width,
+                        layout,
+                        &self.tab_slot_positions.borrow(),
+                        &self.diff_btn_map.borrow(),
+                        &self.split_btn_map.borrow(),
+                        &self.action_btn_map.borrow(),
+                        &self.status_segment_map.borrow(),
+                    );
+                }
                 self.draw_needed.set(true);
             }
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -11184,6 +11184,278 @@ pub enum ClickTarget {
     None,
 }
 
+// ─── Shared screen-level hit-test (#344) ─────────────────────────────────────
+
+/// Top-level screen zone identified by a coordinate hit-test.
+///
+/// Coordinates are in the "editor content bounds" frame — both backends
+/// subtract their chrome (sidebar, menu bar, terminal panel, status bar)
+/// before calling [`screen_zone_hit_test`].
+#[derive(Debug)]
+pub enum ScreenZone {
+    /// Point is in a group's tab bar area.
+    TabBar {
+        group_id: GroupId,
+        local_x: f64,
+        bar_width: f64,
+    },
+    /// Point is on a breadcrumb bar.
+    Breadcrumb {
+        index: usize,
+        local_x: f64,
+        bar_width: f64,
+    },
+    /// Point is on a group divider.
+    GroupDivider { split_index: usize },
+    /// Point is in an editor window.
+    Window {
+        window_id: WindowId,
+        window_idx: usize,
+        rel_x: f64,
+        rel_y: f64,
+    },
+    /// Point is outside all editor zones.
+    None,
+}
+
+/// Sub-zone within an editor window.
+#[derive(Debug)]
+pub enum WindowZone {
+    /// Per-window status bar.
+    StatusBar { local_x: f64, bar_width: f64 },
+    /// Gutter area (breakpoint, git diff, fold indicator columns).
+    Gutter {
+        view_row: usize,
+        gutter_col: usize,
+        line_idx: usize,
+    },
+    /// Vertical scrollbar column.
+    VerticalScrollbar { view_row: usize },
+    /// Horizontal scrollbar row.
+    HorizontalScrollbar { local_x: f64 },
+    /// Text area (editable content).
+    TextArea {
+        view_row: usize,
+        buf_line: usize,
+        seg_col_offset: usize,
+        text_rel_x: f64,
+    },
+}
+
+/// Action to take on a gutter click.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GutterAction {
+    ToggleBreakpoint(usize),
+    DiffPeek(usize),
+    DiagnosticHover(usize),
+    CodeAction(usize),
+    ToggleFold(usize),
+}
+
+/// Determine which top-level screen zone a point falls in.
+///
+/// `x` and `y` are in the editor content-bounds coordinate system.
+/// `tab_bar_height` is the height of a tab bar row (in the same unit).
+/// `single_tab_hidden` should be `true` when `hide_single_tab` is active and
+/// there is only one tab — the tab bar row is not rendered and the window rect
+/// extends upward to reclaim the space.
+/// Both backends subtract their own chrome before calling this.
+pub fn screen_zone_hit_test(
+    layout: &ScreenLayout,
+    x: f64,
+    y: f64,
+    tab_bar_height: f64,
+    single_tab_hidden: bool,
+) -> ScreenZone {
+    // 1. Tab bars — check before windows because tab bars sit just above
+    //    the window content area within the same group bounds.
+    if let Some(ref split) = layout.editor_group_split {
+        for gtb in &split.group_tab_bars {
+            let b = &gtb.bounds;
+            let tab_y = b.y - tab_bar_height;
+            if y >= tab_y && y < tab_y + tab_bar_height && x >= b.x && x < b.x + b.width {
+                return ScreenZone::TabBar {
+                    group_id: gtb.group_id,
+                    local_x: x - b.x,
+                    bar_width: b.width,
+                };
+            }
+        }
+    } else if !single_tab_hidden && y >= 0.0 && y < tab_bar_height && !layout.tab_bar.is_empty() {
+        let bar_width = layout
+            .windows
+            .first()
+            .map(|w| w.rect.x + w.rect.width)
+            .unwrap_or(0.0);
+        return ScreenZone::TabBar {
+            group_id: GroupId(0),
+            local_x: x,
+            bar_width,
+        };
+    }
+
+    // 2. Breadcrumbs — sit within the tab-bar area, below the tab row.
+    for (i, bc) in layout.breadcrumbs.iter().enumerate() {
+        let b = &bc.bounds;
+        if x >= b.x && x < b.x + b.width && y >= b.y && y < b.y + b.height {
+            return ScreenZone::Breadcrumb {
+                index: i,
+                local_x: x - b.x,
+                bar_width: b.width,
+            };
+        }
+    }
+
+    // 3. Group dividers.
+    if let Some(ref split) = layout.editor_group_split {
+        for div in &split.dividers {
+            let hit = match div.direction {
+                SplitDirection::Vertical => {
+                    let div_x = div.position;
+                    (x - div_x).abs() < 0.5
+                        && y >= div.cross_start
+                        && y < div.cross_start + div.cross_size
+                }
+                SplitDirection::Horizontal => {
+                    let div_y = div.position;
+                    (y - div_y).abs() < 0.5
+                        && x >= div.cross_start
+                        && x < div.cross_start + div.cross_size
+                }
+            };
+            if hit {
+                return ScreenZone::GroupDivider {
+                    split_index: div.split_index,
+                };
+            }
+        }
+    }
+
+    // 4. Windows.
+    for (i, rw) in layout.windows.iter().enumerate() {
+        let r = &rw.rect;
+        if x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height {
+            return ScreenZone::Window {
+                window_id: rw.window_id,
+                window_idx: i,
+                rel_x: x - r.x,
+                rel_y: y - r.y,
+            };
+        }
+    }
+
+    ScreenZone::None
+}
+
+/// Determine which sub-zone of a window a point falls in.
+///
+/// `rel_x` and `rel_y` are relative to the window's top-left corner.
+/// `line_height` and `char_width` are in the same coordinate unit as the rect
+/// (pixels for GTK, 1.0 for TUI).
+pub fn window_zone_hit_test(
+    rw: &RenderedWindow,
+    rel_x: f64,
+    rel_y: f64,
+    line_height: f64,
+    char_width: f64,
+) -> WindowZone {
+    let has_status = rw.status_line.is_some();
+    let status_h = if has_status { line_height } else { 0.0 };
+    let content_h = rw.rect.height - status_h;
+    let viewport_lines = (content_h / line_height).floor() as usize;
+
+    // 1. Per-window status bar (bottom row of window).
+    if has_status && rel_y >= content_h {
+        return WindowZone::StatusBar {
+            local_x: rel_x,
+            bar_width: rw.rect.width,
+        };
+    }
+
+    let view_row = (rel_y / line_height).floor() as usize;
+
+    let gutter_w = rw.gutter_char_width as f64 * char_width;
+    let has_v_sb = rw.total_lines > viewport_lines;
+    let sb_w = if has_v_sb { char_width } else { 0.0 };
+    let viewport_cols = if char_width > 0.0 {
+        ((rw.rect.width - sb_w) / char_width).floor() as usize
+    } else {
+        1
+    }
+    .saturating_sub(rw.gutter_char_width)
+    .max(1);
+    let has_h_sb = rw.max_col > viewport_cols && viewport_lines > 1;
+
+    // 2. Vertical scrollbar (rightmost column).
+    if has_v_sb && rel_x >= rw.rect.width - sb_w {
+        return WindowZone::VerticalScrollbar { view_row };
+    }
+
+    // 3. Horizontal scrollbar (bottom content row, above status bar).
+    let h_sb_y = content_h - line_height;
+    if has_h_sb && rel_y >= h_sb_y && rel_y < content_h {
+        return WindowZone::HorizontalScrollbar {
+            local_x: rel_x - gutter_w,
+        };
+    }
+
+    // Resolve view row to buffer line via cached RenderedLine data.
+    let (line_idx, seg_col_offset) = rw
+        .lines
+        .get(view_row)
+        .map(|rl| (rl.line_idx, rl.segment_col_offset))
+        .unwrap_or((rw.scroll_top + view_row, 0));
+
+    // 4. Gutter.
+    if gutter_w > 0.0 && rel_x < gutter_w {
+        let gutter_col = if char_width > 0.0 {
+            (rel_x / char_width).floor() as usize
+        } else {
+            0
+        };
+        return WindowZone::Gutter {
+            view_row,
+            gutter_col,
+            line_idx,
+        };
+    }
+
+    // 5. Text area.
+    let text_rel_x = rel_x - gutter_w;
+    WindowZone::TextArea {
+        view_row,
+        buf_line: line_idx,
+        seg_col_offset,
+        text_rel_x,
+    }
+}
+
+/// Resolve a gutter click to an action based on column and line data.
+pub fn resolve_gutter_action(
+    rw: &RenderedWindow,
+    line_idx: usize,
+    gutter_col: usize,
+) -> Option<GutterAction> {
+    let bp_offset: usize = if rw.has_breakpoints { 1 } else { 0 };
+    let git_col = if rw.has_git_diff {
+        bp_offset
+    } else {
+        usize::MAX
+    };
+
+    if rw.has_breakpoints && gutter_col == 0 {
+        Some(GutterAction::ToggleBreakpoint(line_idx))
+    } else if gutter_col == git_col {
+        Some(GutterAction::DiffPeek(line_idx))
+    } else if rw.diagnostic_gutter.contains_key(&line_idx) {
+        Some(GutterAction::DiagnosticHover(line_idx))
+    } else if rw.code_action_lines.contains(&line_idx) {
+        Some(GutterAction::CodeAction(line_idx))
+    } else {
+        Some(GutterAction::ToggleFold(line_idx))
+    }
+}
+
 /// Compute the tab bar row height in pixels (the row containing tab labels).
 /// Used by GTK and Win-GUI backends.
 pub fn tab_row_height_px(line_height: f64) -> f64 {

--- a/src/render.rs
+++ b/src/render.rs
@@ -11259,6 +11259,8 @@ pub enum GutterAction {
 /// `single_tab_hidden` should be `true` when `hide_single_tab` is active and
 /// there is only one tab — the tab bar row is not rendered and the window rect
 /// extends upward to reclaim the space.
+/// `active_group` is the engine's current active group ID — used as the group
+/// ID for single-group tab bar hits (the ScreenLayout doesn't carry it).
 /// Both backends subtract their own chrome before calling this.
 pub fn screen_zone_hit_test(
     layout: &ScreenLayout,
@@ -11266,6 +11268,7 @@ pub fn screen_zone_hit_test(
     y: f64,
     tab_bar_height: f64,
     single_tab_hidden: bool,
+    active_group: GroupId,
 ) -> ScreenZone {
     // 1. Tab bars — check before windows because tab bars sit just above
     //    the window content area within the same group bounds.
@@ -11288,7 +11291,7 @@ pub fn screen_zone_hit_test(
             .map(|w| w.rect.x + w.rect.width)
             .unwrap_or(0.0);
         return ScreenZone::TabBar {
-            group_id: GroupId(0),
+            group_id: active_group,
             local_x: x,
             bar_width,
         };

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -3066,50 +3066,46 @@ pub(super) fn handle_mouse(
                     }
                 }
 
-                // Check gutter area
+                // Check gutter area — shared resolution via render::resolve_gutter_action (#344).
                 let view_row = (editor_row - wy) as usize;
                 if gutter > 0 && rel_col >= wx && rel_col < wx + gutter {
                     if let Some(rl) = rw.lines.get(view_row) {
                         let gutter_col = (rel_col - wx) as usize;
-                        let bp_offset: usize = if rw.has_breakpoints { 1 } else { 0 };
-                        let git_col = if rw.has_git_diff {
-                            bp_offset
-                        } else {
-                            usize::MAX
-                        };
-
-                        if rw.has_breakpoints && gutter_col == 0 {
-                            // Breakpoint column (leftmost).
-                            let file = engine
-                                .windows
-                                .get(&rw.window_id)
-                                .and_then(|w| engine.buffer_manager.get(w.buffer_id))
-                                .and_then(|bs| bs.file_path.as_ref())
-                                .map(|p| p.to_string_lossy().into_owned())
-                                .unwrap_or_default();
-                            let bp_line = rl.line_idx as u64 + 1;
-                            engine.dap_toggle_breakpoint(&file, bp_line);
-                        } else if gutter_col == git_col {
-                            // Git diff column — open diff peek popup.
-                            engine.active_tab_mut().active_window = rw.window_id;
-                            engine.view_mut().cursor.line = rl.line_idx;
-                            engine.open_diff_peek();
-                        } else if engine.has_diagnostic_on_line(rl.line_idx) {
-                            // Diagnostic gutter indicator — show hover popup.
-                            engine.active_tab_mut().active_window = rw.window_id;
-                            engine.view_mut().cursor.line = rl.line_idx;
-                            engine.trigger_editor_hover_for_line(rl.line_idx);
-                        } else if engine.has_code_actions_on_line(rl.line_idx) {
-                            // Code action lightbulb — show code actions popup.
-                            engine.active_tab_mut().active_window = rw.window_id;
-                            engine.view_mut().cursor.line = rl.line_idx;
-                            engine.show_code_actions_popup();
-                        } else {
-                            let has_fold_indicator =
-                                rl.gutter_text.chars().any(|c| c == '+' || c == '-');
-                            if has_fold_indicator {
-                                engine.toggle_fold_at_line(rl.line_idx);
+                        use crate::render::GutterAction;
+                        match crate::render::resolve_gutter_action(rw, rl.line_idx, gutter_col) {
+                            Some(GutterAction::ToggleBreakpoint(line)) => {
+                                let file = engine
+                                    .windows
+                                    .get(&rw.window_id)
+                                    .and_then(|w| engine.buffer_manager.get(w.buffer_id))
+                                    .and_then(|bs| bs.file_path.as_ref())
+                                    .map(|p| p.to_string_lossy().into_owned())
+                                    .unwrap_or_default();
+                                engine.dap_toggle_breakpoint(&file, line as u64 + 1);
                             }
+                            Some(GutterAction::DiffPeek(line)) => {
+                                engine.active_tab_mut().active_window = rw.window_id;
+                                engine.view_mut().cursor.line = line;
+                                engine.open_diff_peek();
+                            }
+                            Some(GutterAction::DiagnosticHover(line)) => {
+                                engine.active_tab_mut().active_window = rw.window_id;
+                                engine.view_mut().cursor.line = line;
+                                engine.trigger_editor_hover_for_line(line);
+                            }
+                            Some(GutterAction::CodeAction(line)) => {
+                                engine.active_tab_mut().active_window = rw.window_id;
+                                engine.view_mut().cursor.line = line;
+                                engine.show_code_actions_popup();
+                            }
+                            Some(GutterAction::ToggleFold(line)) => {
+                                let has_fold_indicator =
+                                    rl.gutter_text.chars().any(|c| c == '+' || c == '-');
+                                if has_fold_indicator {
+                                    engine.toggle_fold_at_line(line);
+                                }
+                            }
+                            None => {}
                         }
                     }
                     return sidebar_width;


### PR DESCRIPTION
## Summary

- Extract zone detection + gutter action resolution into shared functions in `render.rs` so both GTK and TUI backends use one source of truth for screen-level hit-testing
- GTK backend now caches `ScreenLayout` from paint — click handlers read cached geometry instead of recomputing from engine state, eliminating the root cause of zone-boundary disagreement bugs
- Three shared functions: `screen_zone_hit_test`, `window_zone_hit_test`, `resolve_gutter_action`
- Tab bar inner hit-testing (Pango-measured slot positions) and buffer position column computation (tab-expansion walk) stay per-backend

Closes #344

## Test plan

- [x] `cargo build` / `cargo test --no-default-features` / `cargo clippy -- -D warnings`
- [x] GTK: tab click/switch/close, gutter clicks (fold, git, diagnostics), text area click/double-click/drag, per-window status bar clicks, right-click context menu, tab drag
- [x] TUI: gutter clicks (fold, breakpoint, git diff peek)

🤖 Generated with [Claude Code](https://claude.com/claude-code)