### PR TITLE
fix: use Pango xy_to_index for GTK click-to-column (#352)

### DIFF
--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -13,6 +13,10 @@ pub(super) use render_mod::ClickTarget;
 ///
 /// Tab bar inner hit-testing (which specific tab/button) stays here because it
 /// uses Pango-measured pixel slot positions from `draw_tab_bar`.
+///
+/// `pango_layout` must be configured with the editor monospace font — it is
+/// used by `xy_to_index` to convert pixel offsets to character columns,
+/// matching the same glyph positioning the paint code uses (#352).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn pixel_to_click_target(
     engine: &mut Engine,
@@ -20,6 +24,7 @@ pub(super) fn pixel_to_click_target(
     y: f64,
     line_height: f64,
     char_width: f64,
+    pango_layout: &pango::Layout,
     cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
@@ -96,19 +101,24 @@ pub(super) fn pixel_to_click_target(
                     ClickTarget::Gutter
                 }
                 WindowZone::TextArea {
+                    view_row,
                     buf_line,
                     seg_col_offset,
                     text_rel_x,
-                    ..
                 } => {
-                    let col = gtk_text_column(
-                        engine,
-                        window_id,
-                        buf_line,
-                        seg_col_offset,
-                        text_rel_x,
-                        char_width,
-                    );
+                    let raw_text = rw
+                        .lines
+                        .get(view_row)
+                        .map(|rl| rl.raw_text.as_str())
+                        .unwrap_or("");
+                    pango_layout.set_text(raw_text);
+                    pango_layout.set_attributes(None);
+                    let scroll_px = rw.scroll_left as f64 * char_width;
+                    let x_pango = ((text_rel_x + scroll_px).max(0.0) * pango::SCALE as f64) as i32;
+                    let (_inside, byte_index, trailing) = pango_layout.xy_to_index(x_pango, 0);
+                    let byte_pos = (byte_index as usize).saturating_add(trailing as usize);
+                    let clamped = byte_pos.min(raw_text.len());
+                    let col = raw_text[..clamped].chars().count() + seg_col_offset;
                     ClickTarget::BufferPos(window_id, buf_line, col)
                 }
                 _ => ClickTarget::None,
@@ -242,51 +252,6 @@ fn execute_gutter_action(
     }
 }
 
-/// Compute the buffer column for a text area click (GTK tab-expansion walk).
-fn gtk_text_column(
-    engine: &Engine,
-    window_id: WindowId,
-    buf_line: usize,
-    seg_col_offset: usize,
-    text_rel_x: f64,
-    char_width: f64,
-) -> usize {
-    let line = engine
-        .windows
-        .get(&window_id)
-        .and_then(|w| engine.buffer_manager.get(w.buffer_id))
-        .map(|bs| buf_line.min(bs.buffer.content.len_lines().saturating_sub(1)))
-        .unwrap_or(buf_line);
-
-    let display_col = if char_width > 0.0 && text_rel_x >= 0.0 {
-        (text_rel_x / char_width) as usize
-    } else {
-        0
-    };
-
-    let line_text = engine
-        .windows
-        .get(&window_id)
-        .and_then(|w| engine.buffer_manager.get(w.buffer_id))
-        .map(|bs| bs.buffer.content.line(line).to_string())
-        .unwrap_or_default();
-
-    let mut col = seg_col_offset;
-    let mut display_pos = 0;
-    for ch in line_text.chars().skip(seg_col_offset) {
-        if display_pos >= display_col {
-            break;
-        }
-        if ch == '\t' {
-            display_pos += 4;
-        } else {
-            display_pos += 1;
-        }
-        col += 1;
-    }
-    col
-}
-
 /// Handle mouse click by converting coordinates to buffer position.
 /// Returns: `(click, engine_action)` where click is `None` = non-buffer click,
 /// `Some(true)` = close-tab on dirty buffer, `Some(false)` = normal buffer click;
@@ -299,6 +264,7 @@ pub(super) fn handle_mouse_click(
     alt: bool,
     line_height: f64,
     char_width: f64,
+    pango_layout: &pango::Layout,
     cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
@@ -312,6 +278,7 @@ pub(super) fn handle_mouse_click(
         y,
         line_height,
         char_width,
+        pango_layout,
         cached_layout,
         tab_slot_positions,
         diff_btn_map,
@@ -452,6 +419,7 @@ pub(super) fn handle_mouse_double_click(
     y: f64,
     line_height: f64,
     char_width: f64,
+    pango_layout: &pango::Layout,
     cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
@@ -465,6 +433,7 @@ pub(super) fn handle_mouse_double_click(
         y,
         line_height,
         char_width,
+        pango_layout,
         cached_layout,
         tab_slot_positions,
         diff_btn_map,
@@ -484,6 +453,7 @@ pub(super) fn handle_mouse_drag(
     y: f64,
     line_height: f64,
     char_width: f64,
+    pango_layout: &pango::Layout,
     cached_layout: &render::ScreenLayout,
     tab_slot_positions: &TabSlotMap,
     diff_btn_map: &DiffBtnMap,
@@ -497,6 +467,7 @@ pub(super) fn handle_mouse_drag(
         y,
         line_height,
         char_width,
+        pango_layout,
         cached_layout,
         tab_slot_positions,
         diff_btn_map,

--- a/src/gtk/click.rs
+++ b/src/gtk/click.rs
@@ -115,9 +115,8 @@ pub(super) fn pixel_to_click_target(
                     pango_layout.set_attributes(None);
                     let scroll_px = rw.scroll_left as f64 * char_width;
                     let x_pango = ((text_rel_x + scroll_px).max(0.0) * pango::SCALE as f64) as i32;
-                    let (_inside, byte_index, trailing) = pango_layout.xy_to_index(x_pango, 0);
-                    let byte_pos = (byte_index as usize).saturating_add(trailing as usize);
-                    let clamped = byte_pos.min(raw_text.len());
+                    let (_inside, byte_index, _trailing) = pango_layout.xy_to_index(x_pango, 0);
+                    let clamped = (byte_index as usize).min(raw_text.len());
                     let col = raw_text[..clamped].chars().count() + seg_col_offset;
                     ClickTarget::BufferPos(window_id, buf_line, col)
                 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4032,6 +4032,8 @@ impl SimpleComponent for App {
             let engine_rc = engine.clone();
             let sender_rc = sender.input_sender().clone();
             let lh_rc = line_height_cell.clone();
+            let cw_rc = char_width_cell.clone();
+            let da_rc = model.drawing_area.clone();
             let tab_slots_rc = tab_slot_positions_cell.clone();
             let diff_btn_rc = diff_btn_map_cell.clone();
             let split_btn_rc = split_btn_map_cell.clone();
@@ -4043,17 +4045,30 @@ impl SimpleComponent for App {
             rc_gesture.connect_pressed(move |gesture, _n_press, x, y| {
                 let _widget = gesture.widget();
                 let lh = lh_rc.get().max(1.0);
+                let cw = cw_rc.get().max(1.0);
                 let layout_ref = screen_layout_rc.borrow();
                 let Some(ref layout) = *layout_ref else {
                     return;
                 };
                 let mut engine = engine_rc.borrow_mut();
+                let editor_pl = {
+                    let da_ref = da_rc.borrow();
+                    let ctx = da_ref.as_ref().expect("drawing area").pango_context();
+                    let pl = pango::Layout::new(&ctx);
+                    let fd = FontDescription::from_string(&format!(
+                        "{} {}",
+                        engine.settings.font_family, engine.settings.font_size
+                    ));
+                    pl.set_font_description(Some(&fd));
+                    pl
+                };
                 let target = pixel_to_click_target(
                     &mut engine,
                     x,
                     y,
                     lh,
-                    0.0, // char_width not needed for tab bar detection
+                    cw,
+                    &editor_pl,
                     layout,
                     &tab_slots_rc.borrow(),
                     &diff_btn_rc.borrow(),
@@ -4289,12 +4304,14 @@ impl SimpleComponent for App {
                 if let Some(ref layout) = *layout_ref {
                     let mut engine = self.engine.borrow_mut();
                     if !engine.picker_open {
+                        let editor_pl = self.editor_pango_layout(&engine);
                         if let ClickTarget::BufferPos(_, line, col) = pixel_to_click_target(
                             &mut engine,
                             x,
                             y,
                             self.cached_line_height,
                             self.cached_char_width,
+                            &editor_pl,
                             layout,
                             &self.tab_slot_positions.borrow(),
                             &self.diff_btn_map.borrow(),
@@ -4351,6 +4368,7 @@ impl SimpleComponent for App {
                         }
                     }
                     if !bc_handled {
+                        let editor_pl = self.editor_pango_layout(&engine);
                         let layout_ref = self.cached_screen_layout.borrow();
                         if let Some(ref layout) = *layout_ref {
                             handle_mouse_double_click(
@@ -4359,6 +4377,7 @@ impl SimpleComponent for App {
                                 y,
                                 self.cached_line_height,
                                 self.cached_char_width,
+                                &editor_pl,
                                 layout,
                                 &self.tab_slot_positions.borrow(),
                                 &self.diff_btn_map.borrow(),
@@ -6225,6 +6244,20 @@ impl App {
         }
     }
 
+    fn editor_pango_layout(&self, engine: &Engine) -> pango::Layout {
+        let ctx = {
+            let da_ref = self.drawing_area.borrow();
+            da_ref.as_ref().expect("drawing area").pango_context()
+        };
+        let layout = pango::Layout::new(&ctx);
+        let font_desc = FontDescription::from_string(&format!(
+            "{} {}",
+            engine.settings.font_family, engine.settings.font_size
+        ));
+        layout.set_font_description(Some(&font_desc));
+        layout
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn handle_mouse_click_msg(
         &mut self,
@@ -7517,6 +7550,7 @@ impl App {
                         if engine.is_vscode_mode() {
                             engine.vscode_clear_selection();
                         }
+                        let editor_pl = self.editor_pango_layout(&engine);
                         let (click_result, engine_action) = {
                             let layout_ref = self.cached_screen_layout.borrow();
                             if let Some(ref layout) = *layout_ref {
@@ -7527,6 +7561,7 @@ impl App {
                                     alt,
                                     self.cached_line_height,
                                     self.cached_char_width,
+                                    &editor_pl,
                                     layout,
                                     &self.tab_slot_positions.borrow(),
                                     &self.diff_btn_map.borrow(),
@@ -7835,12 +7870,14 @@ impl App {
                     return;
                 };
                 let mut engine = self.engine.borrow_mut();
+                let editor_pl = self.editor_pango_layout(&engine);
                 let target = pixel_to_click_target(
                     &mut engine,
                     sx,
                     sy,
                     self.cached_line_height,
                     self.cached_char_width,
+                    &editor_pl,
                     layout,
                     &self.tab_slot_positions.borrow(),
                     &self.diff_btn_map.borrow(),
@@ -7992,12 +8029,14 @@ impl App {
                 let layout_ref = self.cached_screen_layout.borrow();
                 if let Some(ref layout) = *layout_ref {
                     let mut engine = self.engine.borrow_mut();
+                    let editor_pl = self.editor_pango_layout(&engine);
                     handle_mouse_drag(
                         &mut engine,
                         x,
                         y,
                         self.cached_line_height,
                         self.cached_char_width,
+                        &editor_pl,
                         layout,
                         &self.tab_slot_positions.borrow(),
                         &self.diff_btn_map.borrow(),


### PR DESCRIPTION
## Summary

- Replace approximate `text_rel_x / char_width` division in GTK click handler with Pango's `xy_to_index`, matching the exact glyph positioning used by the paint code. Eliminates cumulative rounding drift on long lines.
- Ignore `trailing` from `xy_to_index` so clicking anywhere within a glyph selects that character (Vim cursor semantics), not the next one.
- Delete `gtk_text_column` function; inline the Pango conversion in `pixel_to_click_target`.

Closes #352

## Test plan

- [x] `cargo test --no-default-features` — 1960 lib + 33 integration, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] Smoke: GTK click on characters near line end — caret lands on clicked character
- [x] Smoke: GTK click on right edge of character — stays on that character
- [x] Smoke: GTK double-click and drag selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)