### PR TITLE
fix: horizontal scroll in ensure_cursor_visible + exact viewport_cols (#361)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2908,6 +2908,10 @@ pub struct Engine {
     /// Scroll surfaces registered at paint time for `dispatch_scroll`.
     /// Cleared at the start of each frame.
     pub scroll_surfaces: std::cell::RefCell<Vec<quadraui::ScrollSurface>>,
+    /// Per-window text viewport columns computed at paint time by
+    /// `build_screen_layout`. `ensure_cursor_visible` reads this
+    /// instead of the stale `view.viewport_cols` for horizontal scroll.
+    pub paint_viewport_cols: std::cell::RefCell<HashMap<WindowId, usize>>,
     /// Watch expressions added by the user (`:DapWatch <expr>`).
     pub dap_watch_expressions: Vec<String>,
     /// Evaluated values for each watch expression (parallel vec; `None` = not yet evaluated).
@@ -3638,6 +3642,7 @@ impl Engine {
             debug_output_scroll: 0,
             debug_output_auto_scroll: true,
             scroll_surfaces: std::cell::RefCell::new(Vec::new()),
+            paint_viewport_cols: std::cell::RefCell::new(HashMap::new()),
             dap_watch_expressions: Vec::new(),
             dap_watch_values: Vec::new(),
             dap_launch_configs: Vec::new(),

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -140,16 +140,32 @@ impl Engine {
             let viewport_lines = self.effective_viewport_lines();
             let cursor_line = self.view().cursor.line;
             let scroll_top = self.view().scroll_top;
-            // Unified path: handle both scrolloff=0 and scrolloff>0 cases
-            // using the effective viewport (#185). Previously the scrolloff=0
-            // branch delegated to `view_mut().ensure_cursor_visible()` which
-            // read the stale `view.viewport_lines` directly.
             if cursor_line < scroll_top + scrolloff {
                 self.view_mut().scroll_top = cursor_line.saturating_sub(scrolloff);
             } else if viewport_lines > 0
                 && cursor_line + scrolloff + 1 > scroll_top + viewport_lines
             {
                 self.view_mut().scroll_top = cursor_line + scrolloff + 1 - viewport_lines;
+            }
+
+            // Horizontal: keep cursor within the visible column range.
+            // Prefer paint-time viewport_cols (exact) over the resize
+            // handler's approximate value.
+            let wid = self.active_window_id();
+            let viewport_cols = self
+                .paint_viewport_cols
+                .borrow()
+                .get(&wid)
+                .copied()
+                .unwrap_or(self.view().viewport_cols);
+            let cursor_col = self.view().cursor.col;
+            let scroll_left = self.view().scroll_left;
+            if viewport_cols > 0 {
+                if cursor_col < scroll_left {
+                    self.view_mut().scroll_left = cursor_col;
+                } else if cursor_col >= scroll_left + viewport_cols {
+                    self.view_mut().scroll_left = cursor_col + 1 - viewport_cols;
+                }
             }
         }
     }

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -103,10 +103,13 @@ pub(super) fn draw_editor(
     let font_desc = FontDescription::from_string(&font_str);
     layout.set_font_description(Some(&font_desc));
 
-    // Derive line height and char width from font metrics
+    // Derive line height and char width from font metrics.
+    // Use Pango layout measurement for char_width (not approximate_char_width)
+    // so the value matches actual glyph positioning in draw_editor.
     let font_metrics = pango_ctx.metrics(Some(&font_desc), None);
     let line_height = (font_metrics.ascent() + font_metrics.descent()) as f64 / pango::SCALE as f64;
-    let char_width = font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+    layout.set_text("0");
+    let char_width = layout.pixel_size().0 as f64;
 
     // Only send CacheFontMetrics when metrics actually change (e.g. on startup or font change).
     // Sending on every draw creates a feedback loop: draw → message → #[watch] → queue_draw → draw.

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2772,8 +2772,10 @@ impl SimpleComponent for App {
                     let line_height = (font_metrics.ascent() + font_metrics.descent()) as f64
                         / pango::SCALE as f64;
                     lh.set(line_height);
-                    let char_width =
-                        font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+                    let char_width = {
+                        layout.set_text("0");
+                        layout.pixel_size().0 as f64
+                    };
                     let screen =
                         build_screen_layout(&engine, &theme, &[], line_height, char_width, false);
                     let window_w = da.width() as f64;
@@ -3015,8 +3017,10 @@ impl SimpleComponent for App {
                     let font_metrics = pango_ctx.metrics(Some(&font_desc), None);
                     let line_height = (font_metrics.ascent() + font_metrics.descent()) as f64
                         / pango::SCALE as f64;
-                    let char_width =
-                        font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+                    let char_width = {
+                        layout.set_text("0");
+                        layout.pixel_size().0 as f64
+                    };
                     // Publish line_height for the click / scroll / key
                     // handlers — they can't recompute it themselves
                     // (no cairo context available outside the draw
@@ -3121,7 +3125,10 @@ impl SimpleComponent for App {
                 let font_metrics = pango_ctx.metrics(Some(&font_desc), None);
                 let line_height =
                     (font_metrics.ascent() + font_metrics.descent()) as f64 / pango::SCALE as f64;
-                let char_width = font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+                let char_width = {
+                    layout.set_text("0");
+                    layout.pixel_size().0 as f64
+                };
                 let screen =
                     build_screen_layout(&engine, &theme, &[], line_height, char_width, false);
                 let w = da.width() as f64;
@@ -3196,7 +3203,10 @@ impl SimpleComponent for App {
                 let font_metrics = pango_ctx.metrics(Some(&font_desc), None);
                 let line_height =
                     (font_metrics.ascent() + font_metrics.descent()) as f64 / pango::SCALE as f64;
-                let char_width = font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+                let char_width = {
+                    layout.set_text("0");
+                    layout.pixel_size().0 as f64
+                };
                 let screen =
                     build_screen_layout(&engine, &theme, &[], line_height, char_width, false);
                 let w = da.width() as f64;
@@ -3251,8 +3261,10 @@ impl SimpleComponent for App {
                     let font_metrics = pango_ctx.metrics(Some(&font_desc), None);
                     let line_height = (font_metrics.ascent() + font_metrics.descent()) as f64
                         / pango::SCALE as f64;
-                    let char_width =
-                        font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+                    let char_width = {
+                        layout.set_text("0");
+                        layout.pixel_size().0 as f64
+                    };
                     let screen =
                         build_screen_layout(&engine, &theme, &[], line_height, char_width, false);
                     let w = da.width() as f64;
@@ -3486,7 +3498,10 @@ impl SimpleComponent for App {
                 let font_metrics = pango_ctx.metrics(Some(&font_desc), None);
                 let line_height =
                     (font_metrics.ascent() + font_metrics.descent()) as f64 / pango::SCALE as f64;
-                let char_width = font_metrics.approximate_char_width() as f64 / pango::SCALE as f64;
+                let char_width = {
+                    layout.set_text("0");
+                    layout.pixel_size().0 as f64
+                };
                 let screen =
                     build_screen_layout(&engine, &theme, &[], line_height, char_width, false);
                 let w = da.width() as f64;
@@ -4604,6 +4619,22 @@ impl SimpleComponent for App {
                         let cols = ((da.width() as f64 / char_width) as u16).max(40);
                         let rows = self.engine.borrow().session.terminal_panel_rows;
                         self.engine.borrow_mut().terminal_resize(cols, rows);
+                    }
+                }
+                // Sync per-window viewport_cols from paint-time geometry
+                // so ensure_cursor_visible (run during key handling) uses
+                // exact column counts, not the resize handler's estimate.
+                {
+                    let layout_ref = self.cached_screen_layout.borrow();
+                    if let Some(ref layout) = *layout_ref {
+                        let mut engine = self.engine.borrow_mut();
+                        for rw in &layout.windows {
+                            engine.set_viewport_for_window(
+                                rw.window_id,
+                                rw.lines.len().max(1),
+                                rw.text_viewport_cols.max(1),
+                            );
+                        }
                     }
                 }
             }
@@ -5782,19 +5813,19 @@ impl App {
                     }
                 }
 
-                // Sync per-window viewport dimensions from actual window rects
-                // so ensure_cursor_visible uses accurate heights (not the rough
-                // DrawingArea-based estimate from connect_resize).
+                // Sync per-window viewport dimensions from the paint-time
+                // ScreenLayout so ensure_cursor_visible uses exact geometry.
                 {
-                    let mut engine = self.engine.borrow_mut();
-                    for (wid, rect) in &rects {
-                        let pane_lines = (rect.height / lh).floor() as usize;
-                        let pane_cols = (rect.width / cw).floor() as usize;
-                        engine.set_viewport_for_window(
-                            *wid,
-                            pane_lines.max(1),
-                            pane_cols.saturating_sub(5).max(1),
-                        );
+                    let layout_ref = self.cached_screen_layout.borrow();
+                    if let Some(ref layout) = *layout_ref {
+                        let mut engine = self.engine.borrow_mut();
+                        for rw in &layout.windows {
+                            engine.set_viewport_for_window(
+                                rw.window_id,
+                                rw.lines.len().max(1),
+                                rw.text_viewport_cols.max(1),
+                            );
+                        }
                     }
                 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -731,6 +731,11 @@ pub struct RenderedWindow {
     /// Width of the line-number gutter in *character cells* (0 = no gutter).
     /// GTK backend multiplies by `char_width` to get pixels.
     pub gutter_char_width: usize,
+    /// Exact number of text columns visible (rect width minus gutter minus
+    /// scrollbar, divided by char_width). Backends should feed this back
+    /// to `Engine::set_viewport_for_window` so `ensure_cursor_visible`
+    /// uses accurate geometry.
+    pub text_viewport_cols: usize,
     /// Whether this is the focused window.
     pub is_active: bool,
     /// Whether to render with the slightly-different active-window background
@@ -5378,6 +5383,10 @@ pub fn build_screen_layout(
                     engine, theme, *window_id, is_active,
                 ));
             }
+            engine
+                .paint_viewport_cols
+                .borrow_mut()
+                .insert(*window_id, rw.text_viewport_cols);
             rw
         })
         .collect();
@@ -8488,6 +8497,7 @@ fn build_rendered_window(
         scroll_left: 0,
         total_lines: 0,
         gutter_char_width: 0,
+        text_viewport_cols: 0,
         is_active,
         show_active_bg: false,
         has_git_diff: false,
@@ -9362,6 +9372,7 @@ fn build_rendered_window(
         scroll_left: view.scroll_left,
         total_lines,
         gutter_char_width,
+        text_viewport_cols: render_viewport_cols,
         is_active,
         show_active_bg: is_active && multi_window,
         has_git_diff: has_git,

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -1262,16 +1262,15 @@ fn event_loop(
                 last_layout.as_ref()
             };
 
-            // Update per-window viewport dimensions so ensure_cursor_visible uses
-            // the actual pane width (critical for horizontal scrolling in vsplit).
+            // Update per-window viewport dimensions from paint-time geometry
+            // so ensure_cursor_visible uses exact column counts.
             if let Some(ref layout) = last_layout {
                 for rw in &layout.windows {
-                    let gutter = rw.gutter_char_width as u16;
-                    // -1 for the vertical scrollbar column
-                    let pane_cols =
-                        (rw.rect.width as u16).saturating_sub(gutter + 1).max(1) as usize;
-                    let pane_rows = (rw.rect.height as u16).max(1) as usize;
-                    engine.set_viewport_for_window(rw.window_id, pane_rows, pane_cols);
+                    engine.set_viewport_for_window(
+                        rw.window_id,
+                        rw.lines.len().max(1),
+                        rw.text_viewport_cols.max(1),
+                    );
                 }
             }
 


### PR DESCRIPTION
## Summary

- Add horizontal scroll adjustment to `ensure_cursor_visible` — cursor movement (`$`, `End`, `w`, `l`, etc.) now scrolls the view horizontally to keep the cursor on-screen. Previously only vertical scroll was adjusted.
- Add `text_viewport_cols` to `RenderedWindow` — exact visible text columns computed at paint time from the window rect, gutter, and scrollbar.
- Add `paint_viewport_cols` RefCell on Engine — populated by `build_screen_layout`, read by `ensure_cursor_visible` for accurate horizontal scroll math.
- Replace all `approximate_char_width()` calls with Pango `layout.pixel_size()` measurement (7 sites) so `char_width` matches actual glyph positioning in `draw_editor`.

Closes #361

## Test plan

- [x] `cargo test --no-default-features` — 1960 lib + 33 integration, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] Smoke GTK: press `$` on long line — cursor visible at end
- [x] Smoke TUI: press `$` on long line — cursor visible at end
- [x] Smoke: `w`/`l` on long lines scrolls view right; `b`/`h` scrolls left

🤖 Generated with [Claude Code](https://claude.com/claude-code)