### PR TITLE
fix: first-line click, tab hit-test geometry, wildmenu test (#362, #359)

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -358,9 +358,7 @@ pub(super) fn draw_editor(
         if bc.segments.is_empty() || engine.terminal_maximized {
             continue;
         }
-        // Breadcrumb bar sits one line_height above the window content (bc.bounds.y)
-        // and one line_height below the tab bar.
-        let bc_y = bc.bounds.y - line_height;
+        let bc_y = bc.bounds.y;
         let bc_x = bc.bounds.x;
         let bc_w = bc.bounds.width;
         cr.save().ok();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -11300,13 +11300,7 @@ fn tab_close_hit_test(
     } else {
         tab_row_height
     };
-    let wildmenu_px = if engine.wildmenu_items.is_empty() {
-        0.0
-    } else {
-        line_height
-    };
-    let status_bar_height = line_height * 2.0 + wildmenu_px;
-    let editor_bottom = da_h - status_bar_height;
+    let editor_bottom = gtk_editor_bottom(engine, da_w, da_h, line_height);
     let content_bounds = core::WindowRect::new(0.0, 0.0, da_w, editor_bottom);
     let mut group_rects = engine
         .group_layout
@@ -11354,13 +11348,7 @@ fn tab_tooltip_hit_test(
     } else {
         tab_row_height
     };
-    let wildmenu_px = if engine.wildmenu_items.is_empty() {
-        0.0
-    } else {
-        line_height
-    };
-    let status_bar_height = line_height * 2.0 + wildmenu_px;
-    let editor_bottom = da_h - status_bar_height;
+    let editor_bottom = gtk_editor_bottom(engine, da_w, da_h, line_height);
     let content_bounds = core::WindowRect::new(0.0, 0.0, da_w, editor_bottom);
     let mut group_rects = engine
         .group_layout

--- a/src/render.rs
+++ b/src/render.rs
@@ -5897,7 +5897,10 @@ pub fn build_screen_layout(
                     min_y = 0.0;
                     max_x = 0.0;
                 }
-                let bounds = WindowRect::new(min_x, min_y, max_x - min_x, line_height);
+                // Place bounds at the actual breadcrumb row (one line_height
+                // above the window content top).
+                let bc_y = (min_y - line_height).max(0.0);
+                let bounds = WindowRect::new(min_x, bc_y, max_x - min_x, line_height);
                 BreadcrumbBar {
                     group_id: gid,
                     segments,
@@ -13702,5 +13705,50 @@ mod tests {
         // Fallback: 3 spans (leading-pad, whole-label, trailing-pad).
         assert_eq!(styled.spans.len(), 3);
         assert_eq!(styled.spans[1].text, "fn foo(x: i32)");
+    }
+
+    #[test]
+    fn test_breadcrumb_bounds_do_not_overlap_first_line() {
+        use crate::core::engine::Engine;
+        use crate::core::window::{GroupId, WindowRect};
+
+        let mut engine = Engine::new();
+        engine.settings.breadcrumbs = true;
+        engine.buffer_mut().insert(0, "line 1\nline 2\nline 3\n");
+
+        let line_height = 20.0;
+        let char_width = 8.0;
+        let tbh = tab_bar_height_px(line_height, true);
+        let wid = engine.active_window_id();
+        let rects = vec![(wid, WindowRect::new(0.0, tbh, 800.0, 600.0 - tbh))];
+        let theme = Theme::onedark();
+        let layout = build_screen_layout(&engine, &theme, &rects, line_height, char_width, false);
+
+        assert!(!layout.breadcrumbs.is_empty());
+        let bc = &layout.breadcrumbs[0];
+        // Breadcrumb bounds must sit ABOVE the window content, not overlap it.
+        let window_top = layout.windows[0].rect.y;
+        assert!(
+            bc.bounds.y + bc.bounds.height <= window_top,
+            "breadcrumb bottom ({}) must not exceed window top ({})",
+            bc.bounds.y + bc.bounds.height,
+            window_top,
+        );
+
+        // Clicking at the window top (line 1) must return Window, not Breadcrumb.
+        let single_tab_hidden = engine.is_tab_bar_hidden(engine.active_group);
+        let zone = screen_zone_hit_test(
+            &layout,
+            100.0,
+            window_top,
+            tbh,
+            single_tab_hidden,
+            engine.active_group,
+        );
+        assert!(
+            matches!(zone, ScreenZone::Window { .. }),
+            "click at window_top should hit Window zone, got {:?}",
+            zone,
+        );
     }
 }

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2608,13 +2608,7 @@ pub(super) fn handle_mouse(
     if engine.settings.breadcrumbs {
         if let Some(layout) = last_layout {
             for bc in &layout.breadcrumbs {
-                // Match the renderer: bc_y = editor_area.y + bounds.y - 1
-                // where editor_area.y == menu_rows in TUI coordinates.
-                let bc_row = if bc.bounds.y >= 1.0 {
-                    menu_rows + bc.bounds.y as u16 - 1
-                } else {
-                    menu_rows
-                };
+                let bc_row = menu_rows + bc.bounds.y as u16;
                 let bc_x = editor_left + bc.bounds.x as u16;
                 let bc_w = bc.bounds.width as u16;
                 if row == bc_row && col >= bc_x && col < bc_x + bc_w {

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -365,13 +365,7 @@ pub(super) fn draw_frame(
             }
             let bc_x = bc.bounds.x as u16 + editor_area.x;
             let bc_w = bc.bounds.width as u16;
-            // Breadcrumb bar is one row above the window content (bounds.y - 1 in
-            // breadcrumb coordinates, which is one row below the tab bar).
             let bc_y = editor_area.y + bc.bounds.y as u16;
-            // In multi-group with breadcrumbs, bounds.y points to the breadcrumb row
-            // (tab_bar_height=2 means row 0=tab, row 1=breadcrumb, row 2+=windows).
-            // The breadcrumb bounds.y is window min_y, so the bc sits 1 above.
-            let bc_y = bc_y.saturating_sub(1);
             if bc_w > 0 {
                 let bc_rect = Rect {
                     x: bc_x,

--- a/tests/wildmenu.rs
+++ b/tests/wildmenu.rs
@@ -412,3 +412,30 @@ fn trailing_space_item_clears_wildmenu_for_next_tab() {
         "should show setting completions"
     );
 }
+
+// ── :set  + Tab cycles through settings (#360) ──────────────────────────
+
+#[test]
+fn set_tab_cycles_through_settings() {
+    let mut e = engine_with("hello\n");
+    press(&mut e, ':');
+    type_chars(&mut e, "set ");
+    press_key(&mut e, "Tab"); // opens wildmenu
+
+    assert!(!e.wildmenu_items.is_empty(), "wildmenu should open");
+    assert_mode(&e, Mode::Command);
+
+    let items = e.wildmenu_items.clone();
+
+    // Second Tab: select first item
+    press_key(&mut e, "Tab");
+    assert_mode(&e, Mode::Command);
+    assert_eq!(e.wildmenu_selected, Some(0));
+    assert_eq!(e.command_buffer, items[0]);
+
+    // Third Tab: select second item
+    press_key(&mut e, "Tab");
+    assert_mode(&e, Mode::Command);
+    assert_eq!(e.wildmenu_selected, Some(1));
+    assert_eq!(e.command_buffer, items[1]);
+}


### PR DESCRIPTION
## Summary

- **#362 — First-line click fix:** `BreadcrumbBar.bounds.y` in `ScreenLayout` was set to the window content top instead of the actual breadcrumb row position. `screen_zone_hit_test` returned `ScreenZone::Breadcrumb` for clicks on line 1, which mapped to `ClickTarget::None` — silently swallowing the click. Fixed the bounds at the source in `render.rs` and removed the per-backend workaround subtractions in both GTK and TUI.
- **#359 — Tab hit-test geometry:** `tab_close_hit_test` and `tab_tooltip_hit_test` hardcoded `status_bar_height` to `2.0 * line_height`, ignoring the `window_status_line` setting. Replaced with `gtk_editor_bottom()` which reads the setting dynamically. Also confirmed that gutter/text clicks work correctly with `:set nowsl`.
- **#360 — Wildmenu test:** Added integration test for the exact `:set ` + Tab cycling scenario. All 24 wildmenu tests pass; engine logic is correct. Root cause needs live GTK debugging.

## Test plan

- [x] `cargo test --no-default-features` — all lib + integration tests pass (6 pre-existing zh/zl failures unrelated)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Smoke: click on line 1 with breadcrumbs enabled — cursor moves (was swallowed before)
- [x] Smoke: `:set nowsl` then click gutter/text — clicks register correctly

Closes #362
Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)