### PR TITLE
refactor: pre-build tab bar and breadcrumb primitives in ScreenLayout

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -252,10 +252,6 @@ pub(super) fn draw_editor(
             let tab_y = gtb.bounds.y - tab_bar_height;
             let tab_x = gtb.bounds.x;
             let tab_w = gtb.bounds.width;
-            let is_active = gtb.group_id == split.active_group;
-            // In diff mode, show split buttons on all groups so clicking
-            // an inactive group's toolbar doesn't cause a visual shift.
-            let show_split = is_active || engine.is_in_diff_view();
             cr.save().ok();
             cr.rectangle(tab_x, tab_y, tab_w, tab_row_height);
             cr.clip();
@@ -267,25 +263,16 @@ pub(super) fn draw_editor(
                     None
                 }
             });
-            let accent = if is_active {
-                Some(theme.tab_active_accent)
-            } else {
-                None
-            };
             let (positions, close_b, dbp, sbp, vis_count, abp, correct_offset) = draw_tab_bar(
                 backend,
                 cr,
                 &layout,
                 &theme,
-                &gtb.tabs,
+                &gtb.bar,
                 tab_w,
                 line_height,
                 0.0,
-                show_split,
                 hover_idx,
-                gtb.diff_toolbar.as_ref(),
-                gtb.tab_scroll_offset,
-                accent,
             );
             tab_slot_positions_out
                 .borrow_mut()
@@ -315,15 +302,11 @@ pub(super) fn draw_editor(
             cr,
             &layout,
             &theme,
-            &screen.tab_bar,
+            &screen.tab_bar_primitive,
             width as f64,
             line_height,
             0.0,
-            true,
             hover_idx,
-            screen.diff_toolbar.as_ref(),
-            screen.tab_scroll_offset,
-            Some(theme.tab_active_accent),
         );
         // Use group_id 0 for single-group mode
         tab_slot_positions_out
@@ -368,12 +351,10 @@ pub(super) fn draw_editor(
             cr,
             &layout,
             &theme,
-            &bc.segments,
+            &bc.bar,
             bc_w,
             line_height,
             bc_y,
-            engine.breadcrumb_focus,
-            engine.breadcrumb_selected,
             breadcrumb_hit_regions_out,
         );
         cr.restore().ok();
@@ -1070,11 +1051,10 @@ pub(super) fn draw_tab_drag_overlay(
     }
 }
 
-/// A.6d / B5c.2: GTK tab bar renders via `Backend::draw_tab_bar`.
+/// GTK tab bar renders via `Backend::draw_tab_bar`.
 ///
-/// Builds the shared `quadraui::TabBar` primitive via
-/// `render::build_tab_bar_primitive`, routes through the trait, and
-/// reshapes `TabBarHits.right_segment_bounds` (keyed by `WidgetId`)
+/// Takes a pre-built `quadraui::TabBar` primitive (from `ScreenLayout`)
+/// and reshapes `TabBarHits.right_segment_bounds` (keyed by `WidgetId`)
 /// into the vimcode-specific (diff_btns, split_btns, action_btn)
 /// groupings the click handler consumes. The vimcode UI font is set
 /// on the Pango layout before the trait call and restored afterwards
@@ -1085,26 +1065,13 @@ pub(super) fn draw_tab_bar(
     cr: &Context,
     layout: &pango::Layout,
     theme: &Theme,
-    tabs: &[TabInfo],
+    bar: &quadraui::TabBar,
     width: f64,
     line_height: f64,
     y_offset: f64,
-    show_split_btn: bool,
     hovered_close_tab: Option<usize>,
-    diff_toolbar: Option<&render::DiffToolbarData>,
-    tab_scroll_offset: usize,
-    accent_color: Option<render::Color>,
 ) -> TabBarDrawResult {
     use pango::FontDescription;
-
-    let accent = accent_color.map(render::to_quadraui_color);
-    let bar = render::build_tab_bar_primitive(
-        tabs,
-        show_split_btn,
-        diff_toolbar,
-        tab_scroll_offset,
-        accent,
-    );
 
     // The rasteriser uses whatever font is on the layout. Vimcode renders
     // tabs in the UI sans-serif, not the editor monospace; set it before
@@ -1120,7 +1087,7 @@ pub(super) fn draw_tab_bar(
         let tab_row_h = (line_height * 1.6).ceil();
         b.draw_tab_bar(
             quadraui::Rect::new(0.0, y_offset as f32, width as f32, tab_row_h as f32),
-            &bar,
+            bar,
             hovered_close_tab,
         )
     });
@@ -1177,29 +1144,29 @@ pub(super) fn draw_tab_bar(
     )
 }
 
+/// Draw the breadcrumb bar via `Backend::draw_status_bar`.
+///
+/// The pre-built `quadraui::StatusBar` primitive comes from
+/// `ScreenLayout` (built by `render::build_screen_layout`).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_breadcrumb_bar(
     backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     theme: &Theme,
-    segments: &[render::BreadcrumbSegment],
+    bar: &quadraui::StatusBar,
     width: f64,
     line_height: f64,
     y_offset: f64,
-    focus_active: bool,
-    focus_selected: usize,
     hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
 ) {
-    let bar =
-        render::breadcrumbs_to_quadraui_status_bar(segments, theme, focus_active, focus_selected);
     use quadraui::Backend;
     backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
         let hits = b.draw_status_bar(
             quadraui::Rect::new(0.0, y_offset as f32, width as f32, line_height as f32),
-            &bar,
+            bar,
             None,
             None,
         );

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -23,7 +23,7 @@ use crate::render;
 use core::engine::EngineAction;
 use core::settings::LineNumberMode;
 use core::{Engine, OpenMode, WindowRect};
-use render::{build_screen_layout, CommandLineData, RenderedWindow, TabInfo, Theme};
+use render::{build_screen_layout, CommandLineData, RenderedWindow, Theme};
 
 use copypasta_ext::ClipboardProviderExt;
 use std::collections::HashMap;

--- a/src/render.rs
+++ b/src/render.rs
@@ -427,6 +427,8 @@ pub struct GroupTabBar {
         crate::core::engine::TabBarHitRegion,
         crate::core::engine::TabBarClickTarget,
     )>,
+    /// Pre-built quadraui `TabBar` primitive — backends draw this directly.
+    pub bar: quadraui::TabBar,
 }
 
 // ── Tab bar hit region constants (char-cell units) ──────────────────────────
@@ -589,6 +591,8 @@ pub struct BreadcrumbBar {
     pub group_id: GroupId,
     pub segments: Vec<BreadcrumbSegment>,
     pub bounds: WindowRect,
+    /// Pre-built quadraui `StatusBar` primitive — backends draw this directly.
+    pub bar: quadraui::StatusBar,
 }
 
 /// Convert a slice of `BreadcrumbSegment` plus the focus state into a
@@ -3408,6 +3412,8 @@ pub struct ScreenLayout {
     pub tab_tooltip: Option<String>,
     /// Tab scroll offset for the single-group tab bar.
     pub tab_scroll_offset: usize,
+    /// Pre-built quadraui `TabBar` primitive for the single-group tab bar.
+    pub tab_bar_primitive: quadraui::TabBar,
     /// When `status_line_above_terminal` is OFF and the terminal panel is open,
     /// this carries the active window's status line to render as a dedicated row
     /// above the terminal panel. When `Some`, per-window `status_line` fields on
@@ -5829,6 +5835,18 @@ pub fn build_screen_layout(
                     diff_label_cols,
                     has_split,
                 );
+                let accent = if is_active {
+                    Some(to_quadraui_color(theme.tab_active_accent))
+                } else {
+                    None
+                };
+                let bar = build_tab_bar_primitive(
+                    &tabs,
+                    has_split,
+                    diff_toolbar.as_ref(),
+                    tab_scroll_offset,
+                    accent,
+                );
                 GroupTabBar {
                     group_id: gid,
                     tabs,
@@ -5836,6 +5854,7 @@ pub fn build_screen_layout(
                     diff_toolbar,
                     tab_scroll_offset,
                     hit_regions,
+                    bar,
                 }
             })
             .collect();
@@ -5901,10 +5920,17 @@ pub fn build_screen_layout(
                 // above the window content top).
                 let bc_y = (min_y - line_height).max(0.0);
                 let bounds = WindowRect::new(min_x, bc_y, max_x - min_x, line_height);
+                let bar = breadcrumbs_to_quadraui_status_bar(
+                    &segments,
+                    theme,
+                    engine.breadcrumb_focus,
+                    engine.breadcrumb_selected,
+                );
                 BreadcrumbBar {
                     group_id: gid,
                     segments,
                     bounds,
+                    bar,
                 }
             })
             .collect()
@@ -5926,6 +5952,19 @@ pub fn build_screen_layout(
     } else {
         None
     };
+
+    let tab_scroll_offset_single = engine
+        .editor_groups
+        .get(&engine.active_group)
+        .map(|g| g.tab_scroll_offset)
+        .unwrap_or(0);
+    let tab_bar_primitive = build_tab_bar_primitive(
+        &tab_bar,
+        true,
+        diff_toolbar.as_ref(),
+        tab_scroll_offset_single,
+        Some(to_quadraui_color(theme.tab_active_accent)),
+    );
 
     ScreenLayout {
         tab_bar,
@@ -6126,11 +6165,8 @@ pub fn build_screen_layout(
             None
         },
         tab_tooltip: engine.tab_hover_tooltip.clone(),
-        tab_scroll_offset: engine
-            .editor_groups
-            .get(&engine.active_group)
-            .map(|g| g.tab_scroll_offset)
-            .unwrap_or(0),
+        tab_scroll_offset: tab_scroll_offset_single,
+        tab_bar_primitive,
         separated_status_line,
     }
 }

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -328,8 +328,6 @@ pub(super) fn draw_frame(
             }
             let tab_x = gtb.bounds.x as u16 + editor_area.x;
             let tab_w = gtb.bounds.width as u16;
-            let is_active = gtb.group_id == split.active_group;
-            let show_split = is_active;
             if tab_w > 0 {
                 let bar_y = editor_area.y + (gtb.bounds.y as u16).saturating_sub(tui_tbh);
                 let g_tab = Rect {
@@ -338,22 +336,7 @@ pub(super) fn draw_frame(
                     width: tab_w,
                     height: 1,
                 };
-                let accent = if is_active {
-                    Some(rc(theme.tab_active_accent))
-                } else {
-                    None
-                };
-                let vis = render_tab_bar(
-                    backend,
-                    frame,
-                    g_tab,
-                    &gtb.tabs,
-                    theme,
-                    show_split,
-                    gtb.diff_toolbar.as_ref(),
-                    gtb.tab_scroll_offset,
-                    accent,
-                );
+                let vis = render_tab_bar(backend, frame, g_tab, &gtb.bar, theme);
                 tab_visible_counts_out.push((gtb.group_id, vis));
             }
         }
@@ -373,15 +356,7 @@ pub(super) fn draw_frame(
                     width: bc_w,
                     height: 1,
                 };
-                draw_breadcrumb_bar(
-                    backend,
-                    frame,
-                    bc_rect,
-                    &bc.segments,
-                    theme,
-                    engine.breadcrumb_focus,
-                    engine.breadcrumb_selected,
-                );
+                draw_breadcrumb_bar(backend, frame, bc_rect, &bc.bar, theme);
             }
         }
         // Draw divider lines (vertical only — horizontal splits use the tab bar as divider).
@@ -408,17 +383,7 @@ pub(super) fn draw_frame(
                 width: editor_area.width,
                 height: 1,
             };
-            let vis = render_tab_bar(
-                backend,
-                frame,
-                tab_rect,
-                &screen.tab_bar,
-                theme,
-                true,
-                screen.diff_toolbar.as_ref(),
-                screen.tab_scroll_offset,
-                Some(rc(theme.tab_active_accent)),
-            );
+            let vis = render_tab_bar(backend, frame, tab_rect, &screen.tab_bar_primitive, theme);
             tab_visible_counts_out.push((engine.active_group, vis));
         }
         // Draw breadcrumb bar for the single group. Hidden while the terminal
@@ -436,15 +401,7 @@ pub(super) fn draw_frame(
                     width: editor_area.width,
                     height: 1,
                 };
-                draw_breadcrumb_bar(
-                    backend,
-                    frame,
-                    bc_rect,
-                    &bc.segments,
-                    theme,
-                    engine.breadcrumb_focus,
-                    engine.breadcrumb_selected,
-                );
+                draw_breadcrumb_bar(backend, frame, bc_rect, &bc.bar, theme);
             }
         }
         render_all_windows(backend, frame, editor_area, &screen.windows, theme);
@@ -1517,31 +1474,15 @@ pub(super) fn compute_tui_tab_drop_zone(
 /// `set_tab_visible_count` (misnamed; it's the bar width used by
 /// `ensure_active_tab_visible` to derive scroll offsets).
 ///
-/// B5c.2: routes through the trait. The Backend impl computes layout
-/// internally with the cell measurer.
-#[allow(clippy::too_many_arguments)]
+/// The pre-built `quadraui::TabBar` primitive comes from `ScreenLayout`
+/// (built by `render::build_screen_layout`).
 pub(super) fn render_tab_bar(
     backend: &mut super::backend::TuiBackend,
     frame: &mut ratatui::Frame,
     area: Rect,
-    tabs: &[render::TabInfo],
+    bar: &quadraui::TabBar,
     theme: &Theme,
-    show_split_btns: bool,
-    diff_toolbar: Option<&render::DiffToolbarData>,
-    tab_scroll_offset: usize,
-    focused_accent: Option<ratatui::style::Color>,
 ) -> usize {
-    let accent = focused_accent.and_then(|c| match c {
-        ratatui::style::Color::Rgb(r, g, b) => Some(quadraui::Color::rgb(r, g, b)),
-        _ => None,
-    });
-    let bar = render::build_tab_bar_primitive(
-        tabs,
-        show_split_btns,
-        diff_toolbar,
-        tab_scroll_offset,
-        accent,
-    );
     let q_rect = quadraui::Rect::new(
         area.x as f32,
         area.y as f32,
@@ -1551,27 +1492,22 @@ pub(super) fn render_tab_bar(
     backend.set_current_theme(super::quadraui_tui::q_theme(theme));
     let hits = backend.enter_frame_scope(frame, |b| {
         use quadraui::Backend;
-        b.draw_tab_bar(q_rect, &bar, None)
+        b.draw_tab_bar(q_rect, bar, None)
     });
     hits.available_cols
 }
 
 /// Draw the breadcrumb bar via the D6 StatusBar pipeline.
 ///
-/// B5c.1: routes through `Backend::draw_status_bar`. Breadcrumbs have
-/// no right segments so the trait method's internal `MIN_GAP_CELLS` is
-/// inert.
+/// The pre-built `quadraui::StatusBar` primitive comes from
+/// `ScreenLayout` (built by `render::build_screen_layout`).
 pub(super) fn draw_breadcrumb_bar(
     backend: &mut super::backend::TuiBackend,
     frame: &mut ratatui::Frame,
     area: Rect,
-    segments: &[render::BreadcrumbSegment],
+    bar: &quadraui::StatusBar,
     theme: &Theme,
-    focus_active: bool,
-    focus_selected: usize,
 ) {
-    let bar =
-        render::breadcrumbs_to_quadraui_status_bar(segments, theme, focus_active, focus_selected);
     let q_rect = quadraui::Rect::new(
         area.x as f32,
         area.y as f32,
@@ -1581,7 +1517,7 @@ pub(super) fn draw_breadcrumb_bar(
     backend.set_current_theme(super::quadraui_tui::q_theme(theme));
     backend.enter_frame_scope(frame, |b| {
         use quadraui::Backend;
-        let _ = b.draw_status_bar(q_rect, &bar, None, None);
+        let _ = b.draw_status_bar(q_rect, bar, None, None);
     });
 }
 


### PR DESCRIPTION
## Summary

- Moves `build_tab_bar_primitive()` and `breadcrumbs_to_quadraui_status_bar()` calls from both backends into `build_screen_layout()`, storing pre-built primitives on `GroupTabBar`, `BreadcrumbBar`, and `ScreenLayout`
- Backend wrappers (`render_tab_bar`, `draw_tab_bar`, `draw_breadcrumb_bar`) now take pre-built `quadraui::TabBar` / `quadraui::StatusBar` instead of raw data + adapter params
- Unifies `show_split_btns` cross-backend divergence: TUI used `is_active`, GTK used `is_active || is_in_diff_view()` — now both use the GTK logic via render.rs

Closes #347

## Test plan

- [x] `cargo build` — compiles
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test --no-default-features` — all pass (6 pre-existing z_commands failures unrelated)
- [x] GTK smoke: tab bar renders, breadcrumbs show, split buttons work, diff toolbar works, tab scrolling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)