### PR TITLE
fix: shared breadcrumb click resolution via StatusBarLayout (#366)

### DIFF
--- a/src/core/engine/dap_ops.rs
+++ b/src/core/engine/dap_ops.rs
@@ -389,6 +389,18 @@ impl Engine {
         self.message = format!("DAP: starting {} debug session\u{2026}", config.name);
     }
 
+    /// Handle the debug sidebar action button click (play/stop/debug).
+    /// Both backends call this — zero per-backend dispatch logic.
+    pub fn handle_dap_sidebar_action_click(&mut self) {
+        if self.dap_session_active && self.dap_stopped_thread.is_some() {
+            self.dap_continue();
+        } else if self.dap_session_active {
+            self.execute_command("stop");
+        } else {
+            self.execute_command("debug");
+        }
+    }
+
     /// Continue execution of the stopped thread.
     pub fn dap_continue(&mut self) {
         let tid = self.dap_stopped_thread.unwrap_or(0);

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2898,9 +2898,9 @@ pub struct Engine {
     /// Per-section allocated heights in content rows (excluding header).
     /// Computed by backends and stored for ensure_visible calculations.
     pub dap_sidebar_section_heights: [u16; 4],
-    /// Cached hit regions for the debug sidebar action-button row.
-    /// Paint fills; click reads verbatim (paint↔click pattern).
-    pub dap_sidebar_action_hits: std::cell::RefCell<Vec<quadraui::StatusBarHitRegion>>,
+    /// Cached layout for the debug sidebar action-button row.
+    /// Paint fills; click reads via `hit_test()` (paint↔click pattern).
+    pub dap_sidebar_action_hits: std::cell::RefCell<Option<quadraui::StatusBarLayout>>,
     /// Forward-indexed scroll offset for the debug output panel (0 = top/oldest).
     pub debug_output_scroll: usize,
     /// When true, debug output auto-scrolls to show newest lines.
@@ -3638,7 +3638,7 @@ impl Engine {
             dap_sidebar_selected: 0,
             dap_sidebar_scroll: [0; 4],
             dap_sidebar_section_heights: [0; 4],
-            dap_sidebar_action_hits: std::cell::RefCell::new(Vec::new()),
+            dap_sidebar_action_hits: std::cell::RefCell::new(None),
             debug_output_scroll: 0,
             debug_output_auto_scroll: true,
             scroll_surfaces: std::cell::RefCell::new(Vec::new()),

--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -285,6 +285,14 @@ impl Engine {
 
     /// Open a scoped picker for the currently selected breadcrumb segment.
     /// Path segments open the file picker for that directory.
+    /// Handle a breadcrumb segment click from either backend.
+    /// Rebuilds segments, selects the clicked index, and opens scoped.
+    pub fn handle_breadcrumb_click(&mut self, idx: usize) {
+        self.rebuild_breadcrumb_segments();
+        self.breadcrumb_selected = idx;
+        self.breadcrumb_open_scoped();
+    }
+
     /// Symbol segments open the `@` symbol picker filtered to siblings
     /// within the parent scope.
     pub(crate) fn breadcrumb_open_scoped(&mut self) {

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -60,9 +60,7 @@ pub(super) fn draw_editor(
     tab_visible_counts_out: &Rc<RefCell<Vec<(crate::core::window::GroupId, usize, usize)>>>,
     status_segment_map_out: &Rc<RefCell<StatusSegmentMap>>,
     screen_layout_out: &Rc<RefCell<Option<render::ScreenLayout>>>,
-    breadcrumb_hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
-    breadcrumb_y_offset_out: &Rc<Cell<f64>>,
-    debug_toolbar_hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
+    debug_toolbar_layout_out: &Rc<RefCell<Option<quadraui::StatusBarLayout>>>,
     debug_toolbar_y_offset_out: &Rc<Cell<f64>>,
     debug_toolbar_height_out: &Rc<Cell<f64>>,
     // Phase B.5 Stage 3: shared `quadraui::Backend` impl. Routed
@@ -346,7 +344,7 @@ pub(super) fn draw_editor(
         let bc_w = bc.bounds.width;
         cr.save().ok();
         cr.translate(bc_x, 0.0);
-        draw_breadcrumb_bar(
+        let bar_layout = draw_breadcrumb_bar(
             backend,
             cr,
             &layout,
@@ -355,13 +353,9 @@ pub(super) fn draw_editor(
             bc_w,
             line_height,
             bc_y,
-            breadcrumb_hit_regions_out,
         );
         cr.restore().ok();
-        // Cache the y-offset (in DA-coords, accounting for the bc_x translate
-        // we just did — y_offset is a pure y, x is captured via the
-        // hit_regions' col).
-        breadcrumb_y_offset_out.set(bc_y);
+        *bc.draw_layout.borrow_mut() = Some(bar_layout);
     }
 
     // 5. Draw tab drag overlay (drop zone highlight + ghost label).
@@ -720,7 +714,7 @@ pub(super) fn draw_editor(
             toolbar_y,
             width as f64,
             line_height,
-            debug_toolbar_hit_regions_out,
+            debug_toolbar_layout_out,
             debug_toolbar_hovered_id,
             debug_toolbar_pressed_id,
         );
@@ -1158,20 +1152,26 @@ pub(super) fn draw_breadcrumb_bar(
     width: f64,
     line_height: f64,
     y_offset: f64,
-    hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
-) {
+) -> quadraui::StatusBarLayout {
     use quadraui::Backend;
+    let mut result = quadraui::StatusBarLayout {
+        bar_width: 0.0,
+        bar_height: 0.0,
+        visible_segments: Vec::new(),
+        hit_regions: Vec::new(),
+        resolved_right_start: 0,
+    };
     backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
-        let hits = b.draw_status_bar(
+        result = b.draw_status_bar(
             quadraui::Rect::new(0.0, y_offset as f32, width as f32, line_height as f32),
             bar,
             None,
             None,
         );
-        *hit_regions_out.borrow_mut() = hits;
     });
+    result
 }
 
 /// Render one editor window (pane) onto `cr`.
@@ -2380,7 +2380,7 @@ pub(super) fn draw_debug_sidebar(
     line_height: f64,
     backend: &Rc<RefCell<super::backend::GtkBackend>>,
     engine: &crate::core::engine::Engine,
-) -> Vec<quadraui::StatusBarHitRegion> {
+) -> quadraui::StatusBarLayout {
     let sidebar = &screen.debug_sidebar;
 
     let (bg_r, bg_g, bg_b) = theme.tab_bar_bg.to_cairo();
@@ -2559,7 +2559,7 @@ fn draw_window_status_bar(
     let bar =
         render::window_status_line_to_status_bar(status, quadraui::WidgetId::new("status:window"));
     use quadraui::Backend;
-    let regions = backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+    let bar_layout = backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
         b.draw_status_bar(
@@ -2571,11 +2571,13 @@ fn draw_window_status_bar(
     });
 
     segment_zones.clear();
-    for region in regions {
-        if let Some(action) = render::status_action_from_id(region.id.as_str()) {
-            let start = region.col as f64;
-            let end = start + region.width as f64;
-            segment_zones.push((start, end, action));
+    for (rect, hit) in &bar_layout.hit_regions {
+        if let quadraui::StatusBarHit::Segment(ref id) = hit {
+            if let Some(action) = render::status_action_from_id(id.as_str()) {
+                let start = rect.x as f64;
+                let end = start + rect.width as f64;
+                segment_zones.push((start, end, action));
+            }
         }
     }
 }
@@ -4198,7 +4200,7 @@ pub(super) fn draw_debug_toolbar(
     y: f64,
     width: f64,
     height: f64,
-    hit_regions_out: &Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
+    hit_layout_out: &Rc<RefCell<Option<quadraui::StatusBarLayout>>>,
     hovered_id: Option<&quadraui::WidgetId>,
     pressed_id: Option<&quadraui::WidgetId>,
 ) {
@@ -4209,7 +4211,7 @@ pub(super) fn draw_debug_toolbar(
 
     let bar = render::debug_toolbar_to_quadraui_status_bar(toolbar, theme);
     use quadraui::Backend;
-    let hits = backend.borrow_mut().enter_frame_scope(cr, &ui_layout, |b| {
+    let bar_layout = backend.borrow_mut().enter_frame_scope(cr, &ui_layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(height);
         b.draw_status_bar(
@@ -4219,5 +4221,5 @@ pub(super) fn draw_debug_toolbar(
             pressed_id,
         )
     });
-    *hit_regions_out.borrow_mut() = hits;
+    *hit_layout_out.borrow_mut() = Some(bar_layout);
 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -380,14 +380,8 @@ struct App {
     /// Cached ScreenLayout from the last draw_editor paint pass. Click handlers
     /// read this instead of recomputing geometry from engine state (#344).
     cached_screen_layout: Rc<RefCell<Option<render::ScreenLayout>>>,
-    /// Cached breadcrumb segment pixel hit regions from `draw_breadcrumb_bar`.
-    /// Click handler walks this list to translate (x, y) → segment index.
-    breadcrumb_hit_regions: Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
-    /// Pixel y-offset where the breadcrumb bar was last drawn.
-    /// Click handler uses this with `breadcrumb_hit_regions` for hit-test.
-    breadcrumb_y_offset: Rc<Cell<f64>>,
-    /// Cached debug toolbar button hit regions from `draw_debug_toolbar`.
-    debug_toolbar_hit_regions: Rc<RefCell<Vec<quadraui::StatusBarHitRegion>>>,
+    /// Cached debug toolbar layout from `draw_debug_toolbar`.
+    debug_toolbar_layout: Rc<RefCell<Option<quadraui::StatusBarLayout>>>,
     /// Pixel y-offset where the debug toolbar was last drawn.
     debug_toolbar_y_offset: Rc<Cell<f64>>,
     /// Pixel height of the debug toolbar (last draw).
@@ -2207,9 +2201,7 @@ impl SimpleComponent for App {
             action_btn_map: action_btn_map_cell.clone(),
             status_segment_map: status_segment_map_cell.clone(),
             cached_screen_layout: Rc::new(RefCell::new(None)),
-            breadcrumb_hit_regions: Rc::new(RefCell::new(Vec::new())),
-            breadcrumb_y_offset: Rc::new(Cell::new(0.0)),
-            debug_toolbar_hit_regions: Rc::new(RefCell::new(Vec::new())),
+            debug_toolbar_layout: Rc::new(RefCell::new(None)),
             debug_toolbar_y_offset: Rc::new(Cell::new(0.0)),
             debug_toolbar_height: Rc::new(Cell::new(0.0)),
             debug_toolbar_hovered_id: Rc::new(RefCell::new(None)),
@@ -3047,7 +3039,7 @@ impl SimpleComponent for App {
                         &backend_d,
                         &engine,
                     );
-                    engine.dap_sidebar_action_hits.replace(action_hits);
+                    engine.dap_sidebar_action_hits.replace(Some(action_hits));
                 });
         }
         // ── Debug sidebar click handler ────────────────────────────────────────
@@ -3830,9 +3822,7 @@ impl SimpleComponent for App {
         let tab_vis_for_draw = tab_visible_counts_cell.clone();
         let status_seg_for_draw = model.status_segment_map.clone();
         let screen_layout_for_draw = model.cached_screen_layout.clone();
-        let bc_hits_for_draw = model.breadcrumb_hit_regions.clone();
-        let bc_y_for_draw = model.breadcrumb_y_offset.clone();
-        let dbg_hits_for_draw = model.debug_toolbar_hit_regions.clone();
+        let dbg_layout_for_draw = model.debug_toolbar_layout.clone();
         let dbg_y_for_draw = model.debug_toolbar_y_offset.clone();
         let dbg_h_for_draw = model.debug_toolbar_height.clone();
         let dbg_hovered_for_draw = model.debug_toolbar_hovered_id.clone();
@@ -3873,9 +3863,7 @@ impl SimpleComponent for App {
                             &tab_vis_for_draw,
                             &status_seg_for_draw,
                             &screen_layout_for_draw,
-                            &bc_hits_for_draw,
-                            &bc_y_for_draw,
-                            &dbg_hits_for_draw,
+                            &dbg_layout_for_draw,
                             &dbg_y_for_draw,
                             &dbg_h_for_draw,
                             &backend_for_draw,
@@ -5794,14 +5782,11 @@ impl App {
                     let dbg_y = self.debug_toolbar_y_offset.get();
                     let dbg_h = self.debug_toolbar_height.get();
                     let new_hover = if dbg_h > 0.0 && my >= dbg_y && my < dbg_y + dbg_h {
-                        let regions = self.debug_toolbar_hit_regions.borrow();
-                        regions.iter().find_map(|region| {
-                            let r_x = region.col as f64;
-                            let r_w = region.width as f64;
-                            if mx >= r_x && mx < r_x + r_w {
-                                Some(region.id.clone())
-                            } else {
-                                None
+                        let guard = self.debug_toolbar_layout.borrow();
+                        guard.as_ref().and_then(|l| {
+                            match l.hit_test(mx as f32, (my - dbg_y) as f32) {
+                                quadraui::StatusBarHit::Segment(id) => Some(id),
+                                quadraui::StatusBarHit::Empty => None,
                             }
                         })
                     } else {
@@ -6879,43 +6864,39 @@ impl App {
             }
         }
 
-        // Breadcrumb click: walk the cached `StatusBarHitRegion` list
-        // (populated by `draw_breadcrumb_bar` via the shared
-        // `quadraui_gtk::draw_status_bar`). Each region's `id` is
-        // `bc:N` — translated back to the segment index via
-        // `render::breadcrumb_action_index`.
+        // Breadcrumb click: shared resolution via cached StatusBarLayout.
         {
             let engine = self.engine.borrow();
             if engine.settings.breadcrumbs {
                 let lh = self.cached_line_height.max(1.0);
-                let bc_y = self.breadcrumb_y_offset.get();
-                if y >= bc_y && y < bc_y + lh {
-                    drop(engine);
-                    self.engine.borrow_mut().rebuild_breadcrumb_segments();
-                    let regions = self.breadcrumb_hit_regions.borrow();
-                    for region in regions.iter() {
-                        let r_x = region.col as f64;
-                        let r_w = region.width as f64;
-                        if x >= r_x && x < r_x + r_w {
-                            if let Some(idx) = render::breadcrumb_action_index(&region.id) {
-                                drop(regions);
-                                let mut engine = self.engine.borrow_mut();
-                                engine.breadcrumb_selected = idx;
-                                engine.breadcrumb_open_scoped();
-                                return;
-                            }
-                        }
+                if let Some(ref screen) = *self.cached_screen_layout.borrow() {
+                    if let Some(idx) =
+                        render::resolve_breadcrumb_click(&screen.breadcrumbs, x, y, lh)
+                    {
+                        drop(engine);
+                        self.engine.borrow_mut().rebuild_breadcrumb_segments();
+                        let mut engine = self.engine.borrow_mut();
+                        engine.breadcrumb_selected = idx;
+                        engine.breadcrumb_open_scoped();
+                        return;
                     }
-                    return; // clicked on breadcrumb row but not a segment
+                    let on_bc_row = screen.breadcrumbs.iter().any(|bc| {
+                        !bc.segments.is_empty()
+                            && y >= bc.bounds.y
+                            && y < bc.bounds.y + lh
+                            && x >= bc.bounds.x
+                            && x < bc.bounds.x + bc.bounds.width
+                    });
+                    if on_bc_row {
+                        return;
+                    }
                 }
             }
         }
 
-        // Debug toolbar click: walk the cached `StatusBarHitRegion` list
-        // (populated by `draw_debug_toolbar`). Each region's `id` is
-        // `debug:btn:N` — translated to the action via
-        // `render::debug_toolbar_action_index`, then dispatched to the
-        // engine via the same path the keyboard hotkey uses.
+        // Debug toolbar click: resolve via cached StatusBarLayout.
+        // Each region's `id` is `debug:btn:N` — translated to the
+        // action via `render::debug_toolbar_action_index`.
         {
             let dbg_y = self.debug_toolbar_y_offset.get();
             let dbg_h = self.debug_toolbar_height.get();
@@ -6923,14 +6904,16 @@ impl App {
                 *self.debug_toolbar_pressed_id.borrow_mut() =
                     self.debug_toolbar_hovered_id.borrow().clone();
                 self.draw_needed.set(true);
-                let regions = self.debug_toolbar_hit_regions.borrow();
-                for region in regions.iter() {
-                    let r_x = region.col as f64;
-                    let r_w = region.width as f64;
-                    if x >= r_x && x < r_x + r_w {
-                        if let Some(idx) = render::debug_toolbar_action_index(&region.id) {
+                let guard = self.debug_toolbar_layout.borrow();
+                if let Some(ref bar_layout) = *guard {
+                    let local_x = x as f32;
+                    let local_y = (y - dbg_y) as f32;
+                    if let quadraui::StatusBarHit::Segment(ref id) =
+                        bar_layout.hit_test(local_x, local_y)
+                    {
+                        if let Some(idx) = render::debug_toolbar_action_index(id) {
                             if let Some(btn) = render::DEBUG_BUTTONS.get(idx) {
-                                drop(regions);
+                                drop(guard);
                                 let _ = self.engine.borrow_mut().execute_command(btn.action);
                                 return;
                             }
@@ -8863,12 +8846,17 @@ impl App {
                 engine.dap_sidebar_has_focus = true;
 
                 if y < 2.0 * lh {
-                    let hits = engine.dap_sidebar_action_hits.borrow();
-                    let matched = hits.iter().any(|r| {
-                        let rx = r.col as f64;
-                        click_x >= rx && click_x < rx + r.width as f64
-                    });
-                    drop(hits);
+                    let guard = engine.dap_sidebar_action_hits.borrow();
+                    let matched = guard
+                        .as_ref()
+                        .map(|l| {
+                            matches!(
+                                l.hit_test(click_x as f32, 0.0),
+                                quadraui::StatusBarHit::Segment(_)
+                            )
+                        })
+                        .unwrap_or(false);
+                    drop(guard);
                     if matched {
                         if engine.dap_session_active && engine.dap_stopped_thread.is_some() {
                             engine.dap_continue();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6870,25 +6870,14 @@ impl App {
             if engine.settings.breadcrumbs {
                 let lh = self.cached_line_height.max(1.0);
                 if let Some(ref screen) = *self.cached_screen_layout.borrow() {
-                    if let Some(idx) =
-                        render::resolve_breadcrumb_click(&screen.breadcrumbs, x, y, lh)
-                    {
-                        drop(engine);
-                        self.engine.borrow_mut().rebuild_breadcrumb_segments();
-                        let mut engine = self.engine.borrow_mut();
-                        engine.breadcrumb_selected = idx;
-                        engine.breadcrumb_open_scoped();
-                        return;
-                    }
-                    let on_bc_row = screen.breadcrumbs.iter().any(|bc| {
-                        !bc.segments.is_empty()
-                            && y >= bc.bounds.y
-                            && y < bc.bounds.y + lh
-                            && x >= bc.bounds.x
-                            && x < bc.bounds.x + bc.bounds.width
-                    });
-                    if on_bc_row {
-                        return;
+                    match render::resolve_breadcrumb_click(&screen.breadcrumbs, x, y, lh) {
+                        render::BreadcrumbClickResult::Hit(idx) => {
+                            drop(engine);
+                            self.engine.borrow_mut().handle_breadcrumb_click(idx);
+                            return;
+                        }
+                        render::BreadcrumbClickResult::OnBar => return,
+                        render::BreadcrumbClickResult::Miss => {}
                     }
                 }
             }
@@ -8858,13 +8847,7 @@ impl App {
                         .unwrap_or(false);
                     drop(guard);
                     if matched {
-                        if engine.dap_session_active && engine.dap_stopped_thread.is_some() {
-                            engine.dap_continue();
-                        } else if engine.dap_session_active {
-                            engine.execute_command("stop");
-                        } else {
-                            engine.execute_command("debug");
-                        }
+                        engine.handle_dap_sidebar_action_click();
                     }
                 } else {
                     let rect = engine.dap_sidebar_body_rect.get();

--- a/src/render.rs
+++ b/src/render.rs
@@ -672,11 +672,21 @@ pub fn breadcrumb_action_index(id: &quadraui::WidgetId) -> Option<usize> {
     id.as_str().strip_prefix("bc:")?.parse().ok()
 }
 
+/// Result of resolving a breadcrumb click.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BreadcrumbClickResult {
+    /// A clickable segment was hit — carries the segment index.
+    Hit(usize),
+    /// Click landed on a breadcrumb bar but not on a segment.
+    OnBar,
+    /// Click was not on any breadcrumb bar.
+    Miss,
+}
+
 /// Resolve a breadcrumb click at `(x, y)` across all editor groups.
 ///
 /// Iterates each group's `BreadcrumbBar`, checks bounds, then delegates to
-/// the cached `StatusBarLayout::hit_test()` for segment resolution. Returns
-/// the segment index if a clickable breadcrumb was hit.
+/// the cached `StatusBarLayout::hit_test()` for segment resolution.
 ///
 /// Both backends call this — zero per-backend breadcrumb click code.
 pub fn resolve_breadcrumb_click(
@@ -684,7 +694,7 @@ pub fn resolve_breadcrumb_click(
     x: f64,
     y: f64,
     line_height: f64,
-) -> Option<usize> {
+) -> BreadcrumbClickResult {
     for bc in breadcrumbs {
         if bc.segments.is_empty() {
             continue;
@@ -698,13 +708,15 @@ pub fn resolve_breadcrumb_click(
             let guard = bc.draw_layout.borrow();
             if let Some(ref layout) = *guard {
                 if let quadraui::StatusBarHit::Segment(ref id) = layout.hit_test(local_x, local_y) {
-                    return breadcrumb_action_index(id);
+                    if let Some(idx) = breadcrumb_action_index(id) {
+                        return BreadcrumbClickResult::Hit(idx);
+                    }
                 }
             }
-            return None;
+            return BreadcrumbClickResult::OnBar;
         }
     }
-    None
+    BreadcrumbClickResult::Miss
 }
 
 /// Present when the editor area is split into two or more independent groups.

--- a/src/render.rs
+++ b/src/render.rs
@@ -586,13 +586,16 @@ pub struct BreadcrumbSegment {
 }
 
 /// Breadcrumb bar data for one editor group.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BreadcrumbBar {
     pub group_id: GroupId,
     pub segments: Vec<BreadcrumbSegment>,
     pub bounds: WindowRect,
     /// Pre-built quadraui `StatusBar` primitive — backends draw this directly.
     pub bar: quadraui::StatusBar,
+    /// Cached layout from `Backend::draw_status_bar` — set at draw time,
+    /// read by `resolve_breadcrumb_click` at click time.
+    pub draw_layout: std::cell::RefCell<Option<quadraui::StatusBarLayout>>,
 }
 
 /// Convert a slice of `BreadcrumbSegment` plus the focus state into a
@@ -667,6 +670,41 @@ pub fn breadcrumbs_to_quadraui_status_bar(
 /// doesn't match the `bc:N` pattern.
 pub fn breadcrumb_action_index(id: &quadraui::WidgetId) -> Option<usize> {
     id.as_str().strip_prefix("bc:")?.parse().ok()
+}
+
+/// Resolve a breadcrumb click at `(x, y)` across all editor groups.
+///
+/// Iterates each group's `BreadcrumbBar`, checks bounds, then delegates to
+/// the cached `StatusBarLayout::hit_test()` for segment resolution. Returns
+/// the segment index if a clickable breadcrumb was hit.
+///
+/// Both backends call this — zero per-backend breadcrumb click code.
+pub fn resolve_breadcrumb_click(
+    breadcrumbs: &[BreadcrumbBar],
+    x: f64,
+    y: f64,
+    line_height: f64,
+) -> Option<usize> {
+    for bc in breadcrumbs {
+        if bc.segments.is_empty() {
+            continue;
+        }
+        let bx = bc.bounds.x;
+        let by = bc.bounds.y;
+        let bw = bc.bounds.width;
+        if y >= by && y < by + line_height && x >= bx && x < bx + bw {
+            let local_x = (x - bx) as f32;
+            let local_y = (y - by) as f32;
+            let guard = bc.draw_layout.borrow();
+            if let Some(ref layout) = *guard {
+                if let quadraui::StatusBarHit::Segment(ref id) = layout.hit_test(local_x, local_y) {
+                    return breadcrumb_action_index(id);
+                }
+            }
+            return None;
+        }
+    }
+    None
 }
 
 /// Present when the editor area is split into two or more independent groups.
@@ -5931,6 +5969,7 @@ pub fn build_screen_layout(
                     segments,
                     bounds,
                     bar,
+                    draw_layout: std::cell::RefCell::new(None),
                 }
             })
             .collect()

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2462,13 +2462,7 @@ pub(super) fn handle_mouse(
                     .unwrap_or(false);
                 drop(guard);
                 if matched {
-                    if engine.dap_session_active && engine.dap_stopped_thread.is_some() {
-                        engine.dap_continue();
-                    } else if engine.dap_session_active {
-                        engine.execute_command("stop");
-                    } else {
-                        engine.execute_command("debug");
-                    }
+                    engine.handle_dap_sidebar_action_click();
                 }
             } else {
                 // Route body click through SidebarSystem.
@@ -2617,22 +2611,18 @@ pub(super) fn handle_mouse(
         if let Some(layout) = last_layout {
             let bc_x = (col - editor_left) as f64;
             let bc_y = (row - menu_rows) as f64;
-            let on_bc_row = layout
-                .breadcrumbs
-                .iter()
-                .any(|bc| !bc.segments.is_empty() && bc_y == bc.bounds.y.floor());
-            if on_bc_row {
-                if !matches!(ev.kind, MouseEventKind::Down(MouseButton::Left)) {
+            match render::resolve_breadcrumb_click(&layout.breadcrumbs, bc_x, bc_y, 1.0) {
+                render::BreadcrumbClickResult::Hit(idx) => {
+                    if !matches!(ev.kind, MouseEventKind::Down(MouseButton::Left)) {
+                        return sidebar_width;
+                    }
+                    engine.handle_breadcrumb_click(idx);
                     return sidebar_width;
                 }
-                if let Some(idx) =
-                    render::resolve_breadcrumb_click(&layout.breadcrumbs, bc_x, bc_y, 1.0)
-                {
-                    engine.rebuild_breadcrumb_segments();
-                    engine.breadcrumb_selected = idx;
-                    engine.breadcrumb_open_scoped();
+                render::BreadcrumbClickResult::OnBar => {
+                    return sidebar_width;
                 }
-                return sidebar_width;
+                render::BreadcrumbClickResult::Miss => {}
             }
         }
     }

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2450,9 +2450,17 @@ pub(super) fn handle_mouse(
 
             if sidebar_row < 2 {
                 // Chrome rows (title + action button).
-                let hits = engine.dap_sidebar_action_hits.borrow();
-                let matched = hits.iter().any(|r| col >= r.col && col < r.col + r.width);
-                drop(hits);
+                let guard = engine.dap_sidebar_action_hits.borrow();
+                let matched = guard
+                    .as_ref()
+                    .map(|l| {
+                        matches!(
+                            l.hit_test(col as f32, 0.0),
+                            quadraui::StatusBarHit::Segment(_)
+                        )
+                    })
+                    .unwrap_or(false);
+                drop(guard);
                 if matched {
                     if engine.dap_session_active && engine.dap_stopped_thread.is_some() {
                         engine.dap_continue();
@@ -2607,33 +2615,24 @@ pub(super) fn handle_mouse(
     // ── Breadcrumb click ────────────────────────────────────────────────────
     if engine.settings.breadcrumbs {
         if let Some(layout) = last_layout {
-            for bc in &layout.breadcrumbs {
-                let bc_row = menu_rows + bc.bounds.y as u16;
-                let bc_x = editor_left + bc.bounds.x as u16;
-                let bc_w = bc.bounds.width as u16;
-                if row == bc_row && col >= bc_x && col < bc_x + bc_w {
-                    if !matches!(ev.kind, MouseEventKind::Down(MouseButton::Left)) {
-                        return sidebar_width; // consume non-click events on breadcrumb row
-                    }
-                    // Theme only feeds segment fg/bg here, which resolve_click
-                    // ignores — onedark stand-in is fine for hit-test only.
-                    let theme = Theme::onedark();
-                    let bar = render::breadcrumbs_to_quadraui_status_bar(
-                        &bc.segments,
-                        &theme,
-                        engine.breadcrumb_focus,
-                        engine.breadcrumb_selected,
-                    );
-                    let local_col = col - bc_x;
-                    if let Some(id) = bar.resolve_click(local_col, bc_w as usize) {
-                        if let Some(idx) = render::breadcrumb_action_index(&id) {
-                            engine.rebuild_breadcrumb_segments();
-                            engine.breadcrumb_selected = idx;
-                            engine.breadcrumb_open_scoped();
-                        }
-                    }
+            let bc_x = (col - editor_left) as f64;
+            let bc_y = (row - menu_rows) as f64;
+            let on_bc_row = layout
+                .breadcrumbs
+                .iter()
+                .any(|bc| !bc.segments.is_empty() && bc_y == bc.bounds.y.floor());
+            if on_bc_row {
+                if !matches!(ev.kind, MouseEventKind::Down(MouseButton::Left)) {
                     return sidebar_width;
                 }
+                if let Some(idx) =
+                    render::resolve_breadcrumb_click(&layout.breadcrumbs, bc_x, bc_y, 1.0)
+                {
+                    engine.rebuild_breadcrumb_segments();
+                    engine.breadcrumb_selected = idx;
+                    engine.breadcrumb_open_scoped();
+                }
+                return sidebar_width;
             }
         }
     }

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -2272,7 +2272,7 @@ pub(super) fn render_debug_sidebar(
         use quadraui::Backend;
         b.draw_status_bar(action_rect, &action_bar, None, None)
     });
-    engine.dap_sidebar_action_hits.replace(hits);
+    engine.dap_sidebar_action_hits.replace(Some(hits));
 
     // ── SidebarSystem body (the four sections). ──
     if area.height < 3 {

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -356,7 +356,8 @@ pub(super) fn draw_frame(
                     width: bc_w,
                     height: 1,
                 };
-                draw_breadcrumb_bar(backend, frame, bc_rect, &bc.bar, theme);
+                let layout = draw_breadcrumb_bar(backend, frame, bc_rect, &bc.bar, theme);
+                *bc.draw_layout.borrow_mut() = Some(layout);
             }
         }
         // Draw divider lines (vertical only — horizontal splits use the tab bar as divider).
@@ -401,7 +402,8 @@ pub(super) fn draw_frame(
                     width: editor_area.width,
                     height: 1,
                 };
-                draw_breadcrumb_bar(backend, frame, bc_rect, &bc.bar, theme);
+                let layout = draw_breadcrumb_bar(backend, frame, bc_rect, &bc.bar, theme);
+                *bc.draw_layout.borrow_mut() = Some(layout);
             }
         }
         render_all_windows(backend, frame, editor_area, &screen.windows, theme);
@@ -769,7 +771,7 @@ pub(super) fn draw_frame(
                 debug_toolbar_interaction.pressed_id(),
             )
         });
-        debug_toolbar_interaction.set_hit_regions(hits);
+        debug_toolbar_interaction.set_layout(hits);
     }
 
     // ── Wildmenu bar (command Tab completion) ─────────────────────────────────
@@ -1501,13 +1503,14 @@ pub(super) fn render_tab_bar(
 ///
 /// The pre-built `quadraui::StatusBar` primitive comes from
 /// `ScreenLayout` (built by `render::build_screen_layout`).
+/// Returns the `StatusBarLayout` for click-time hit testing.
 pub(super) fn draw_breadcrumb_bar(
     backend: &mut super::backend::TuiBackend,
     frame: &mut ratatui::Frame,
     area: Rect,
     bar: &quadraui::StatusBar,
     theme: &Theme,
-) {
+) -> quadraui::StatusBarLayout {
     let q_rect = quadraui::Rect::new(
         area.x as f32,
         area.y as f32,
@@ -1517,8 +1520,8 @@ pub(super) fn draw_breadcrumb_bar(
     backend.set_current_theme(super::quadraui_tui::q_theme(theme));
     backend.enter_frame_scope(frame, |b| {
         use quadraui::Backend;
-        let _ = b.draw_status_bar(q_rect, bar, None, None);
-    });
+        b.draw_status_bar(q_rect, bar, None, None)
+    })
 }
 
 // ─── Editor windows ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Fixed GTK breadcrumb clicks broken on non-first editor group** in multi-group layouts. Root cause: single shared hit-region vec overwritten per-group, plus group-local coordinates compared against absolute click x.
- **Added `render::resolve_breadcrumb_click()`** — a shared function both TUI and GTK call. Zero per-backend breadcrumb click code.
- **Adopted quadraui#140** (`Backend::draw_status_bar` returns `StatusBarLayout`). Each `BreadcrumbBar` caches the layout at draw time via `RefCell<Option<StatusBarLayout>>`; the shared function calls `StatusBarLayout::hit_test()` for segment resolution.
- **Migrated debug toolbar + debug sidebar action hits** from `Vec<StatusBarHitRegion>` to `StatusBarLayout` — same `hit_test()` pattern, removing all `StatusBarHitRegion` usage from vimcode.

## Test plan

- [x] Split editor (`Ctrl+\`), click breadcrumb segments on both left and right groups — both resolve correctly
- [x] Single-group breadcrumb clicks still work
- [x] TUI breadcrumb clicks still work (both single and split)
- [ ] Debug toolbar hover/click (if DAP session available)
- [x] `cargo test --no-default-features` — all pass (6 pre-existing z_commands failures unrelated)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)