### PR TITLE
fix: breadcrumb path segments show peers instead of children (#368)

### DIFF
--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -178,10 +178,19 @@ impl Engine {
                 };
                 self.picker_filter();
                 self.picker_load_preview();
-            } else {
-                // File segment (the last path component): open symbol picker
-                self.open_picker(PickerSource::CommandCenter);
-                self.picker_query = "@".to_string();
+            } else if let Some(parent) = path.parent() {
+                // File segment: show sibling files in the same directory.
+                self.open_picker(PickerSource::Files);
+                let rel = parent
+                    .strip_prefix(&self.cwd)
+                    .unwrap_or(parent)
+                    .to_string_lossy()
+                    .to_string();
+                self.picker_query = if rel.is_empty() {
+                    String::new()
+                } else {
+                    format!("{}/", rel)
+                };
                 self.picker_filter();
                 self.picker_load_preview();
             }

--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -163,37 +163,21 @@ impl Engine {
             self.picker_filter();
             self.picker_load_preview();
         } else if let Some(path) = path_prefix {
-            if path.is_dir() {
-                // Directory segment: open file picker filtered to that directory
-                self.open_picker(PickerSource::Files);
-                let rel = path
-                    .strip_prefix(&self.cwd)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .to_string();
-                self.picker_query = if rel.is_empty() {
-                    String::new()
-                } else {
-                    format!("{}/", rel)
-                };
-                self.picker_filter();
-                self.picker_load_preview();
-            } else if let Some(parent) = path.parent() {
-                // File segment: show sibling files in the same directory.
-                self.open_picker(PickerSource::Files);
-                let rel = parent
-                    .strip_prefix(&self.cwd)
-                    .unwrap_or(parent)
-                    .to_string_lossy()
-                    .to_string();
-                self.picker_query = if rel.is_empty() {
-                    String::new()
-                } else {
-                    format!("{}/", rel)
-                };
-                self.picker_filter();
-                self.picker_load_preview();
-            }
+            // Path segment: show peers (sibling entries in the parent directory).
+            let parent = path.parent().unwrap_or(path);
+            self.open_picker(PickerSource::Files);
+            let rel = parent
+                .strip_prefix(&self.cwd)
+                .unwrap_or(parent)
+                .to_string_lossy()
+                .to_string();
+            self.picker_query = if rel.is_empty() {
+                String::new()
+            } else {
+                format!("{}/", rel)
+            };
+            self.picker_filter();
+            self.picker_load_preview();
         }
     }
 

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -17611,15 +17611,13 @@ fn test_breadcrumb_click_directory_opens_file_picker() {
 }
 
 #[test]
-fn test_breadcrumb_click_file_opens_symbol_picker() {
+fn test_breadcrumb_click_file_opens_sibling_files() {
     let mut e = engine_with_text("hello");
     let file = std::env::temp_dir().join("vimcode_test_bc_file.rs");
     std::fs::write(&file, "fn foo() {}").unwrap();
-    // Clicking a file segment should open the @ symbol picker
     e.breadcrumb_click(false, Some(&file));
     assert!(e.picker_open, "breadcrumb file click should open picker");
-    assert_eq!(e.picker_source, PickerSource::CommandCenter);
-    assert_eq!(e.picker_query, "@");
+    assert_eq!(e.picker_source, PickerSource::Files);
     let _ = std::fs::remove_file(&file);
 }
 


### PR DESCRIPTION
## Summary

- **Breadcrumb filename click** now opens the file picker showing sibling files in the parent directory, instead of opening the symbol picker.
- **All path segments** (directories and files) now show **peers** at the same level — uses `path.parent()` to filter to the parent directory, matching VSCode behavior.
- Deduplicated the directory/file branches in `breadcrumb_click()` into a single code path.
- Updated existing test to match new behavior.

## Test plan

- [x] Click filename segment (`picker.rs`) → shows sibling files in `src/core/engine/`
- [x] Click directory segment (`engine`) → shows peers in `src/core/`
- [x] Click top-level segment (`src`) → shows top-level project entries
- [x] Symbol segments still open `@` symbol picker
- [x] `cargo test --no-default-features --lib` — 1960 pass

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)