### PR TITLE
fix: F5/F9/F10/F11 work from any panel and any mode (#292)

### DIFF
--- a/src/core/engine/dap_ops.rs
+++ b/src/core/engine/dap_ops.rs
@@ -773,26 +773,8 @@ impl Engine {
                 self.dispatch_dap_sidebar_delete();
                 false
             }
-            "F5" => {
-                self.execute_command("debug");
-                false
-            }
-            "F6" => {
-                self.execute_command("pause");
-                false
-            }
-            "F9" => {
-                self.execute_command("brkpt");
-                false
-            }
-            "F10" => {
-                self.execute_command("stepover");
-                false
-            }
-            "F11" => {
-                self.execute_command("stepin");
-                false
-            }
+            // F5/F9/F10/F11 handled globally in handle_key() before
+            // the dap_sidebar_has_focus guard.
             _ => false,
         }
     }

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -189,10 +189,15 @@ impl Engine {
             return self.handle_quickfix_key(&qf_key, ctrl);
         }
 
-        // Debug sidebar intercepts all keys when it has focus.
-        // TUI and GTK route through SidebarSystem directly.
+        // Debug sidebar intercepts all keys when it has focus
+        // (TUI and GTK route through SidebarSystem directly),
+        // EXCEPT debug F-keys which must always reach the engine.
         if self.dap_sidebar_has_focus {
-            return EngineAction::None;
+            if !ctrl && matches!(key_name, "F5" | "F9" | "F10" | "F11") {
+                // Fall through to the global F-key handler below.
+            } else {
+                return EngineAction::None;
+            }
         }
 
         // Extension panel input field intercepts keys when active.
@@ -287,6 +292,34 @@ impl Engine {
         let pre_cursor_line = self.cursor().line;
         let pre_cursor_col = self.cursor().col;
         let pre_mode = self.mode;
+
+        // Debug F-keys work from any mode (global debugger commands).
+        if !ctrl {
+            match key_name {
+                "F5" => {
+                    let cmd = if self.dap_session_active {
+                        "continue"
+                    } else {
+                        "debug"
+                    };
+                    let _ = self.execute_command(cmd);
+                    return EngineAction::None;
+                }
+                "F9" => {
+                    let _ = self.execute_command("brkpt");
+                    return EngineAction::None;
+                }
+                "F10" => {
+                    let _ = self.execute_command("stepover");
+                    return EngineAction::None;
+                }
+                "F11" => {
+                    let _ = self.execute_command("stepin");
+                    return EngineAction::None;
+                }
+                _ => {}
+            }
+        }
 
         // Ctrl+F: open find/replace from any mode (Visual captures the selection)
         if ctrl
@@ -1661,26 +1694,9 @@ impl Engine {
                     self.open_picker(PickerSource::Commands);
                     return EngineAction::None;
                 }
-                // Debug / DAP function keys
-                "F5" => {
-                    let cmd = if self.dap_session_active {
-                        "continue"
-                    } else {
-                        "debug"
-                    };
-                    let _ = self.execute_command(cmd);
-                }
+                // F5/F9/F10/F11 handled globally before mode dispatch.
                 "F6" => {
                     let _ = self.execute_command("pause");
-                }
-                "F9" => {
-                    let _ = self.execute_command("brkpt");
-                }
-                "F10" => {
-                    let _ = self.execute_command("stepover");
-                }
-                "F11" => {
-                    let _ = self.execute_command("stepin");
                 }
                 _ => {}
             },

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4150,6 +4150,46 @@ impl SimpleComponent for App {
             }
         }
 
+        // Intercept F10 at the window level before GTK's built-in
+        // menubar activation shortcut can swallow it.
+        {
+            let sender_fkey = sender.input_sender().clone();
+            let fkey_ctrl = gtk4::EventControllerKey::new();
+            fkey_ctrl.set_propagation_phase(gtk4::PropagationPhase::Capture);
+            fkey_ctrl.connect_key_pressed(move |_, key, _, modifier| {
+                let name = key.name().map(|s| s.to_string()).unwrap_or_default();
+                let dominated = modifier.contains(gdk::ModifierType::CONTROL_MASK)
+                    || modifier.contains(gdk::ModifierType::ALT_MASK);
+                if !dominated && matches!(name.as_str(), "F5" | "F9" | "F10" | "F11") {
+                    sender_fkey
+                        .send(Msg::KeyPress {
+                            key_name: name,
+                            unicode: None,
+                            ctrl: false,
+                            alt: false,
+                        })
+                        .ok();
+                    return gtk4::glib::Propagation::Stop;
+                }
+                if modifier.contains(gdk::ModifierType::SHIFT_MASK)
+                    && !dominated
+                    && matches!(name.as_str(), "F5" | "F11")
+                {
+                    sender_fkey
+                        .send(Msg::KeyPress {
+                            key_name: name,
+                            unicode: None,
+                            ctrl: false,
+                            alt: false,
+                        })
+                        .ok();
+                    return gtk4::glib::Propagation::Stop;
+                }
+                gtk4::glib::Propagation::Proceed
+            });
+            root.add_controller(fkey_ctrl);
+        }
+
         ComponentParts { model, widgets }
     }
 
@@ -5453,6 +5493,22 @@ impl App {
                     }
                 }
                 // Fall through — handle_key() will execute the paste.
+            }
+        }
+
+        // Debug F-keys must reach the engine regardless of which panel
+        // has focus — F5 (continue), F9 (breakpoint), F10 (step over),
+        // F11 (step in) are global debugger commands.
+        if !ctrl && !alt {
+            match key_name.as_str() {
+                "F5" | "F9" | "F10" | "F11" => {
+                    let mapped = map_gtk_key_name(&key_name);
+                    let action = self.engine.borrow_mut().handle_key(mapped, None, false);
+                    self.dispatch_engine_action(action, sender, false);
+                    self.draw_needed.set(true);
+                    return;
+                }
+                _ => {}
             }
         }
 
@@ -11431,6 +11487,10 @@ pub(crate) fn run(file_path: Option<PathBuf>) {
         app.activate();
         0
     });
+    // Unbind F10 from GTK's built-in "activate-menubar" action so it
+    // reaches our key controller (used for DAP step-over).
+    gtk_app.set_accels_for_action("win.show-help-overlay", &[]);
+    gtk_app.set_accels_for_action("win.activate-menubar", &[]);
     let app = RelmApp::from_app(gtk_app);
     app.run::<App>(file_path);
 }

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -2490,11 +2490,13 @@ fn event_loop(
                                     _ => "",
                                 },
                                 KeyCode::F(n @ 5..=11) => match n {
-                                    5 => "F5",
+                                    5 | 9 | 10 | 11 => {
+                                        let name = format!("F{n}");
+                                        engine.handle_key(&name, None, false);
+                                        needs_redraw = true;
+                                        continue;
+                                    }
                                     6 => "F6",
-                                    9 => "F9",
-                                    10 => "F10",
-                                    11 => "F11",
                                     _ => "",
                                 },
                                 _ => "",


### PR DESCRIPTION
## Summary
- Debug F-keys (F5/F9/F10/F11) now work regardless of which panel has focus and from any editor mode
- GTK: window-level capture controller intercepts F10 before GTK's built-in menubar activation
- Engine: global F-key handler before mode dispatch, exempted from `dap_sidebar_has_focus` guard
- Both TUI and GTK route through the same engine handler — removed duplicate F-key handling from `dispatch_dap_sidebar_action_key()`
- Fixes pre-existing F5 bug: sidebar handler always called "debug" instead of "continue" when a session was active

Closes #292

## Test plan
- [x] GTK: F10 step-over with editor focused
- [x] GTK: F10 step-over with debug sidebar focused
- [x] TUI: F10 step-over with debug sidebar focused
- [x] F5 continues (not restarts) when session is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)