### PR TITLE
refactor: settings panel uses FormController for scroll + scrollbar (#255)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -3118,6 +3118,8 @@ pub struct Engine {
     pub settings_selected: usize,
     /// Scroll offset for the settings panel content.
     pub settings_scroll_top: usize,
+    /// Form scroll/scrollbar controller for the settings panel.
+    pub settings_form_controller: std::cell::RefCell<quadraui::FormController>,
     /// Search/filter query typed in the settings panel.
     pub settings_query: String,
     /// Whether the search input is active (user typing a filter).
@@ -3710,6 +3712,9 @@ impl Engine {
             settings_has_focus: false,
             settings_selected: 0,
             settings_scroll_top: 0,
+            settings_form_controller: std::cell::RefCell::new(quadraui::FormController::new(
+                "settings".to_string(),
+            )),
             settings_query: String::new(),
             settings_input_active: false,
             settings_editing: None,

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -3096,18 +3096,17 @@ pub(super) fn draw_settings_panel(
     let sb_w = if need_sb { 8.0 } else { 0.0 };
     let form_w = (w - sb_w).max(0.0);
 
-    // Form rendering via the shared primitive.
-    // Phase B.5b Stage 8: route through `Backend::draw_form`.
-    let form = render::settings_to_form(engine);
+    // Form + scrollbar via FormController.
+    render::populate_settings_form_controller(engine);
     {
-        use quadraui::Backend;
+        let q_rect = quadraui::Rect::new(x as f32, body_y as f32, w as f32, body_h as f32);
         backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
             b.set_current_theme(super::quadraui_gtk::q_theme(theme));
             b.set_current_line_height(line_height);
-            b.draw_form(
-                quadraui::Rect::new(x as f32, body_y as f32, form_w as f32, body_h as f32),
-                &form,
-            );
+            engine
+                .settings_form_controller
+                .borrow_mut()
+                .render_and_cache(b, q_rect);
         });
     }
 
@@ -3179,28 +3178,6 @@ pub(super) fn draw_settings_panel(
                 cr.fill().ok();
             }
         }
-    }
-
-    // ── Scrollbar ───────────────────────────────────────────────────────────
-    if need_sb {
-        let sb_x = x + form_w;
-        let track_len = body_h;
-        let thumb_len = (track_len * visible_rows as f64 / total as f64).max(8.0);
-        let max_scroll = total.saturating_sub(visible_rows) as f64;
-        let scroll_ratio = if max_scroll > 0.0 {
-            engine.settings_scroll_top as f64 / max_scroll
-        } else {
-            0.0
-        };
-        let thumb_y = body_y + scroll_ratio * (track_len - thumb_len);
-        // Track.
-        cr.set_source_rgb(bg_r, bg_g, bg_b);
-        cr.rectangle(sb_x, body_y, sb_w, track_len);
-        cr.fill().ok();
-        // Thumb.
-        cr.set_source_rgb(dim_r, dim_g, dim_b);
-        cr.rectangle(sb_x + 2.0, thumb_y, sb_w - 4.0, thumb_len);
-        cr.fill().ok();
     }
 
     // ── Footer: "Open settings.json" ───────────────────────────────────────

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2373,27 +2373,43 @@ impl SimpleComponent for App {
             widgets.settings_da.add_controller(scroll_ctrl);
         }
         {
-            let drag_rc = model.backend.borrow().drag_state_handle();
             let engine_drag = engine.clone();
             let sender_drag = sender.input_sender().clone();
+            let settings_da_drag = model.settings_da_ref.clone();
             let gesture = gtk4::GestureDrag::new();
             gesture.set_button(1);
             gesture.connect_drag_update(move |g, dx, dy| {
                 let (sx, sy) = g.start_point().unwrap_or((0.0, 0.0));
                 let pt = quadraui::Point::new((sx + dx) as f32, (sy + dy) as f32);
-                let drag = drag_rc.borrow_mut();
-                let buttons = quadraui::ButtonMask {
-                    left: true,
-                    middle: false,
-                    right: false,
+                let da_h = settings_da_drag
+                    .borrow()
+                    .as_ref()
+                    .map(|da| da.height() as f32)
+                    .unwrap_or(0.0);
+                let event = quadraui::UiEvent::MouseMoved {
+                    position: pt,
+                    buttons: quadraui::ButtonMask {
+                        left: true,
+                        middle: false,
+                        right: false,
+                    },
                 };
-                let events = quadraui::dispatch_mouse_drag(&drag, pt, buttons);
-                drop(drag);
-                for ev in &events {
-                    if let quadraui::UiEvent::ScrollOffsetChanged { new_offset, .. } = ev {
-                        engine_drag.borrow_mut().settings_scroll_top = *new_offset;
-                        sender_drag.send(Msg::SettingsScroll(0.0)).ok();
-                    }
+                let q_rect = quadraui::Rect::new(0.0, 0.0, 1.0, da_h);
+                let eng = engine_drag.borrow();
+                render::populate_settings_form_controller(&eng);
+                let result = eng
+                    .settings_form_controller
+                    .borrow_mut()
+                    .handle_cached(&event, q_rect);
+                if matches!(
+                    result,
+                    quadraui::FormControllerEvent::ScrollChanged
+                        | quadraui::FormControllerEvent::Consumed
+                ) {
+                    let new_offset = eng.settings_form_controller.borrow().scroll_offset();
+                    drop(eng);
+                    engine_drag.borrow_mut().settings_scroll_top = new_offset;
+                    sender_drag.send(Msg::SettingsScroll(0.0)).ok();
                 }
             });
             widgets.settings_da.add_controller(gesture);
@@ -9489,64 +9505,28 @@ impl App {
                 let sb_w = if need_sb { 8.0 } else { 0.0 };
                 let form_right = (panel_w - sb_w).max(0.0);
 
-                // Route scrollbar clicks through quadraui dispatch
-                // (handles both track-click-jump and thumb-drag-start).
+                // Route scrollbar clicks through FormController.
                 if need_sb && x_click >= form_right {
-                    let sb_w_f = 8.0_f64;
-                    let sb_x = form_right;
-                    let track_len = body_h;
-                    let thumb_len = (track_len * visible_rows as f64 / total as f64).max(8.0);
-                    let max_scroll = total.saturating_sub(visible_rows) as f64;
-                    let scroll_ratio = if max_scroll > 0.0 {
-                        engine.settings_scroll_top as f64 / max_scroll
-                    } else {
-                        0.0
+                    let q_rect =
+                        quadraui::Rect::new(0.0, body_top as f32, panel_w as f32, body_h as f32);
+                    render::populate_settings_form_controller(&engine);
+                    let event = quadraui::UiEvent::MouseDown {
+                        button: quadraui::MouseButton::Left,
+                        position: quadraui::Point::new(x_click as f32, y_click as f32),
+                        modifiers: Default::default(),
+                        widget: None,
                     };
-                    let thumb_y = body_top + scroll_ratio * (track_len - thumb_len);
-                    let surface = quadraui::ScrollSurface {
-                        id: quadraui::WidgetId::new("gtk:settings"),
-                        bounds: quadraui::Rect::new(
-                            0.0,
-                            body_top as f32,
-                            panel_w as f32,
-                            body_h as f32,
-                        ),
-                        scrollbar: Some(quadraui::SurfaceScrollbar {
-                            axis: quadraui::ScrollAxis::Vertical,
-                            track_bounds: quadraui::Rect::new(
-                                sb_x as f32,
-                                body_top as f32,
-                                sb_w_f as f32,
-                                track_len as f32,
-                            ),
-                            thumb_bounds: quadraui::Rect::new(
-                                (sb_x + 2.0) as f32,
-                                thumb_y as f32,
-                                (sb_w_f - 4.0) as f32,
-                                thumb_len as f32,
-                            ),
-                            total_items: total,
-                            visible_items: visible_rows,
-                            scroll_offset: engine.settings_scroll_top,
-                            inverted: false,
-                        }),
-                    };
-                    let surfaces = [surface];
-                    let modal = self.backend.borrow().modal_stack_handle().borrow().clone();
-                    let mut drag = self.backend.borrow().drag_state_handle().borrow().clone();
-                    let click_events = quadraui::dispatch_click(
-                        &modal,
-                        &surfaces,
-                        &mut drag,
-                        quadraui::Point::new(x_click as f32, y_click as f32),
-                        quadraui::MouseButton::Left,
-                        Default::default(),
-                    );
-                    *self.backend.borrow().drag_state_handle().borrow_mut() = drag;
-                    for ev in &click_events {
-                        if let quadraui::UiEvent::ScrollOffsetChanged { new_offset, .. } = ev {
-                            engine.settings_scroll_top = *new_offset;
-                        }
+                    let result = engine
+                        .settings_form_controller
+                        .borrow_mut()
+                        .handle_cached(&event, q_rect);
+                    if matches!(
+                        result,
+                        quadraui::FormControllerEvent::ScrollChanged
+                            | quadraui::FormControllerEvent::Consumed
+                    ) {
+                        let new_offset = engine.settings_form_controller.borrow().scroll_offset();
+                        engine.settings_scroll_top = new_offset;
                     }
                     drop(engine);
                     self.draw_needed.set(true);

--- a/src/render.rs
+++ b/src/render.rs
@@ -7794,6 +7794,17 @@ pub fn settings_to_form(engine: &Engine) -> quadraui::Form {
     }
 }
 
+/// Populate the engine's `settings_form_controller` with current form
+/// data and scroll state. Call before `FormController::render()` or
+/// `FormController::handle()`.
+pub fn populate_settings_form_controller(engine: &Engine) {
+    let form = settings_to_form(engine);
+    let mut fc = engine.settings_form_controller.borrow_mut();
+    fc.set_form(form);
+    fc.set_scroll_offset(engine.settings_scroll_top);
+    fc.set_has_focus(engine.settings_has_focus);
+}
+
 /// Adapt the quickfix panel data into a generic `quadraui::ListView`.
 ///
 /// The quickfix panel is a simple flat list of pre-formatted strings

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -78,10 +78,6 @@ fn apply_scrollbar_drag(
                 "tui:search_results" => {
                     handled = true;
                 }
-                "tui:settings" => {
-                    engine.settings_scroll_top = *new_offset;
-                    handled = true;
-                }
                 // Inverted scrollbars: top of track = max offset (oldest
                 // content), bottom = 0 (newest). dispatch_mouse_drag
                 // reports the raw forward offset; flip it here.
@@ -920,6 +916,39 @@ pub(super) fn handle_mouse(
             engine.handle_search_sidebar_ui_event(move_ev);
             return sidebar_width;
         }
+        MouseEventKind::Drag(MouseButton::Left)
+            if sidebar.visible
+                && sidebar.active_panel == TuiPanel::Settings
+                && col >= ab_width
+                && col < ab_width + sidebar_width =>
+        {
+            let content_start = 2_u16;
+            let content_height = term_height.saturating_sub(4);
+            let q_rect = quadraui::Rect::new(
+                ab_width as f32,
+                content_start as f32,
+                sidebar_width as f32,
+                content_height as f32,
+            );
+            let move_ev = quadraui::UiEvent::MouseMoved {
+                position: quadraui::Point::new(col as f32, row as f32),
+                buttons: quadraui::ButtonMask {
+                    left: true,
+                    middle: false,
+                    right: false,
+                },
+            };
+            render::populate_settings_form_controller(engine);
+            let result = engine
+                .settings_form_controller
+                .borrow_mut()
+                .handle_cached(&move_ev, q_rect);
+            if !matches!(result, quadraui::FormControllerEvent::Ignored) {
+                engine.settings_scroll_top =
+                    engine.settings_form_controller.borrow().scroll_offset();
+            }
+            return sidebar_width;
+        }
         MouseEventKind::Drag(MouseButton::Left) => {
             // Explorer drag-and-drop: activate or update target row.
             if explorer_drag_src.is_some() || explorer_drag_active.is_some() {
@@ -999,7 +1028,7 @@ pub(super) fn handle_mouse(
             // Widget id routes the resulting `ScrollOffsetChanged` to the
             // matching scroll-state field. Sites covered:
             // - `explorer:sb`, `ext_panel:sb`, `editor_hover` (Stage 5a)
-            // - `tui:search_results`, `tui:settings`, `tui:debug_sidebar:N` (5c)
+            // - `tui:search_results`, `tui:debug_sidebar:N` (5c)
             // - `tui:terminal_scrollback`, `tui:debug_output` (5c, inverted)
             if drag_state.is_active() {
                 let point = quadraui::Point {
@@ -1260,6 +1289,35 @@ pub(super) fn handle_mouse(
                 engine.handle_search_sidebar_ui_event(scroll_ev);
                 return sidebar_width;
             }
+            if sidebar.visible
+                && col >= ab_width
+                && col < ab_width + sidebar_width
+                && sidebar.active_panel == TuiPanel::Settings
+            {
+                let content_start = 2_u16;
+                let content_height = term_height.saturating_sub(4);
+                let q_rect = quadraui::Rect::new(
+                    ab_width as f32,
+                    content_start as f32,
+                    sidebar_width as f32,
+                    content_height as f32,
+                );
+                let scroll_ev = quadraui::UiEvent::Scroll {
+                    widget: None,
+                    delta: quadraui::ScrollDelta::new(0.0, if scroll_up { 3.0 } else { -3.0 }),
+                    position: quadraui::Point::new(col as f32, row as f32),
+                };
+                render::populate_settings_form_controller(engine);
+                let result = engine
+                    .settings_form_controller
+                    .borrow_mut()
+                    .handle_cached(&scroll_ev, q_rect);
+                if !matches!(result, quadraui::FormControllerEvent::Ignored) {
+                    engine.settings_scroll_top =
+                        engine.settings_form_controller.borrow().scroll_offset();
+                }
+                return sidebar_width;
+            }
             // Terminal panel scroll now routes through dispatch_scroll
             // via the registered "tui:terminal_scrollback" surface.
             // Scroll-surface wheel dispatch — routes to registered surfaces.
@@ -1317,19 +1375,6 @@ pub(super) fn handle_mouse(
                                 } else {
                                     engine.ext_panel_scroll_top =
                                         engine.ext_panel_scroll_top.saturating_sub(step);
-                                }
-                                return sidebar_width;
-                            }
-                            "tui:settings" => {
-                                let flat = engine.settings_flat_list();
-                                let content_height = term_height.saturating_sub(4) as usize;
-                                let max_scroll = flat.len().saturating_sub(content_height);
-                                if down {
-                                    engine.settings_scroll_top =
-                                        (engine.settings_scroll_top + step).min(max_scroll);
-                                } else {
-                                    engine.settings_scroll_top =
-                                        engine.settings_scroll_top.saturating_sub(step);
                                 }
                                 return sidebar_width;
                             }
@@ -2068,7 +2113,7 @@ pub(super) fn handle_mouse(
                 }
                 quadraui::UiEvent::MouseDown {
                     widget: Some(id), ..
-                } if matches!(id.as_str(), "explorer:sb" | "ext_panel:sb" | "tui:settings")
+                } if matches!(id.as_str(), "explorer:sb" | "ext_panel:sb")
                     && drag_state.is_active() =>
                 {
                     return sidebar_width;
@@ -2553,7 +2598,33 @@ pub(super) fn handle_mouse(
             engine.settings_has_focus = true;
             let flat_total = engine.settings_flat_list().len();
 
-            if sidebar_row == 0 {
+            // Route scrollbar clicks through FormController.
+            let sb_col = ab_width + sidebar_width - 1;
+            if col == sb_col && sidebar_row >= 2 {
+                let content_start = 2_u16;
+                let content_height = term_height.saturating_sub(4);
+                let q_rect = quadraui::Rect::new(
+                    ab_width as f32,
+                    content_start as f32,
+                    sidebar_width as f32,
+                    content_height as f32,
+                );
+                let click_ev = quadraui::UiEvent::MouseDown {
+                    button: quadraui::MouseButton::Left,
+                    position: quadraui::Point::new(col as f32, row as f32),
+                    modifiers: Default::default(),
+                    widget: None,
+                };
+                render::populate_settings_form_controller(engine);
+                let result = engine
+                    .settings_form_controller
+                    .borrow_mut()
+                    .handle_cached(&click_ev, q_rect);
+                if !matches!(result, quadraui::FormControllerEvent::Ignored) {
+                    engine.settings_scroll_top =
+                        engine.settings_form_controller.borrow().scroll_offset();
+                }
+            } else if sidebar_row == 0 {
                 // Header — no-op
             } else if sidebar_row == 1 {
                 // Search box — activate search input

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -317,84 +317,20 @@ pub(super) fn render_settings_panel(
     let has_inline_edit =
         engine.settings_editing.is_some() || engine.ext_settings_editing.is_some();
     if !has_inline_edit {
-        let form = render::settings_to_form(engine);
-        // Reserve rightmost column for the scrollbar.
-        let form_area = Rect {
-            x: area.x,
-            y: content_start,
-            width: area.width.saturating_sub(1),
-            height: content_height as u16,
-        };
-        // B5c.4: route through the trait. The scrollbar/chrome below
-        // re-borrows `buf` from `frame` after the trait call.
+        render::populate_settings_form_controller(engine);
         let q_rect = quadraui::Rect::new(
-            form_area.x as f32,
-            form_area.y as f32,
-            form_area.width as f32,
-            form_area.height as f32,
+            area.x as f32,
+            content_start as f32,
+            area.width as f32,
+            content_height as f32,
         );
         backend.set_current_theme(super::quadraui_tui::q_theme(theme));
         backend.enter_frame_scope(frame, |b| {
-            use quadraui::Backend;
-            b.draw_form(q_rect, &form);
+            engine
+                .settings_form_controller
+                .borrow_mut()
+                .render_and_cache(b, q_rect);
         });
-        let buf = frame.buffer_mut();
-
-        // Scrollbar (mirrors the legacy renderer below).
-        let total = engine.settings_flat_list().len();
-        let scroll = engine.settings_scroll_top;
-        let settings_scrollbar = if total > content_height && content_height > 0 {
-            let sb_col = area.x + area.width - 1;
-            let track_len = content_height;
-            let thumb_len = (content_height * content_height / total).max(1);
-            let thumb_start = scroll * track_len / total;
-            let sb_thumb = rc(theme.scrollbar_thumb);
-            let sb_track = rc(theme.scrollbar_track);
-            let sb_bg = rc(theme.background);
-            for i in 0..track_len {
-                let y = content_start + i as u16;
-                let (ch, cfp) = if i >= thumb_start && i < thumb_start + thumb_len {
-                    ('█', sb_thumb)
-                } else {
-                    ('░', sb_track)
-                };
-                set_cell(buf, sb_col, y, ch, cfp, sb_bg);
-            }
-            Some(quadraui::SurfaceScrollbar {
-                axis: quadraui::ScrollAxis::Vertical,
-                track_bounds: quadraui::Rect::new(
-                    sb_col as f32,
-                    content_start as f32,
-                    1.0,
-                    track_len as f32,
-                ),
-                thumb_bounds: quadraui::Rect::new(
-                    sb_col as f32,
-                    content_start as f32 + thumb_start as f32,
-                    1.0,
-                    thumb_len as f32,
-                ),
-                total_items: total,
-                visible_items: content_height,
-                scroll_offset: scroll,
-                inverted: false,
-            })
-        } else {
-            None
-        };
-        engine
-            .scroll_surfaces
-            .borrow_mut()
-            .push(quadraui::ScrollSurface {
-                id: quadraui::WidgetId::new("tui:settings"),
-                bounds: quadraui::Rect::new(
-                    area.x as f32,
-                    content_start as f32,
-                    area.width as f32,
-                    content_height as f32,
-                ),
-                scrollbar: settings_scrollbar,
-            });
         return;
     }
 


### PR DESCRIPTION
## Summary
- Settings panel form + scrollbar rendered via `FormController::render_and_cache()`
- All mouse interaction (scroll wheel, track-click, thumb-drag) routed through `FormController::handle_cached()` — backend-free, uses cached metrics from render
- Removed manual scrollbar drawing from both TUI and GTK
- Removed `ScrollSurface` registration and `dispatch_click`/`dispatch_drag` wiring for settings
- Removed per-backend scrollbar geometry construction
- Both backends use identical `handle_cached()` call pattern
- Adopts quadraui#155 (FormController) and quadraui#157 (handle_cached)

Closes #255

## Test plan
- [x] TUI: settings scroll wheel
- [x] TUI: settings scrollbar track-click (page)
- [x] TUI: settings scrollbar thumb-drag
- [x] GTK: settings scroll wheel
- [x] GTK: settings scrollbar track-click (page)
- [x] GTK: settings scrollbar thumb-drag
- [x] Both: inline-edit mode still works (legacy path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)