### PR TITLE
refactor: extract Engine::execute_terminal_toolbar_action (#383)

### DIFF
--- a/src/core/engine/accessors.rs
+++ b/src/core/engine/accessors.rs
@@ -415,8 +415,7 @@ impl Engine {
             self.view_mut().cursor.line = (new_top + scrolloff).min(lines);
             self.clamp_cursor_col();
         } else if cur >= new_top + vp.saturating_sub(scrolloff) {
-            self.view_mut().cursor.line =
-                (new_top + vp.saturating_sub(scrolloff + 1)).min(lines);
+            self.view_mut().cursor.line = (new_top + vp.saturating_sub(scrolloff + 1)).min(lines);
             self.clamp_cursor_col();
         }
     }

--- a/src/core/engine/terminal_ops.rs
+++ b/src/core/engine/terminal_ops.rs
@@ -276,6 +276,42 @@ impl Engine {
         }
     }
 
+    /// Execute a terminal toolbar action. Returns `false` for `StartResize`
+    /// (backend-local drag state) and `None`; returns `true` for all other
+    /// actions handled internally.
+    pub fn execute_terminal_toolbar_action(
+        &mut self,
+        action: TerminalToolbarAction,
+        ctx: UiEventContext,
+    ) -> bool {
+        match action {
+            TerminalToolbarAction::SwitchTab(idx) => self.terminal_switch_tab(idx),
+            TerminalToolbarAction::CloseTab => self.terminal_close_active_tab(),
+            TerminalToolbarAction::ToggleMaximize => {
+                self.toggle_terminal_maximize();
+                let effective = self.effective_terminal_panel_rows(ctx.terminal_max_rows);
+                if self.terminal_panes.is_empty() {
+                    self.terminal_new_tab(ctx.terminal_cols, effective);
+                } else {
+                    self.terminal_resize(ctx.terminal_cols, effective);
+                }
+            }
+            TerminalToolbarAction::ToggleSplit => {
+                let rows = self.session.terminal_panel_rows;
+                self.terminal_toggle_split(ctx.terminal_cols, rows);
+            }
+            TerminalToolbarAction::AddTab => {
+                let rows = self.session.terminal_panel_rows;
+                self.terminal_new_tab(ctx.terminal_cols, rows);
+            }
+            TerminalToolbarAction::CloseFindBar => {
+                self.terminal_find_active = false;
+            }
+            TerminalToolbarAction::StartResize | TerminalToolbarAction::None => return false,
+        }
+        true
+    }
+
     /// Toggle "terminal maximized" state.
     ///
     /// This only flips `terminal_maximized`; the stored user-preferred panel

--- a/src/core/engine/windows.rs
+++ b/src/core/engine/windows.rs
@@ -1648,7 +1648,11 @@ impl Engine {
     /// Set `active_group` to the group that owns the given window.
     pub fn activate_group_for_window(&mut self, window_id: WindowId) {
         for (&gid, group) in &self.editor_groups {
-            if group.tabs.iter().any(|t| t.window_ids().contains(&window_id)) {
+            if group
+                .tabs
+                .iter()
+                .any(|t| t.window_ids().contains(&window_id))
+            {
                 self.active_group = gid;
                 return;
             }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4516,9 +4516,7 @@ impl SimpleComponent for App {
                         engine.scroll_viewport_with_cursor(dir, scroll_count);
                     } else {
                         let dir = if delta_y > 0.0 { 1 } else { -1 };
-                        engine.scroll_viewport_with_cursor_for_window(
-                            target, dir, scroll_count,
-                        );
+                        engine.scroll_viewport_with_cursor_for_window(target, dir, scroll_count);
                     }
                     engine.sync_scroll_binds();
                 }
@@ -7163,30 +7161,22 @@ impl App {
                     }
                 } else {
                     // Header row — dispatch through cached toolbar hit regions.
-                    use crate::core::engine::TerminalToolbarAction;
-                    match self.engine.borrow().resolve_terminal_toolbar_click(x) {
-                        TerminalToolbarAction::SwitchTab(idx) => {
-                            sender.input(Msg::TerminalSwitchTab(idx));
-                        }
-                        TerminalToolbarAction::CloseTab => {
-                            sender.input(Msg::TerminalCloseActiveTab);
-                        }
-                        TerminalToolbarAction::ToggleMaximize => {
-                            sender.input(Msg::ToggleTerminalMaximize);
-                        }
-                        TerminalToolbarAction::ToggleSplit => {
-                            sender.input(Msg::TerminalToggleSplit);
-                        }
-                        TerminalToolbarAction::AddTab => {
-                            sender.input(Msg::NewTerminalTab);
-                        }
-                        TerminalToolbarAction::CloseFindBar => {
-                            self.engine.borrow_mut().terminal_find_active = false;
-                        }
-                        TerminalToolbarAction::StartResize => {
+                    let action = self.engine.borrow().resolve_terminal_toolbar_click(x);
+                    let ctx = crate::core::engine::UiEventContext {
+                        terminal_cols: self.terminal_cols(),
+                        terminal_max_rows: self.terminal_target_maximize_rows(),
+                    };
+                    if !self
+                        .engine
+                        .borrow_mut()
+                        .execute_terminal_toolbar_action(action, ctx)
+                    {
+                        if matches!(
+                            action,
+                            crate::core::engine::TerminalToolbarAction::StartResize
+                        ) {
                             self.terminal_resize_dragging = true;
                         }
-                        TerminalToolbarAction::None => {}
                     }
                 }
                 self.draw_needed.set(true);

--- a/src/render.rs
+++ b/src/render.rs
@@ -3601,7 +3601,11 @@ pub fn dialog_panel_to_quadraui_dialog(panel: &DialogPanel) -> quadraui::Dialog 
         title: quadraui::StyledText::plain(panel.title.clone()),
         // Body is multi-line — join with newlines. Backends split on
         // `\n` when rendering.
-        body: panel.body.iter().map(|l| quadraui::StyledText::plain(l.clone())).collect(),
+        body: panel
+            .body
+            .iter()
+            .map(|l| quadraui::StyledText::plain(l.clone()))
+            .collect(),
         buttons,
         severity: None,
         vertical_buttons: panel.vertical_buttons,

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -1401,7 +1401,9 @@ pub(super) fn handle_mouse(
                                 if let Some(rw) = target {
                                     let dir = if down { 1 } else { -1 };
                                     engine.scroll_viewport_with_cursor_for_window(
-                                        rw.window_id, dir, step,
+                                        rw.window_id,
+                                        dir,
+                                        step,
                                     );
                                     engine.sync_scroll_binds();
                                 }
@@ -1417,7 +1419,11 @@ pub(super) fn handle_mouse(
             // "tui:editor_viewport" surface above — fallback to active window
             // for scroll events that don't hit any registered surface.
             if col >= editor_left && row + 2 < term_height {
-                let dir = if matches!(ev.kind, MouseEventKind::ScrollUp) { -1 } else { 1 };
+                let dir = if matches!(ev.kind, MouseEventKind::ScrollUp) {
+                    -1
+                } else {
+                    1
+                };
                 engine.scroll_viewport_with_cursor(dir, 3);
                 engine.sync_scroll_binds();
             }
@@ -2164,39 +2170,19 @@ pub(super) fn handle_mouse(
             if row == term_strip_top {
                 // Header row — dispatch through cached toolbar hit regions.
                 engine.terminal_has_focus = true;
-                use crate::core::engine::TerminalToolbarAction;
-                match engine.resolve_terminal_toolbar_click(col as f64) {
-                    TerminalToolbarAction::SwitchTab(idx) => {
-                        engine.terminal_switch_tab(idx);
-                    }
-                    TerminalToolbarAction::CloseTab => {
-                        engine.terminal_close_active_tab();
-                    }
-                    TerminalToolbarAction::ToggleMaximize => {
-                        let screen_h = terminal_size.map(|s| s.height).unwrap_or(24);
-                        let full_cols = terminal_size.map(|s| s.width).unwrap_or(80);
-                        engine.toggle_terminal_maximize();
-                        let target = super::terminal_target_maximize_rows_tui(engine, screen_h);
-                        let effective = engine.effective_terminal_panel_rows(target);
-                        engine.terminal_resize(full_cols, effective);
-                    }
-                    TerminalToolbarAction::ToggleSplit => {
-                        let full_cols = terminal_size.map(|s| s.width).unwrap_or(80);
-                        let rows = engine.session.terminal_panel_rows;
-                        engine.terminal_toggle_split(full_cols, rows);
-                    }
-                    TerminalToolbarAction::AddTab => {
-                        let cols = terminal_size.map(|s| s.width).unwrap_or(80);
-                        let rows = engine.session.terminal_panel_rows;
-                        engine.terminal_new_tab(cols, rows);
-                    }
-                    TerminalToolbarAction::CloseFindBar => {
-                        engine.terminal_find_active = false;
-                    }
-                    TerminalToolbarAction::StartResize => {
+                let action = engine.resolve_terminal_toolbar_click(col as f64);
+                let screen_h = terminal_size.map(|s| s.height).unwrap_or(24);
+                let ctx = crate::core::engine::UiEventContext {
+                    terminal_cols: terminal_size.map(|s| s.width).unwrap_or(80),
+                    terminal_max_rows: super::terminal_target_maximize_rows_tui(engine, screen_h),
+                };
+                if !engine.execute_terminal_toolbar_action(action, ctx) {
+                    if matches!(
+                        action,
+                        crate::core::engine::TerminalToolbarAction::StartResize
+                    ) {
                         *dragging_terminal_resize = true;
                     }
-                    TerminalToolbarAction::None => {}
                 }
             } else {
                 // Content row — focus split pane or start divider drag.

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -1077,7 +1077,9 @@ pub(super) fn build_quit_confirm_dialog(
     let dialog = quadraui::Dialog {
         id: quadraui::WidgetId::new("quit_confirm"),
         title: quadraui::StyledText::plain("Unsaved Changes"),
-        body: vec![quadraui::StyledText::plain("You have unsaved changes. Quit anyway?")],
+        body: vec![quadraui::StyledText::plain(
+            "You have unsaved changes. Quit anyway?",
+        )],
         buttons: vec![
             quadraui::DialogButton {
                 id: quadraui::WidgetId::new("quit:save_all"),
@@ -1133,7 +1135,9 @@ pub(super) fn build_close_tab_dialog(
     let dialog = quadraui::Dialog {
         id: quadraui::WidgetId::new("close_tab_confirm"),
         title: quadraui::StyledText::plain("Unsaved Changes"),
-        body: vec![quadraui::StyledText::plain("This file has unsaved changes.")],
+        body: vec![quadraui::StyledText::plain(
+            "This file has unsaved changes.",
+        )],
         buttons: vec![
             quadraui::DialogButton {
                 id: quadraui::WidgetId::new("close_tab:save"),


### PR DESCRIPTION
## Summary

- Adds `Engine::execute_terminal_toolbar_action(action, ctx)` in `terminal_ops.rs` — handles all `TerminalToolbarAction` variants except `StartResize` (backend-local drag state) and `None`
- Both TUI and GTK click handlers replaced: ~30 lines of duplicated match dispatch → ~8 lines each
- Includes `cargo fmt` fixes for pre-existing formatting drift in 4 other files

Closes #383

## Test plan

- [ ] GTK: open terminal panel, click each toolbar button (new tab, split, maximize, close, switch tabs)
- [ ] TUI: same toolbar button clicks
- [ ] Verify `StartResize` drag still works (drag the terminal panel resize handle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)