### PR TITLE
refactor: extract Engine::check_settings_reload (#376)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2381,6 +2381,10 @@ pub struct Engine {
     // --- Settings ---
     /// Editor settings (line numbers, etc.)
     pub settings: Settings,
+    /// mtime of settings.json at last check — poll-based reload detection.
+    settings_mtime: Option<std::time::SystemTime>,
+    /// save_revision at last check — distinguishes self-saves from external edits.
+    settings_save_revision: u64,
 
     // --- Session state (history, window geometry, etc.) ---
     /// Session state persisted across restarts
@@ -3399,6 +3403,13 @@ impl Engine {
                 Settings::ensure_exists().ok();
                 Settings::load()
             },
+            settings_mtime: {
+                let path = Settings::settings_file_path();
+                std::fs::metadata(&path)
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+            },
+            settings_save_revision: crate::core::settings::save_revision(),
             session: SessionState::load(),
             history: HistoryState::load(),
             command_history_index: None,
@@ -4107,6 +4118,35 @@ impl Engine {
                     self.terminal_resize(ctx.terminal_cols, effective);
                 }
             }
+        }
+    }
+
+    /// Poll settings.json for changes and reload if modified externally.
+    /// Returns `true` if settings were reloaded (caller should redraw).
+    /// Self-saves (`:set`, settings panel) are detected via save_revision
+    /// and skipped.
+    pub fn check_settings_reload(&mut self) -> bool {
+        let path = Settings::settings_file_path();
+        let mtime = std::fs::metadata(&path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+        if mtime.is_none() || mtime == self.settings_mtime {
+            return false;
+        }
+        self.settings_mtime = mtime;
+        let cur_rev = crate::core::settings::save_revision();
+        let is_self_save = cur_rev != self.settings_save_revision;
+        self.settings_save_revision = cur_rev;
+        if is_self_save {
+            return false;
+        }
+        if let Ok(new_settings) = Settings::load_with_validation() {
+            self.settings = new_settings;
+            self.ensure_spell_checker();
+            self.message = "Settings reloaded".to_string();
+            true
+        } else {
+            false
         }
     }
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -450,13 +450,6 @@ struct App {
     css_provider: gtk4::CssProvider,
     /// Colorscheme name at the time the CSS was last applied.
     last_colorscheme: String,
-    /// Save-revision of `settings.json` at the last GIO file-watcher event.
-    /// Compared against `core::settings::save_revision()` to tell self-saves
-    /// (SettingChanged from the panel, `:set` from the command line, anything
-    /// that calls `Settings::save`) apart from external edits. Self-saves
-    /// refresh the cached revision silently; external edits trigger reload +
-    /// the "Settings reloaded from disk" message.
-    settings_save_revision: u64,
     /// Active context-menu popover (explorer or tab). Kept alive so we can
     /// unparent it before creating a new one (avoids GTK CSS node assertions).
     active_ctx_popover: Rc<RefCell<Option<gtk4::PopoverMenu>>>,
@@ -2167,7 +2160,6 @@ impl SimpleComponent for App {
             menu_dd_line_height: menu_dd_lh.clone(),
             css_provider,
             last_colorscheme,
-            settings_save_revision: core::settings::save_revision(),
             active_ctx_popover: active_ctx_popover_ref.clone(),
             backend: backend.clone(),
         };
@@ -4630,28 +4622,7 @@ impl SimpleComponent for App {
                 self.draw_needed.set(true);
             }
             Msg::SettingsFileChanged => {
-                // If the save revision advanced since our last check, the
-                // file change came from us (SettingChanged, `:set`, etc.) —
-                // we already have the correct in-memory state. Refresh the
-                // cached revision and skip the reload + message.
-                let cur_rev = core::settings::save_revision();
-                if cur_rev != self.settings_save_revision {
-                    self.settings_save_revision = cur_rev;
-                    return;
-                }
-
-                // External edit: reload from disk.
-                // Use load_with_validation (not load) to avoid writing back to the file,
-                // which would trigger the watcher again and cause an infinite reload loop.
-                // Silently ignore errors — the file may be mid-write.
-                if let Ok(new_settings) = core::settings::Settings::load_with_validation() {
-                    let mut engine = self.engine.borrow_mut();
-                    engine.settings = new_settings;
-                    engine.ensure_spell_checker();
-                    engine.message = "Settings reloaded from disk".to_string();
-                    drop(engine);
-
-                    // Force redraw to apply new font/line number settings
+                if self.engine.borrow_mut().check_settings_reload() {
                     if let Some(drawing_area) = self.drawing_area.borrow().as_ref() {
                         drawing_area.queue_draw();
                     }
@@ -7170,13 +7141,12 @@ impl App {
                         .engine
                         .borrow_mut()
                         .execute_terminal_toolbar_action(action, ctx)
-                    {
-                        if matches!(
+                        && matches!(
                             action,
                             crate::core::engine::TerminalToolbarAction::StartResize
-                        ) {
-                            self.terminal_resize_dragging = true;
-                        }
+                        )
+                    {
+                        self.terminal_resize_dragging = true;
                     }
                 }
                 self.draw_needed.set(true);

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -13,7 +13,6 @@
     clippy::explicit_counter_loop
 )]
 
-use std::fs;
 use std::io::{self, Stdout, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -1127,14 +1126,6 @@ fn event_loop(
         .unwrap_or_else(Instant::now);
     // Auto-refresh sidebar to reflect external filesystem changes.
     let mut last_sidebar_refresh = Instant::now();
-    // mtime of settings.json at last check — used to auto-reload when user edits the file.
-    let mut settings_mtime: Option<std::time::SystemTime> = {
-        let path = crate::core::settings::Settings::settings_file_path();
-        fs::metadata(&path).ok().and_then(|m| m.modified().ok())
-    };
-    // Save-revision at last check — distinguishes self-saves (e.g. :set) from
-    // external edits, so the watcher doesn't overwrite :set's result message.
-    let mut settings_save_revision: u64 = crate::core::settings::save_revision();
     // Deadline to clear the yank highlight flash.
     let mut yank_hl_deadline: Option<Instant> = None;
     // Timestamp of the last Alt+t press (for tab switcher auto-confirm on timeout).
@@ -1452,30 +1443,8 @@ fn event_loop(
                 last_sidebar_refresh = Instant::now();
                 needs_redraw = true;
             }
-            // Auto-reload settings.json when its mtime changes.
-            {
-                let path = crate::core::settings::Settings::settings_file_path();
-                if let Ok(meta) = fs::metadata(&path) {
-                    if let Ok(mtime) = meta.modified() {
-                        let mtime_changed = settings_mtime != Some(mtime);
-                        if mtime_changed {
-                            settings_mtime = Some(mtime);
-                            let cur_rev = crate::core::settings::save_revision();
-                            let self_save = cur_rev != settings_save_revision;
-                            settings_save_revision = cur_rev;
-                            if !self_save {
-                                if let Ok(new_settings) =
-                                    crate::core::settings::Settings::load_with_validation()
-                                {
-                                    engine.settings = new_settings;
-                                    engine.ensure_spell_checker();
-                                    engine.message = "Settings reloaded".to_string();
-                                    needs_redraw = true;
-                                }
-                            }
-                        }
-                    }
-                }
+            if engine.check_settings_reload() {
+                needs_redraw = true;
             }
             // Run pending terminal commands (needs backend-supplied terminal size).
             if let Some(cmd) = engine.pending_terminal_command.take() {

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2176,13 +2176,13 @@ pub(super) fn handle_mouse(
                     terminal_cols: terminal_size.map(|s| s.width).unwrap_or(80),
                     terminal_max_rows: super::terminal_target_maximize_rows_tui(engine, screen_h),
                 };
-                if !engine.execute_terminal_toolbar_action(action, ctx) {
-                    if matches!(
+                if !engine.execute_terminal_toolbar_action(action, ctx)
+                    && matches!(
                         action,
                         crate::core::engine::TerminalToolbarAction::StartResize
-                    ) {
-                        *dragging_terminal_resize = true;
-                    }
+                    )
+                {
+                    *dragging_terminal_resize = true;
                 }
             } else {
                 // Content row — focus split pane or start divider drag.


### PR DESCRIPTION
## Summary

- Adds `Engine::check_settings_reload() -> bool` that encapsulates mtime polling, self-save detection (via `save_revision`), and `Settings::load_with_validation()` reload
- Engine now owns `settings_mtime` and `settings_save_revision` fields (moved from TUI local vars and GTK struct field)
- TUI: 23 lines of inline reload logic → 3 lines. GTK: 20 lines → 5 lines (keeps GTK-specific `queue_draw` + `RefreshFileTree`)
- Also collapses nested `if` from #383 to fix clippy lint

Closes #376

## Test plan

- [ ] TUI: externally edit `~/.config/vimcode/settings.json` — verify "Settings reloaded" message appears
- [ ] GTK: same external edit test
- [ ] Both: run `:set number` — verify no spurious "Settings reloaded" message (self-save detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)