### PR TITLE
refactor: GTK context menu uses shared handle_context_menu_key (#379)

### DIFF
--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -5318,62 +5318,24 @@ impl App {
             return;
         }
 
-        // Dismiss context menu on any key press (Escape, or j/k for nav, Enter to confirm).
+        // Context menu key dispatch — shared engine method handles nav, confirm, dismiss.
         if self.engine.borrow().context_menu.is_some() {
             let mut engine = self.engine.borrow_mut();
-            match key_name.as_str() {
-                "Escape" => {
-                    engine.close_context_menu();
-                    drop(engine);
-                    self.draw_needed.set(true);
-                    return;
+            let (consumed, _action) = engine.handle_context_menu_key(key_name.as_str());
+            if consumed {
+                let needs_refresh = engine.explorer_needs_refresh;
+                if needs_refresh {
+                    engine.explorer_needs_refresh = false;
                 }
-                "Return" => {
-                    let _act = engine.context_menu_confirm();
-                    let needs_refresh = engine.explorer_needs_refresh;
-                    if needs_refresh {
-                        engine.explorer_needs_refresh = false;
-                    }
-                    drop(engine);
-                    if needs_refresh {
-                        sender.input(Msg::RefreshFileTree);
-                    }
-                    self.draw_needed.set(true);
-                    return;
+                drop(engine);
+                if needs_refresh {
+                    sender.input(Msg::RefreshFileTree);
                 }
-                "j" | "Down" => {
-                    if let Some(ref mut cm) = engine.context_menu {
-                        let len = cm.items.len();
-                        if len > 0 {
-                            cm.selected = (cm.selected + 1) % len;
-                        }
-                    }
-                    drop(engine);
-                    self.draw_needed.set(true);
-                    return;
-                }
-                "k" | "Up" => {
-                    if let Some(ref mut cm) = engine.context_menu {
-                        let len = cm.items.len();
-                        if len > 0 {
-                            cm.selected = if cm.selected > 0 {
-                                cm.selected - 1
-                            } else {
-                                len - 1
-                            };
-                        }
-                    }
-                    drop(engine);
-                    self.draw_needed.set(true);
-                    return;
-                }
-                _ => {
-                    engine.close_context_menu();
-                    drop(engine);
-                    self.draw_needed.set(true);
-                    // Fall through to normal key handling
-                }
+                self.draw_needed.set(true);
+                return;
             }
+            drop(engine);
+            self.draw_needed.set(true);
         }
 
         // Dismiss any panel hover popup on key press.


### PR DESCRIPTION
## Summary

- GTK context menu key handler replaced: ~55 lines of inline j/k/Up/Down/Return/Escape dispatch → 13 lines calling the existing `engine.handle_context_menu_key()`
- Fixes GTK missing disabled-item skipping on j/k navigation (TUI already had this via the engine method)
- Post-confirm `explorer_needs_refresh` → `Msg::RefreshFileTree` handling preserved

Closes #379

## Test plan

- [ ] GTK: right-click a file in explorer → use j/k/Up/Down to navigate, Enter to confirm, Escape to dismiss
- [ ] GTK: right-click a tab → same key navigation test
- [ ] GTK: verify disabled context menu items are skipped when navigating with j/k

🤖 Generated with [Claude Code](https://claude.com/claude-code)