### PR TITLE
refactor: SC button hover uses shared hit-test (#388)

### DIFF
--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -8869,17 +8869,7 @@ impl App {
                     let margin = 4.0;
                     let btn_w = da_w - margin * 2.0;
                     let rel_x = mx - margin;
-                    if rel_x < 0.0 || rel_x >= btn_w {
-                        engine.sc_button_hovered = None;
-                    } else {
-                        let commit_w = btn_w / 2.0;
-                        engine.sc_button_hovered = Some(if rel_x < commit_w {
-                            0
-                        } else {
-                            let icon_w = (btn_w - commit_w) / 3.0;
-                            ((1.0 + (rel_x - commit_w) / icon_w) as usize).min(3)
-                        });
-                    }
+                    engine.sc_button_hovered = Engine::sc_button_hit_test(rel_x, btn_w);
                 } else {
                     engine.sc_button_hovered = None;
                 }

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -1588,14 +1588,8 @@ pub(super) fn handle_mouse(
             let btn_row = 1 + commit_rows + 1; // header + commit + pad_above
             if sidebar_row == btn_row {
                 let rel_col = col.saturating_sub(ab_width);
-                let commit_w = sidebar_width / 2;
-                let btn_idx = if rel_col < commit_w {
-                    0
-                } else {
-                    let icon_w = (sidebar_width - commit_w) / 3;
-                    (1 + ((rel_col - commit_w) / icon_w.max(1))).min(3) as usize
-                };
-                engine.sc_button_hovered = Some(btn_idx);
+                engine.sc_button_hovered =
+                    Engine::sc_button_hit_test(rel_col as f64, sidebar_width as f64);
             } else {
                 engine.sc_button_hovered = None;
                 // SC item hover dwell tracking (sections area).


### PR DESCRIPTION
## Summary

- TUI and GTK SC button hover handlers reimplemented the `commit_w/icon_w` layout formula inline (~7 lines each). Now they call the existing `Engine::sc_button_hit_test()` that click handlers already used.
- Eliminates render/hit-test layout drift risk — one formula, one place.
- Net -16 lines.

Closes #388

## Test plan

- [ ] TUI: hover over SC commit/push/pull/fetch buttons — verify hover highlight tracks correctly
- [ ] GTK: same hover test
- [ ] Both: click each button — verify correct action fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)