### PR TITLE
fix: picker scroll uses actual visible rows instead of hardcoded 20

### DIFF
--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -681,14 +681,20 @@ pub(super) fn handle_mouse(
                 drag_state.end();
             }
             MouseEventKind::ScrollDown => {
-                // Check if scroll is over the preview pane (right side).
                 let term_cols = terminal_size.map(|s| s.width).unwrap_or(80);
+                let term_rows = terminal_size.map(|s| s.height).unwrap_or(24);
                 let has_preview = engine.picker_preview.is_some();
                 let popup_w = if has_preview {
                     (term_cols * 4 / 5).max(60)
                 } else {
                     (term_cols * 55 / 100).max(55)
                 };
+                let popup_h = if has_preview {
+                    (term_rows * 65 / 100).max(18)
+                } else {
+                    (term_rows * 60 / 100).max(16)
+                };
+                let visible_rows = popup_h.saturating_sub(4) as usize;
                 let popup_x = (term_cols.saturating_sub(popup_w)) / 2;
                 let left_w = if has_preview {
                     (popup_w as usize * 35 / 100) as u16
@@ -696,7 +702,6 @@ pub(super) fn handle_mouse(
                     0
                 };
                 if has_preview && col > popup_x + left_w {
-                    // Scroll the preview pane.
                     let max = engine
                         .picker_preview
                         .as_ref()
@@ -705,17 +710,24 @@ pub(super) fn handle_mouse(
                     engine.picker_preview_scroll =
                         (engine.picker_preview_scroll + 3).min(max.saturating_sub(1));
                 } else {
-                    engine.picker_scroll(3, 20);
+                    engine.picker_scroll(3, visible_rows);
                 }
             }
             MouseEventKind::ScrollUp => {
                 let term_cols = terminal_size.map(|s| s.width).unwrap_or(80);
+                let term_rows = terminal_size.map(|s| s.height).unwrap_or(24);
                 let has_preview = engine.picker_preview.is_some();
                 let popup_w = if has_preview {
                     (term_cols * 4 / 5).max(60)
                 } else {
                     (term_cols * 55 / 100).max(55)
                 };
+                let popup_h = if has_preview {
+                    (term_rows * 65 / 100).max(18)
+                } else {
+                    (term_rows * 60 / 100).max(16)
+                };
+                let visible_rows = popup_h.saturating_sub(4) as usize;
                 let popup_x = (term_cols.saturating_sub(popup_w)) / 2;
                 let left_w = if has_preview {
                     (popup_w as usize * 35 / 100) as u16
@@ -725,7 +737,7 @@ pub(super) fn handle_mouse(
                 if has_preview && col > popup_x + left_w {
                     engine.picker_preview_scroll = engine.picker_preview_scroll.saturating_sub(3);
                 } else {
-                    engine.picker_scroll(-3, 20);
+                    engine.picker_scroll(-3, visible_rows);
                 }
             }
             _ => {} // consume all other events


### PR DESCRIPTION
## Summary

- Replaced hardcoded `visible_rows=20` in TUI picker mouse-wheel scroll handlers with the actual computed value from terminal geometry (`popup_h - 4`)
- Fixes selection highlight disappearing when scrolling down in the fuzzy finder on smaller terminals

Closes #391

## Test plan

- [x] Open Ctrl+P with many files, mouse-wheel scroll down/up — highlight stays visible
- [x] Resize terminal to ~20–25 rows and repeat — highlight stays visible
- [x] Preview pane scroll still works (mouse-wheel over right side scrolls preview)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --no-default-features` passes (6 pre-existing z-command failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)