### PR TITLE
refactor: extract PickerGeometry to deduplicate popup layout formulas

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -1733,50 +1733,29 @@ pub(super) fn draw_picker_popup(
     };
 
     let has_preview = picker.preview.is_some();
+    let geo = render::PickerGeometry::compute(
+        editor_width as f32,
+        editor_height as f32,
+        has_preview,
+        &render::gtk_picker_sizing(line_height as f32),
+    );
+    let popup_x = geo.popup_x as f64;
+    let popup_y = geo.popup_y as f64;
+    let popup_w = geo.popup_w as f64;
+    let popup_h = geo.popup_h as f64;
 
-    // Phase A.4b migration: flat-list palettes (no preview pane, no tree
-    // depth) render through the shared `quadraui::Palette` primitive.
-    // File and symbol pickers fall through to the legacy renderer below
-    // because the primitive doesn't carry preview / tree indent yet.
-    //
-    // Phase B.5b Stage 8: route through `Backend::draw_palette` instead
-    // of the direct `quadraui_gtk::draw_palette` shim.
     if let Some(palette) = render::picker_panel_to_palette(picker) {
-        let popup_w = (editor_width * 0.55).max(500.0);
-        let popup_h = (editor_height * 0.60).max(350.0);
-        let popup_x = (editor_width - popup_w) / 2.0;
-        let popup_y = (editor_height - popup_h) / 2.0;
         use quadraui::Backend;
         backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
             b.set_current_theme(super::quadraui_gtk::q_theme(theme));
             b.set_current_line_height(line_height);
             b.draw_palette(
-                quadraui::Rect::new(
-                    popup_x as f32,
-                    popup_y as f32,
-                    popup_w as f32,
-                    popup_h as f32,
-                ),
+                quadraui::Rect::new(geo.popup_x, geo.popup_y, geo.popup_w, geo.popup_h),
                 &palette,
             );
         });
         return;
     }
-
-    // Size adapts based on whether we have a preview pane
-    let popup_w = if has_preview {
-        (editor_width * 0.8).max(600.0)
-    } else {
-        (editor_width * 0.55).max(500.0)
-    };
-    let popup_h = if has_preview {
-        (editor_height * 0.65).max(400.0)
-    } else {
-        (editor_height * 0.60).max(350.0)
-    };
-
-    let popup_x = (editor_width - popup_w) / 2.0;
-    let popup_y = (editor_height - popup_h) / 2.0;
 
     // Background
     let (r, g, b) = theme.fuzzy_bg.to_cairo();
@@ -1823,18 +1802,20 @@ pub(super) fn draw_picker_popup(
     cr.line_to(popup_x + popup_w, sep_y);
     cr.stroke().ok();
 
-    // Two-pane layout
-    let left_pane_w = if has_preview { popup_w * 0.4 } else { popup_w };
+    let left_pane_w = if has_preview {
+        geo.left_pane_w as f64
+    } else {
+        popup_w
+    };
 
     if has_preview {
-        // Vertical separator
         cr.move_to(popup_x + left_pane_w, sep_y);
         cr.line_to(popup_x + left_pane_w, popup_y + popup_h);
         cr.stroke().ok();
     }
 
     let rows_area_h = popup_h - 2.0 * line_height - 2.0;
-    let visible_rows = (rows_area_h / line_height) as usize;
+    let visible_rows = geo.visible_rows;
 
     // Scrollbar geometry (single-pane only)
     let total_items = picker.items.len();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -7421,19 +7421,18 @@ impl App {
         let engine = self.engine.borrow();
         let has_preview = engine.picker_preview.is_some();
         drop(engine);
-        let popup_w = if has_preview {
-            (width * 0.8).max(600.0)
-        } else {
-            (width * 0.55).max(500.0)
+        let sizing = render::PickerSizing {
+            header_h: 0.0,
+            line_h: 1.0,
+            ..render::gtk_picker_sizing(1.0)
         };
-        let popup_h = if has_preview {
-            (height * 0.65).max(400.0)
-        } else {
-            (height * 0.60).max(350.0)
-        };
-        let popup_x = (width - popup_w) / 2.0;
-        let popup_y = (height - popup_h) / 2.0;
-        (popup_x, popup_y, popup_w, popup_h)
+        let geo = render::PickerGeometry::compute(width as f32, height as f32, has_preview, &sizing);
+        (
+            geo.popup_x as f64,
+            geo.popup_y as f64,
+            geo.popup_w as f64,
+            geo.popup_h as f64,
+        )
     }
 
     fn handle_mouse_drag_msg(&mut self, x: f64, y: f64, width: f64, height: f64) {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1342,6 +1342,82 @@ pub struct PickerPanel {
     pub preview_scroll: usize,
 }
 
+// ─── PickerGeometry ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+pub struct PickerSizing {
+    pub min_w: (f32, f32),
+    pub min_h: (f32, f32),
+    pub left_pane_ratio: f32,
+    pub header_h: f32,
+    pub line_h: f32,
+}
+
+pub const TUI_PICKER_SIZING: PickerSizing = PickerSizing {
+    min_w: (55.0, 60.0),
+    min_h: (16.0, 18.0),
+    left_pane_ratio: 0.35,
+    header_h: 4.0,
+    line_h: 1.0,
+};
+
+pub fn gtk_picker_sizing(line_height: f32) -> PickerSizing {
+    PickerSizing {
+        min_w: (500.0, 600.0),
+        min_h: (350.0, 400.0),
+        left_pane_ratio: 0.40,
+        header_h: 2.0 * line_height + 2.0,
+        line_h: line_height,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PickerGeometry {
+    pub popup_x: f32,
+    pub popup_y: f32,
+    pub popup_w: f32,
+    pub popup_h: f32,
+    pub left_pane_w: f32,
+    pub visible_rows: usize,
+}
+
+impl PickerGeometry {
+    pub fn compute(
+        viewport_w: f32,
+        viewport_h: f32,
+        has_preview: bool,
+        sizing: &PickerSizing,
+    ) -> Self {
+        let popup_w = if has_preview {
+            (viewport_w * 0.8).max(sizing.min_w.1)
+        } else {
+            (viewport_w * 0.55).max(sizing.min_w.0)
+        };
+        let popup_h = if has_preview {
+            (viewport_h * 0.65).max(sizing.min_h.1)
+        } else {
+            (viewport_h * 0.60).max(sizing.min_h.0)
+        };
+        let popup_x = (viewport_w - popup_w) / 2.0;
+        let popup_y = (viewport_h - popup_h) / 2.0;
+        let left_pane_w = if has_preview {
+            popup_w * sizing.left_pane_ratio
+        } else {
+            0.0
+        };
+        let results_h = (popup_h - sizing.header_h).max(0.0);
+        let visible_rows = (results_h / sizing.line_h) as usize;
+        PickerGeometry {
+            popup_x,
+            popup_y,
+            popup_w,
+            popup_h,
+            left_pane_w,
+            visible_rows,
+        }
+    }
+}
+
 // ─── TabSwitcherPanel ─────────────────────────────────────────────────────
 
 /// Data needed to render the tab switcher popup (Ctrl+Tab MRU list).

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -541,21 +541,18 @@ pub(super) fn handle_mouse(
                 let term_cols = terminal_size.map(|s| s.width).unwrap_or(80);
                 let term_rows = terminal_size.map(|s| s.height).unwrap_or(24);
                 let has_preview = engine.picker_preview.is_some();
-                let popup_w = if has_preview {
-                    (term_cols * 4 / 5).max(60)
-                } else {
-                    (term_cols * 55 / 100).max(55)
-                };
-                let popup_h = if has_preview {
-                    (term_rows * 65 / 100).max(18)
-                } else {
-                    (term_rows * 60 / 100).max(16)
-                };
-                let popup_x = (term_cols.saturating_sub(popup_w)) / 2;
-                let popup_y = (term_rows.saturating_sub(popup_h)) / 2;
+                let geo = render::PickerGeometry::compute(
+                    term_cols as f32,
+                    term_rows as f32,
+                    has_preview,
+                    &render::TUI_PICKER_SIZING,
+                );
+                let popup_x = geo.popup_x as u16;
+                let popup_y = geo.popup_y as u16;
+                let popup_w = geo.popup_w as u16;
                 let results_start = popup_y + 3;
-                let results_end = popup_y + popup_h - 1;
-                let visible_rows = results_end.saturating_sub(results_start) as usize;
+                let results_end = results_start + geo.visible_rows as u16;
+                let visible_rows = geo.visible_rows;
                 let total_items = engine.picker_items.len();
 
                 // Phase B.4: route the click through quadraui's modal
@@ -570,10 +567,10 @@ pub(super) fn handle_mouse(
                 modal_stack.push(
                     picker_id.clone(),
                     quadraui::Rect {
-                        x: popup_x as f32,
-                        y: popup_y as f32,
-                        width: popup_w as f32,
-                        height: popup_h as f32,
+                        x: geo.popup_x,
+                        y: geo.popup_y,
+                        width: geo.popup_w,
+                        height: geo.popup_h,
                     },
                 );
                 let events = quadraui::dispatch_mouse_down(
@@ -680,64 +677,35 @@ pub(super) fn handle_mouse(
             MouseEventKind::Up(MouseButton::Left) => {
                 drag_state.end();
             }
-            MouseEventKind::ScrollDown => {
+            MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
                 let term_cols = terminal_size.map(|s| s.width).unwrap_or(80);
                 let term_rows = terminal_size.map(|s| s.height).unwrap_or(24);
                 let has_preview = engine.picker_preview.is_some();
-                let popup_w = if has_preview {
-                    (term_cols * 4 / 5).max(60)
-                } else {
-                    (term_cols * 55 / 100).max(55)
-                };
-                let popup_h = if has_preview {
-                    (term_rows * 65 / 100).max(18)
-                } else {
-                    (term_rows * 60 / 100).max(16)
-                };
-                let visible_rows = popup_h.saturating_sub(4) as usize;
-                let popup_x = (term_cols.saturating_sub(popup_w)) / 2;
-                let left_w = if has_preview {
-                    (popup_w as usize * 35 / 100) as u16
-                } else {
-                    0
-                };
+                let geo = render::PickerGeometry::compute(
+                    term_cols as f32,
+                    term_rows as f32,
+                    has_preview,
+                    &render::TUI_PICKER_SIZING,
+                );
+                let popup_x = geo.popup_x as u16;
+                let left_w = geo.left_pane_w as u16;
+                let scroll_down = matches!(ev.kind, MouseEventKind::ScrollDown);
                 if has_preview && col > popup_x + left_w {
-                    let max = engine
-                        .picker_preview
-                        .as_ref()
-                        .map(|p| p.lines.len())
-                        .unwrap_or(0);
-                    engine.picker_preview_scroll =
-                        (engine.picker_preview_scroll + 3).min(max.saturating_sub(1));
+                    if scroll_down {
+                        let max = engine
+                            .picker_preview
+                            .as_ref()
+                            .map(|p| p.lines.len())
+                            .unwrap_or(0);
+                        engine.picker_preview_scroll =
+                            (engine.picker_preview_scroll + 3).min(max.saturating_sub(1));
+                    } else {
+                        engine.picker_preview_scroll =
+                            engine.picker_preview_scroll.saturating_sub(3);
+                    }
                 } else {
-                    engine.picker_scroll(3, visible_rows);
-                }
-            }
-            MouseEventKind::ScrollUp => {
-                let term_cols = terminal_size.map(|s| s.width).unwrap_or(80);
-                let term_rows = terminal_size.map(|s| s.height).unwrap_or(24);
-                let has_preview = engine.picker_preview.is_some();
-                let popup_w = if has_preview {
-                    (term_cols * 4 / 5).max(60)
-                } else {
-                    (term_cols * 55 / 100).max(55)
-                };
-                let popup_h = if has_preview {
-                    (term_rows * 65 / 100).max(18)
-                } else {
-                    (term_rows * 60 / 100).max(16)
-                };
-                let visible_rows = popup_h.saturating_sub(4) as usize;
-                let popup_x = (term_cols.saturating_sub(popup_w)) / 2;
-                let left_w = if has_preview {
-                    (popup_w as usize * 35 / 100) as u16
-                } else {
-                    0
-                };
-                if has_preview && col > popup_x + left_w {
-                    engine.picker_preview_scroll = engine.picker_preview_scroll.saturating_sub(3);
-                } else {
-                    engine.picker_scroll(-3, visible_rows);
+                    let delta = if scroll_down { 3 } else { -3 };
+                    engine.picker_scroll(delta, geo.visible_rows);
                 }
             }
             _ => {} // consume all other events

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -1418,32 +1418,21 @@ pub(super) fn render_picker_popup(
     theme: &Theme,
     backend: &mut super::backend::TuiBackend,
 ) {
-    let term_cols = term_area.width;
-    let term_rows = term_area.height;
     let has_preview = picker.preview.is_some();
+    let geo = render::PickerGeometry::compute(
+        term_area.width as f32,
+        term_area.height as f32,
+        has_preview,
+        &render::TUI_PICKER_SIZING,
+    );
+    let x = geo.popup_x as u16;
+    let y = geo.popup_y as u16;
+    let width = geo.popup_w as u16;
+    let height = geo.popup_h as u16;
+    let left_w = geo.left_pane_w as u16;
 
-    // Phase A.4 migration: flat-list palettes (no preview pane, no tree
-    // depth) render through the shared `quadraui::Palette` primitive.
-    // File and symbol pickers fall through to the legacy renderer below
-    // because the primitive doesn't carry preview / tree indent yet.
     if let Some(palette) = render::picker_panel_to_palette(picker) {
-        let width = (term_cols * 55 / 100).max(55);
-        let height = (term_rows * 60 / 100).max(16);
-        let x = (term_cols.saturating_sub(width)) / 2;
-        let y = (term_rows.saturating_sub(height)) / 2;
-        let area = Rect {
-            x,
-            y,
-            width,
-            height,
-        };
-        // Phase B.4 Stage 2: route through `Backend::draw_palette`.
-        let q_rect = quadraui::Rect::new(
-            area.x as f32,
-            area.y as f32,
-            area.width as f32,
-            area.height as f32,
-        );
+        let q_rect = quadraui::Rect::new(geo.popup_x, geo.popup_y, geo.popup_w, geo.popup_h);
         backend.set_current_theme(super::quadraui_tui::q_theme(theme));
         backend.enter_frame_scope(frame, |b| {
             use quadraui::Backend;
@@ -1451,21 +1440,6 @@ pub(super) fn render_picker_popup(
         });
         return;
     }
-
-    // Size adapts based on whether we have a preview pane
-    let width = if has_preview {
-        (term_cols * 4 / 5).max(60)
-    } else {
-        (term_cols * 55 / 100).max(55)
-    };
-    let height = if has_preview {
-        (term_rows * 65 / 100).max(18)
-    } else {
-        (term_rows * 60 / 100).max(16)
-    };
-
-    let x = (term_cols.saturating_sub(width)) / 2;
-    let y = (term_rows.saturating_sub(height)) / 2;
 
     let bg_color = rc(theme.fuzzy_bg);
     let sel_bg_color = rc(theme.fuzzy_selected_bg);
@@ -1477,8 +1451,6 @@ pub(super) fn render_picker_popup(
 
     let buf = frame.buffer_mut();
 
-    // Clear popup background so stale characters from previous content
-    // (e.g. cycling through files with different preview lengths) don't persist.
     for row in y..y + height {
         for col in x..x + width {
             if col < term_area.width && row < term_area.height {
@@ -1486,13 +1458,6 @@ pub(super) fn render_picker_popup(
             }
         }
     }
-
-    // Left pane width for two-pane mode
-    let left_w = if has_preview {
-        (width as usize * 35 / 100) as u16
-    } else {
-        0
-    };
 
     // Row 0: top border ╭─ Title ── N/M ──╮
     let title_text = format!(
@@ -1567,10 +1532,9 @@ pub(super) fn render_picker_popup(
         }
     }
 
-    // Result rows
     let results_start = y + 3;
-    let results_end = y + height - 1;
-    let visible_rows = (results_end.saturating_sub(results_start)) as usize;
+    let results_end = results_start + geo.visible_rows as u16;
+    let visible_rows = geo.visible_rows;
 
     // Determine effective item width for the left pane
     let item_end_col = if has_preview { left_w } else { width - 1 };


### PR DESCRIPTION
## Summary

- Added `PickerGeometry` struct + `PickerSizing` config in `render.rs` — single source of truth for picker popup bounds, left-pane split, and visible_rows
- Replaced 5 independent geometry computations across TUI render, TUI click, TUI scroll, GTK render, and GTK mouse with calls to `PickerGeometry::compute()`
- Merged TUI ScrollDown/ScrollUp picker handlers into one match arm
- Net -12 lines

Closes #401

## Test plan

- [x] TUI: Ctrl+P file picker — sizing, scroll, click all work
- [x] GTK: Ctrl+P file picker — sizing, scroll, click all work
- [x] Preview pane split renders correctly in both backends
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --no-default-features` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)