### PR TITLE
fix: unify completion popup click behavior across backends (#288)

### DIFF
--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -3200,6 +3200,26 @@ impl Engine {
         self.view_mut().cursor.col = start + candidate.len();
     }
 
+    /// Handle a mouse click on the completion popup.
+    /// Returns `true` if the click was consumed (inside the popup).
+    pub fn handle_completion_click(&mut self, hit: quadraui::CompletionsHit) -> bool {
+        match hit {
+            quadraui::CompletionsHit::Item(idx) => {
+                self.apply_completion_candidate(idx);
+                self.dismiss_completion();
+                true
+            }
+            quadraui::CompletionsHit::Inert => {
+                self.dismiss_completion();
+                true
+            }
+            quadraui::CompletionsHit::Empty => {
+                self.dismiss_completion();
+                false
+            }
+        }
+    }
+
     /// Dismiss the completion popup and cancel any pending LSP completion request.
     /// This ensures that a late-arriving LSP response cannot re-show a popup
     /// after the user has already dismissed it (e.g. by pressing Escape or

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -52,7 +52,7 @@ pub(super) fn draw_editor(
     dialog_btn_rects_out: &Rc<RefCell<DialogBtnRects>>,
     dialog_popup_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
     editor_hover_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
-    completion_popup_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
+    completion_layout_out: &Rc<RefCell<Option<quadraui::CompletionsLayout>>>,
     tab_switcher_popup_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
     editor_hover_link_rects_out: &Rc<RefCell<Vec<(f64, f64, f64, f64, String)>>>,
     editor_hover_scrollbar_out: &Rc<Cell<Option<render::PopupScrollbarHit>>>,
@@ -370,16 +370,15 @@ pub(super) fn draw_editor(
     }
 
     // 5b. Draw completion popup (on top of everything else). Cache
-    //     the bounds so the click handler can register the popup on
-    //     the modal stack (B.5b Stage 5).
-    completion_popup_rect_out.set(draw_completion_popup(
+    //     the layout so the click handler can hit-test items.
+    *completion_layout_out.borrow_mut() = draw_completion_popup(
         cr,
         &layout,
         &screen,
         &theme,
         line_height,
         char_width,
-    ));
+    );
 
     // 5c. Draw hover popup (on top of everything else)
     draw_hover_popup(
@@ -1259,9 +1258,8 @@ pub(super) fn draw_window_separators(
 /// shared `render::completion_menu_to_quadraui_completions` adapter,
 /// computes the popup placement via `Completions::layout()`, then
 /// forwards to the lifted rasteriser through the
-/// `quadraui_gtk::draw_completions` shim. Returns the resolved popup
-/// bounds (x, y, w, h) so the existing `completion_popup_rect_out`
-/// integration keeps working unchanged.
+/// `quadraui_gtk::draw_completions` shim. Returns the resolved
+/// `CompletionsLayout` so the click handler can hit-test items.
 pub(super) fn draw_completion_popup(
     cr: &Context,
     layout: &pango::Layout,
@@ -1269,7 +1267,7 @@ pub(super) fn draw_completion_popup(
     theme: &Theme,
     line_height: f64,
     char_width: f64,
-) -> Option<(f64, f64, f64, f64)> {
+) -> Option<quadraui::CompletionsLayout> {
     let menu = screen.completion.as_ref()?;
     let active_win = screen
         .windows
@@ -1310,12 +1308,7 @@ pub(super) fn draw_completion_popup(
 
     super::quadraui_gtk::draw_completions(cr, layout, &completions, &q_layout, theme);
 
-    Some((
-        q_layout.bounds.x as f64,
-        q_layout.bounds.y as f64,
-        q_layout.bounds.width as f64,
-        q_layout.bounds.height as f64,
-    ))
+    Some(q_layout)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -405,11 +405,9 @@ struct App {
     /// Editor hover popup bounding rect (x, y, w, h) — set during draw, used for click hit-testing.
     #[allow(clippy::type_complexity)]
     editor_hover_popup_rect: Rc<Cell<Option<(f64, f64, f64, f64)>>>,
-    /// Completion popup bounding rect (x, y, w, h) — set during draw,
-    /// used for `ModalStack` registration in the click handler. None
-    /// when the popup isn't visible. (B.5b Stage 5.)
-    #[allow(clippy::type_complexity)]
-    completion_popup_rect: Rc<Cell<Option<(f64, f64, f64, f64)>>>,
+    /// Completion popup layout — set during draw, used for hit-test in
+    /// the click handler. None when the popup isn't visible.
+    completion_layout: Rc<RefCell<Option<quadraui::CompletionsLayout>>>,
     /// Tab-switcher popup bounding rect (x, y, w, h) — set during
     /// draw, used for `ModalStack` registration in the click
     /// handler. (B.5b Stage 7.)
@@ -1949,9 +1947,8 @@ impl SimpleComponent for App {
         #[allow(clippy::type_complexity)]
         let editor_hover_popup_rect: Rc<Cell<Option<(f64, f64, f64, f64)>>> =
             Rc::new(Cell::new(None));
-        #[allow(clippy::type_complexity)]
-        let completion_popup_rect: Rc<Cell<Option<(f64, f64, f64, f64)>>> =
-            Rc::new(Cell::new(None));
+        let completion_layout: Rc<RefCell<Option<quadraui::CompletionsLayout>>> =
+            Rc::new(RefCell::new(None));
         #[allow(clippy::type_complexity)]
         let tab_switcher_popup_rect: Rc<Cell<Option<(f64, f64, f64, f64)>>> =
             Rc::new(Cell::new(None));
@@ -2159,7 +2156,7 @@ impl SimpleComponent for App {
             panel_hover_link_rects: panel_hover_link_rects.clone(),
             panel_hover_popup_rect: panel_hover_popup_rect.clone(),
             editor_hover_popup_rect: editor_hover_popup_rect.clone(),
-            completion_popup_rect: completion_popup_rect.clone(),
+            completion_layout: completion_layout.clone(),
             tab_switcher_popup_rect: tab_switcher_popup_rect.clone(),
             dialog_popup_rect: dialog_popup_rect.clone(),
             editor_hover_link_rects: editor_hover_link_rects.clone(),
@@ -3614,7 +3611,7 @@ impl SimpleComponent for App {
         let dialog_btn_for_draw = model.dialog_btn_rects.clone();
         let dialog_popup_for_draw = model.dialog_popup_rect.clone();
         let editor_hover_rect_for_draw = model.editor_hover_popup_rect.clone();
-        let completion_rect_for_draw = model.completion_popup_rect.clone();
+        let completion_layout_for_draw = model.completion_layout.clone();
         let tab_switcher_rect_for_draw = model.tab_switcher_popup_rect.clone();
         let editor_hover_links_for_draw = model.editor_hover_link_rects.clone();
         let editor_hover_sb_for_draw = model.editor_hover_scrollbar.clone();
@@ -3655,7 +3652,7 @@ impl SimpleComponent for App {
                             &dialog_btn_for_draw,
                             &dialog_popup_for_draw,
                             &editor_hover_rect_for_draw,
-                            &completion_rect_for_draw,
+                            &completion_layout_for_draw,
                             &tab_switcher_rect_for_draw,
                             &editor_hover_links_for_draw,
                             &editor_hover_sb_for_draw,
@@ -6004,71 +6001,18 @@ impl App {
         // candidate-row pixel — clicking on the popup shouldn't move
         // the cursor through it. Click-OUTSIDE simply dismisses and
         // falls through; the editor click then proceeds normally.
-        //
-        // The popup is keyboard-driven (Tab to cycle, Enter to commit)
-        // so this stage doesn't add row-level click-to-select; the
-        // bounds registration on `ModalStack` exists so future
-        // `is_modal_open()` consumers (e.g. B5b.6 hover-trigger gate)
-        // see the popup correctly.
         if self.engine.borrow().completion_idx.is_some() {
-            let completion_id = quadraui::WidgetId::new("completion");
-            let inside = if let Some((px, py, pw, ph)) = self.completion_popup_rect.get() {
-                self.backend
-                    .borrow()
-                    .modal_stack_handle()
-                    .borrow_mut()
-                    .push(
-                        completion_id.clone(),
-                        quadraui::Rect {
-                            x: px as f32,
-                            y: py as f32,
-                            width: pw as f32,
-                            height: ph as f32,
-                        },
-                    );
-                let stack_rc = self.backend.borrow().modal_stack_handle();
-                let stack = stack_rc.borrow();
-                let events = quadraui::dispatch_mouse_down(
-                    &stack,
-                    quadraui::Point {
-                        x: x as f32,
-                        y: y as f32,
-                    },
-                    quadraui::MouseButton::Left,
-                    quadraui::Modifiers::default(),
-                );
-                events.iter().any(|ev| {
-                    matches!(
-                        ev,
-                        quadraui::UiEvent::MouseDown { widget: Some(id), .. }
-                            if *id == completion_id
-                    )
-                })
-            } else {
-                false
-            };
-
-            // Either way, dismiss the popup — it's transient.
-            self.engine.borrow_mut().dismiss_completion();
-            self.backend
+            let hit = self
+                .completion_layout
                 .borrow()
-                .modal_stack_handle()
-                .borrow_mut()
-                .pop(&completion_id);
-
-            if inside {
-                self.draw_needed.set(true);
+                .as_ref()
+                .map(|cl| cl.hit_test(x as f32, y as f32))
+                .unwrap_or(quadraui::CompletionsHit::Empty);
+            let consumed = self.engine.borrow_mut().handle_completion_click(hit);
+            self.draw_needed.set(true);
+            if consumed {
                 return;
             }
-            // Fall through so the editor's click (cursor move) proceeds.
-        } else {
-            // Defensive cleanup: completion may have been dismissed
-            // without us seeing a click. Pop any stale entry.
-            self.backend
-                .borrow()
-                .modal_stack_handle()
-                .borrow_mut()
-                .pop(&quadraui::WidgetId::new("completion"));
         }
 
         // ── Context menu click handling (engine-drawn) ──

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -1021,6 +1021,8 @@ fn event_loop(
     let mut editor_hover_link_rects: Vec<(u16, u16, u16, u16, String)> = Vec::new();
     // Scrollbar geometry for the editor hover popup (#215).
     let mut editor_hover_scrollbar: Option<render::PopupScrollbarHit> = None;
+    // Cached completion popup layout for mouse hit-testing (#288).
+    let mut completion_layout: Option<quadraui::CompletionsLayout> = None;
     // Track last draw time to cap frame rate at ~60 fps and keep CPU low.
     let min_frame = Duration::from_millis(16);
     let mut last_draw = Instant::now()
@@ -1180,6 +1182,7 @@ fn event_loop(
                             &mut tab_visible_counts,
                             &debug_toolbar_interaction,
                             &mut debug_toolbar_rect,
+                            &mut completion_layout,
                             &mut backend,
                         );
                     }
@@ -1230,6 +1233,7 @@ fn event_loop(
                                     &mut tab_visible_counts2,
                                     &debug_toolbar_interaction,
                                     &mut debug_toolbar_rect,
+                                    &mut completion_layout,
                                     &mut backend,
                                 );
                             }
@@ -2954,6 +2958,7 @@ fn event_loop(
                                 editor_hover_scrollbar,
                                 &mut hover_selecting,
                                 &mut fr_input_dragging,
+                                completion_layout.as_ref(),
                             );
 
                             if mouse_should_quit {
@@ -2999,6 +3004,7 @@ fn event_loop(
                     editor_hover_scrollbar,
                     &mut hover_selecting,
                     &mut fr_input_dragging,
+                    completion_layout.as_ref(),
                 );
 
                 if mouse_should_quit {

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -161,6 +161,7 @@ pub(super) fn handle_mouse(
     editor_hover_scrollbar: Option<crate::render::PopupScrollbarHit>,
     hover_selecting: &mut bool,
     fr_input_dragging: &mut bool,
+    completion_layout: Option<&quadraui::CompletionsLayout>,
 ) -> u16 {
     let col = ev.column;
     let row = ev.row;
@@ -1472,6 +1473,16 @@ pub(super) fn handle_mouse(
         }
 
         return sidebar_width;
+    }
+
+    // ── Completion popup click intercept ──────────────────────────────────────────
+    if engine.completion_idx.is_some() && ev.kind == MouseEventKind::Down(MouseButton::Left) {
+        let hit = completion_layout
+            .map(|cl| cl.hit_test(col as f32, row as f32))
+            .unwrap_or(quadraui::CompletionsHit::Empty);
+        if engine.handle_completion_click(hit) {
+            return sidebar_width;
+        }
     }
 
     // ── Context menu click intercept ────────────────────────────────────────────

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -108,6 +108,7 @@ pub(super) fn draw_frame(
     tab_visible_counts_out: &mut Vec<(GroupId, usize)>,
     debug_toolbar_interaction: &quadraui::StatusBarInteraction,
     debug_toolbar_rect_out: &mut quadraui::Rect,
+    completion_layout_out: &mut Option<quadraui::CompletionsLayout>,
     // Phase B.4 Stage 2: backend handle for migrated `draw_*` calls.
     // Set once per frame by the caller (cached theme); the migrated
     // call sites wrap their access in `backend.enter_frame_scope`.
@@ -486,6 +487,7 @@ pub(super) fn draw_frame(
                     &layout,
                     theme,
                 );
+                *completion_layout_out = Some(layout);
             }
         }
     }
@@ -1687,6 +1689,7 @@ mod tests {
         let mut tab_visible_counts: Vec<(GroupId, usize)> = Vec::new();
         let dbg_toolbar_interaction = quadraui::StatusBarInteraction::new();
         let mut dbg_toolbar_rect = quadraui::Rect::default();
+        let mut completion_layout = None;
         let mut backend = super::backend::TuiBackend::new();
 
         terminal
@@ -1710,6 +1713,7 @@ mod tests {
                     &mut tab_visible_counts,
                     &dbg_toolbar_interaction,
                     &mut dbg_toolbar_rect,
+                    &mut completion_layout,
                     &mut backend,
                 );
             })


### PR DESCRIPTION
## Summary

- Both GTK and TUI now use `CompletionsLayout::hit_test()` for click-to-pick: clicking a completion item accepts it, clicking inside but not on an item dismisses, clicking outside dismisses and falls through to the editor.
- New shared engine method `handle_completion_click(CompletionsHit) -> bool` encapsulates the logic.
- GTK: `completion_popup_rect` (bounds tuple) replaced with full `CompletionsLayout` cache; ModalStack push/pop/dispatch removed from completion click path.
- TUI: `CompletionsLayout` cached during render, click interception added to `handle_mouse` before context menu handler.
- Net -22 lines.

Closes #288

## Test plan

- [ ] GTK: open a Rust file, trigger completion, click on an item → should accept
- [ ] GTK: click inside popup border → should dismiss
- [ ] GTK: click outside popup on editor → should dismiss and move cursor
- [ ] TUI: same three tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)