### PR TITLE
fix: context menu click/hover uses cached ContextMenuLayout hit_test (#210)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -1176,6 +1176,7 @@ pub struct TabBarHitRegion {
 // ── Context menu hit regions ────────────────────────────────────────────────
 
 /// Result of resolving a click against a context menu popup.
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContextMenuClickResult {
     /// Click on a menu item at this index.
@@ -1186,6 +1187,20 @@ pub enum ContextMenuClickResult {
     Outside,
 }
 
+/// Parse a `ContextMenuHit::Item(id)` back to the engine-side item index.
+/// The adapter (`context_menu_panel_to_quadraui_context_menu`) synthesises
+/// ids as `"context:N"` where N is the engine index.
+pub fn context_menu_hit_to_idx(hit: &quadraui::ContextMenuHit) -> Option<usize> {
+    if let quadraui::ContextMenuHit::Item(id) = hit {
+        id.as_str()
+            .strip_prefix("context:")
+            .and_then(|s| s.parse::<usize>().ok())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
 /// Compute the context menu popup bounds and resolve a click position.
 ///
 /// `items` — the menu items (separator_after items add an extra visual row).

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -53,6 +53,7 @@ pub(super) fn draw_editor(
     dialog_popup_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
     editor_hover_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
     completion_layout_out: &Rc<RefCell<Option<quadraui::CompletionsLayout>>>,
+    context_menu_layout_out: &Rc<RefCell<Option<quadraui::ContextMenuLayout>>>,
     tab_switcher_popup_rect_out: &Rc<Cell<Option<(f64, f64, f64, f64)>>>,
     editor_hover_link_rects_out: &Rc<RefCell<Vec<(f64, f64, f64, f64, String)>>>,
     editor_hover_scrollbar_out: &Rc<Cell<Option<render::PopupScrollbarHit>>>,
@@ -902,7 +903,7 @@ pub(super) fn draw_editor(
     *dialog_btn_rects_out.borrow_mut() = btn_rects;
     dialog_popup_rect_out.set(popup_rect);
 
-    draw_context_menu_popup(
+    *context_menu_layout_out.borrow_mut() = draw_context_menu_popup(
         cr,
         &layout,
         &screen,
@@ -1914,12 +1915,12 @@ pub(super) fn draw_context_menu_popup(
     char_width: f64,
     line_height: f64,
     mouse_pos: (f64, f64),
-) {
+) -> Option<quadraui::ContextMenuLayout> {
     let Some(cm) = &screen.context_menu else {
-        return;
+        return None;
     };
     if cm.items.is_empty() {
-        return;
+        return None;
     }
 
     let pango_ctx = pangocairo::create_context(cr);
@@ -1974,6 +1975,8 @@ pub(super) fn draw_context_menu_popup(
     }
 
     super::quadraui_gtk::draw_context_menu(cr, &ui_layout, &menu, &menu_layout, line_height, theme);
+
+    Some(menu_layout)
 }
 
 /// Draw the tab bar for the bottom panel (Terminal / Debug Output) via

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -408,6 +408,9 @@ struct App {
     /// Completion popup layout — set during draw, used for hit-test in
     /// the click handler. None when the popup isn't visible.
     completion_layout: Rc<RefCell<Option<quadraui::CompletionsLayout>>>,
+    /// Context menu layout — set during draw, used for hit-test in
+    /// both click and motion handlers. None when no menu is visible.
+    context_menu_layout: Rc<RefCell<Option<quadraui::ContextMenuLayout>>>,
     /// Tab-switcher popup bounding rect (x, y, w, h) — set during
     /// draw, used for `ModalStack` registration in the click
     /// handler. (B.5b Stage 7.)
@@ -1949,6 +1952,8 @@ impl SimpleComponent for App {
             Rc::new(Cell::new(None));
         let completion_layout: Rc<RefCell<Option<quadraui::CompletionsLayout>>> =
             Rc::new(RefCell::new(None));
+        let context_menu_layout: Rc<RefCell<Option<quadraui::ContextMenuLayout>>> =
+            Rc::new(RefCell::new(None));
         #[allow(clippy::type_complexity)]
         let tab_switcher_popup_rect: Rc<Cell<Option<(f64, f64, f64, f64)>>> =
             Rc::new(Cell::new(None));
@@ -2157,6 +2162,7 @@ impl SimpleComponent for App {
             panel_hover_popup_rect: panel_hover_popup_rect.clone(),
             editor_hover_popup_rect: editor_hover_popup_rect.clone(),
             completion_layout: completion_layout.clone(),
+            context_menu_layout: context_menu_layout.clone(),
             tab_switcher_popup_rect: tab_switcher_popup_rect.clone(),
             dialog_popup_rect: dialog_popup_rect.clone(),
             editor_hover_link_rects: editor_hover_link_rects.clone(),
@@ -3612,6 +3618,7 @@ impl SimpleComponent for App {
         let dialog_popup_for_draw = model.dialog_popup_rect.clone();
         let editor_hover_rect_for_draw = model.editor_hover_popup_rect.clone();
         let completion_layout_for_draw = model.completion_layout.clone();
+        let context_menu_layout_for_draw = model.context_menu_layout.clone();
         let tab_switcher_rect_for_draw = model.tab_switcher_popup_rect.clone();
         let editor_hover_links_for_draw = model.editor_hover_link_rects.clone();
         let editor_hover_sb_for_draw = model.editor_hover_scrollbar.clone();
@@ -3653,6 +3660,7 @@ impl SimpleComponent for App {
                             &dialog_popup_for_draw,
                             &editor_hover_rect_for_draw,
                             &completion_layout_for_draw,
+                            &context_menu_layout_for_draw,
                             &tab_switcher_rect_for_draw,
                             &editor_hover_links_for_draw,
                             &editor_hover_sb_for_draw,
@@ -3730,8 +3738,7 @@ impl SimpleComponent for App {
             let pos_cell = mouse_pos_cell.clone();
             let pos_cell_leave = mouse_pos_cell.clone();
             let engine_motion = engine.clone();
-            let lh_motion = line_height_cell.clone();
-            let cw_motion = char_width_cell.clone();
+            let cm_layout_motion = model.context_menu_layout.clone();
             let da_motion = widgets.drawing_area.clone();
             let mc = gtk4::EventControllerMotion::new();
             mc.connect_motion(move |_, x, y| {
@@ -3742,25 +3749,9 @@ impl SimpleComponent for App {
                 // function computes hover from mouse_pos directly.
                 if let Ok(mut eng) = engine_motion.try_borrow_mut() {
                     if eng.context_menu.is_some() {
-                        let lh = lh_motion.get();
-                        let cw = cw_motion.get();
-                        if lh >= 1.0 && cw >= 1.0 {
-                            let col = (x / cw) as u16;
-                            let row = (y / lh) as u16;
-                            let tw = (da_motion.width() as f64 / cw) as u16;
-                            let th = (da_motion.height() as f64 / lh) as u16;
-                            let cm = eng.context_menu.as_ref().unwrap();
-                            if let crate::core::engine::ContextMenuClickResult::Item(idx) =
-                                crate::core::engine::resolve_context_menu_click(
-                                    &cm.items,
-                                    cm.screen_x,
-                                    cm.screen_y,
-                                    tw,
-                                    th,
-                                    col,
-                                    row,
-                                )
-                            {
+                        if let Some(ref layout) = *cm_layout_motion.borrow() {
+                            let hit = layout.hit_test(x as f32, y as f32);
+                            if let Some(idx) = crate::core::engine::context_menu_hit_to_idx(&hit) {
                                 eng.context_menu.as_mut().unwrap().selected = idx;
                             }
                         }
@@ -6029,54 +6020,9 @@ impl App {
         // "+1 row top border" layout. Driving both off the same
         // `ContextMenuLayout` eliminates drift by construction.
         if self.engine.borrow().context_menu.is_some() {
-            let cw = self.cached_char_width.max(1.0);
-            let lh = self.cached_line_height.max(1.0);
             let cm_id = quadraui::WidgetId::new("context_menu");
 
-            // Build a `quadraui::ContextMenu` + `ContextMenuLayout`
-            // identical to what the renderer computes. Mirrors
-            // `draw.rs::draw_context_menu_popup` so any future
-            // sizing/positioning change there propagates here without
-            // a parallel update.
-            let menu_layout = {
-                let engine = self.engine.borrow();
-                let cm = engine.context_menu.as_ref().unwrap();
-                if cm.items.is_empty() {
-                    None
-                } else {
-                    let panel = crate::render::ContextMenuPanel {
-                        items: cm
-                            .items
-                            .iter()
-                            .map(|item| crate::render::ContextMenuRenderItem {
-                                label: item.label.clone(),
-                                shortcut: item.shortcut.clone(),
-                                separator_after: item.separator_after,
-                                enabled: item.enabled,
-                            })
-                            .collect(),
-                        selected_idx: cm.selected,
-                        screen_col: cm.screen_x,
-                        screen_row: cm.screen_y,
-                    };
-                    let menu = crate::render::context_menu_panel_to_quadraui_context_menu(&panel);
-                    let item_height = |_i: usize| quadraui::ContextMenuItemMeasure::new(lh as f32);
-                    let max_label = cm.items.iter().map(|i| i.label.len()).max().unwrap_or(4);
-                    let max_sc = cm.items.iter().map(|i| i.shortcut.len()).max().unwrap_or(0);
-                    let content_cols = (max_label + max_sc + 6).clamp(20, 50);
-                    let menu_w = content_cols as f64 * cw;
-                    let anchor_x = cm.screen_x as f64 * cw;
-                    let anchor_y = cm.screen_y as f64 * lh;
-                    let viewport = quadraui::Rect::new(0.0, 0.0, width as f32, height as f32);
-                    Some(menu.layout(
-                        anchor_x as f32,
-                        anchor_y as f32,
-                        viewport,
-                        menu_w as f32,
-                        item_height,
-                    ))
-                }
-            };
+            let menu_layout = self.context_menu_layout.borrow().clone();
 
             let Some(menu_layout) = menu_layout else {
                 // Empty items list — close defensively.

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -1023,6 +1023,8 @@ fn event_loop(
     let mut editor_hover_scrollbar: Option<render::PopupScrollbarHit> = None;
     // Cached completion popup layout for mouse hit-testing (#288).
     let mut completion_layout: Option<quadraui::CompletionsLayout> = None;
+    // Cached context menu layout for mouse hit-testing (#210).
+    let mut context_menu_layout: Option<quadraui::ContextMenuLayout> = None;
     // Track last draw time to cap frame rate at ~60 fps and keep CPU low.
     let min_frame = Duration::from_millis(16);
     let mut last_draw = Instant::now()
@@ -1183,6 +1185,7 @@ fn event_loop(
                             &debug_toolbar_interaction,
                             &mut debug_toolbar_rect,
                             &mut completion_layout,
+                            &mut context_menu_layout,
                             &mut backend,
                         );
                     }
@@ -1234,6 +1237,7 @@ fn event_loop(
                                     &debug_toolbar_interaction,
                                     &mut debug_toolbar_rect,
                                     &mut completion_layout,
+                                    &mut context_menu_layout,
                                     &mut backend,
                                 );
                             }
@@ -2959,6 +2963,7 @@ fn event_loop(
                                 &mut hover_selecting,
                                 &mut fr_input_dragging,
                                 completion_layout.as_ref(),
+                                context_menu_layout.as_ref(),
                             );
 
                             if mouse_should_quit {
@@ -3005,6 +3010,7 @@ fn event_loop(
                     &mut hover_selecting,
                     &mut fr_input_dragging,
                     completion_layout.as_ref(),
+                    context_menu_layout.as_ref(),
                 );
 
                 if mouse_should_quit {

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -162,6 +162,7 @@ pub(super) fn handle_mouse(
     hover_selecting: &mut bool,
     fr_input_dragging: &mut bool,
     completion_layout: Option<&quadraui::CompletionsLayout>,
+    context_menu_layout: Option<&quadraui::ContextMenuLayout>,
 ) -> u16 {
     let col = ev.column;
     let row = ev.row;
@@ -1487,42 +1488,44 @@ pub(super) fn handle_mouse(
 
     // ── Context menu click intercept ────────────────────────────────────────────
     if engine.context_menu.is_some() && ev.kind == MouseEventKind::Down(MouseButton::Left) {
-        if let Some(ref cm) = engine.context_menu {
-            let term_w = terminal_size.map(|s| s.width).unwrap_or(80);
-            let result = crate::core::engine::resolve_context_menu_click(
-                &cm.items,
-                cm.screen_x,
-                cm.screen_y,
-                term_w,
-                term_height,
-                col,
-                row,
-            );
-            use crate::core::engine::ContextMenuClickResult;
-            match result {
-                ContextMenuClickResult::Item(idx) => {
-                    engine.context_menu.as_mut().unwrap().selected = idx;
-                    let ctx = engine.context_menu_target_path();
-                    if let Some(act) = engine.context_menu_confirm() {
-                        if let Some((ctx_path, ctx_is_dir)) = ctx {
-                            handle_explorer_context_action(
-                                &act,
-                                engine,
-                                sidebar,
-                                *terminal_size,
-                                ctx_path,
-                                ctx_is_dir,
-                            );
+        if let Some(cl) = context_menu_layout {
+            let hit = cl.hit_test(col as f32, row as f32);
+            match hit {
+                quadraui::ContextMenuHit::Item(_) => {
+                    if let Some(idx) = crate::core::engine::context_menu_hit_to_idx(&hit) {
+                        engine.context_menu.as_mut().unwrap().selected = idx;
+                        let ctx = engine.context_menu_target_path();
+                        if let Some(act) = engine.context_menu_confirm() {
+                            if let Some((ctx_path, ctx_is_dir)) = ctx {
+                                handle_explorer_context_action(
+                                    &act,
+                                    engine,
+                                    sidebar,
+                                    *terminal_size,
+                                    ctx_path,
+                                    ctx_is_dir,
+                                );
+                            }
                         }
                     }
                     return sidebar_width;
                 }
-                ContextMenuClickResult::InsidePopup => {
+                quadraui::ContextMenuHit::Inert => {
                     return sidebar_width;
                 }
-                ContextMenuClickResult::Outside => {
+                quadraui::ContextMenuHit::Empty => {
+                    // Check if click is on the 1-cell border around the
+                    // inner layout bounds (TUI rasteriser draws border
+                    // outside layout.bounds).
+                    let b = &cl.bounds;
+                    let on_border = col as f32 >= b.x - 1.0
+                        && (col as f32) < b.x + b.width + 1.0
+                        && row as f32 >= b.y - 1.0
+                        && (row as f32) < b.y + b.height + 1.0;
+                    if on_border {
+                        return sidebar_width;
+                    }
                     engine.close_context_menu();
-                    // Fall through to process the click normally
                 }
             }
         } else {
@@ -1532,38 +1535,12 @@ pub(super) fn handle_mouse(
 
     // ── Context menu mouse hover ──────────────────────────────────────────────
     if engine.context_menu.is_some() && matches!(ev.kind, MouseEventKind::Moved) {
-        // Compute hit item by examining the menu geometry.
-        let mut hit_idx: Option<usize> = None;
-        if let Some(ref cm) = engine.context_menu {
-            let sep_count = cm.items.iter().filter(|i| i.separator_after).count() as u16;
-            let popup_h = cm.items.len() as u16 + sep_count + 2;
-            let max_label = cm.items.iter().map(|i| i.label.len()).max().unwrap_or(4);
-            let max_sc = cm.items.iter().map(|i| i.shortcut.len()).max().unwrap_or(0);
-            let popup_w = (max_label + max_sc + 6).clamp(20, 50) as u16;
-            let term_w = terminal_size.map(|s| s.width).unwrap_or(80);
-            let px = cm.screen_x.min(term_w.saturating_sub(popup_w));
-            let py = cm.screen_y.min(term_height.saturating_sub(popup_h));
-
-            if col >= px && col < px + popup_w && row >= py && row < py + popup_h {
-                let inner_row = row - py;
-                if inner_row >= 1 && inner_row < popup_h - 1 {
-                    let mut visual_row: u16 = 1;
-                    for (idx, item) in cm.items.iter().enumerate() {
-                        if visual_row == inner_row && item.enabled {
-                            hit_idx = Some(idx);
-                            break;
-                        }
-                        visual_row += 1;
-                        if item.separator_after {
-                            visual_row += 1;
-                        }
-                    }
+        if let Some(cl) = context_menu_layout {
+            let hit = cl.hit_test(col as f32, row as f32);
+            if let Some(idx) = crate::core::engine::context_menu_hit_to_idx(&hit) {
+                if let Some(ref mut cm) = engine.context_menu {
+                    cm.selected = idx;
                 }
-            }
-        }
-        if let Some(idx) = hit_idx {
-            if let Some(ref mut cm) = engine.context_menu {
-                cm.selected = idx;
             }
         }
         return sidebar_width;

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -109,6 +109,7 @@ pub(super) fn draw_frame(
     debug_toolbar_interaction: &quadraui::StatusBarInteraction,
     debug_toolbar_rect_out: &mut quadraui::Rect,
     completion_layout_out: &mut Option<quadraui::CompletionsLayout>,
+    context_menu_layout_out: &mut Option<quadraui::ContextMenuLayout>,
     // Phase B.4 Stage 2: backend handle for migrated `draw_*` calls.
     // Set once per frame by the caller (cached theme); the migrated
     // call sites wrap their access in `backend.enter_frame_scope`.
@@ -964,6 +965,7 @@ pub(super) fn draw_frame(
             |_| quadraui::ContextMenuItemMeasure::new(1.0),
         );
         super::quadraui_tui::draw_context_menu(frame.buffer_mut(), &menu, &layout, theme);
+        *context_menu_layout_out = Some(layout);
     }
 
     // ── Modal dialog (highest z-order after quit confirm) ────────────────────
@@ -1690,6 +1692,7 @@ mod tests {
         let dbg_toolbar_interaction = quadraui::StatusBarInteraction::new();
         let mut dbg_toolbar_rect = quadraui::Rect::default();
         let mut completion_layout = None;
+        let mut context_menu_layout = None;
         let mut backend = super::backend::TuiBackend::new();
 
         terminal
@@ -1714,6 +1717,7 @@ mod tests {
                     &dbg_toolbar_interaction,
                     &mut dbg_toolbar_rect,
                     &mut completion_layout,
+                    &mut context_menu_layout,
                     &mut backend,
                 );
             })


### PR DESCRIPTION
## Summary

- Both GTK and TUI now cache `ContextMenuLayout` from rendering and use `hit_test()` for click and hover resolution instead of hand-rolled row math.
- New engine helper `context_menu_hit_to_idx()` converts `ContextMenuHit::Item(id)` back to engine index.
- GTK: `draw_context_menu_popup` returns layout; cached in `context_menu_layout` field. Motion handler uses cached `hit_test`. Click handler reads cache instead of rebuilding layout (~35 lines removed).
- TUI: `ContextMenuLayout` cached during render. Click + motion handlers replaced with cached `hit_test` (~30 lines of hand-rolled geometry removed).
- `resolve_context_menu_click()` gated to `#[cfg(test)]` only.
- Net -49 lines.

Closes #210

## Test plan

- [ ] GTK: right-click editor → hover items → highlight follows mouse correctly across separators
- [ ] GTK: click item → action fires; click outside → dismisses
- [ ] TUI: right-click editor → hover items → highlight follows mouse
- [ ] TUI: click item → action fires; click outside → dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)