### PR TITLE
fix: re-add ..Default::default() to ContextMenuItem literals

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -2631,6 +2631,7 @@ pub fn build_menu_defs(is_vscode_mode: bool) -> Vec<quadraui::MenuDef> {
                             label: quadraui::StyledText::default(),
                             detail: None,
                             disabled: false,
+                            ..Default::default()
                         };
                     }
                     let shortcut = if is_vscode_mode && !item.vscode_shortcut.is_empty() {
@@ -2647,6 +2648,7 @@ pub fn build_menu_defs(is_vscode_mode: bool) -> Vec<quadraui::MenuDef> {
                             Some(quadraui::StyledText::plain(shortcut.to_string()))
                         },
                         disabled: !item.enabled,
+                        ..Default::default()
                     }
                 })
                 .collect(),
@@ -3594,6 +3596,7 @@ pub fn context_menu_panel_to_quadraui_context_menu(
                 Some(quadraui::StyledText::plain(item.shortcut.clone()))
             },
             disabled: !item.enabled,
+            ..Default::default()
         });
         if item.separator_after {
             items.push(quadraui::ContextMenuItem {
@@ -3601,6 +3604,7 @@ pub fn context_menu_panel_to_quadraui_context_menu(
                 label: quadraui::StyledText::default(),
                 detail: None,
                 disabled: false,
+                ..Default::default()
             });
         }
     }


### PR DESCRIPTION
## Summary

- Commit \`8a53307\` (merged via PR #424) removed the \`..Default::default()\` lines on four \`quadraui::ContextMenuItem\` literals in \`src/render.rs\` that \`a516f76\` had added to keep develop compiling against the newer quadraui field shape (\`checked\`, \`key_equivalent\`, \`submenu\` added in quadraui \`daed293\`).
- Without these lines, develop fails to build with E0063 — confirmed locally on a fresh checkout.
- This PR re-applies the same 4-line fix. No behavior change; the doc on \`ContextMenuItem\` explicitly recommends struct-update syntax for forward compat.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo clippy -- -D warnings\` — no warnings
- [x] \`cargo test --no-default-features --lib\` — 1963 passed / 0 failed

Discovered while smoke-testing PR #427 (action menu migration). #427 will be rebased onto develop once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)