### PR TITLE
fix: use TerminalSplitLayout::hit_test() for split click dispatch (#430)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2986,6 +2986,9 @@ pub struct Engine {
     /// Written at paint time by both backends; read by `resolve_bottom_panel_zone`
     /// so click handlers don't recompute the snapped panel top (#418).
     pub bottom_panel_geometry: std::cell::RefCell<Option<BottomPanelGeometry>>,
+    /// Cached terminal split layout from the last paint. Written at paint
+    /// time; read by click handlers via `handle_terminal_split_click` (#430).
+    pub terminal_split_layout: std::cell::RefCell<Option<quadraui::TerminalSplitLayout>>,
     /// Cached layout from the last paint of the command center (nav arrows + search box).
     /// Written at paint time; read by click handlers.
     pub command_center_layout: std::cell::RefCell<Option<quadraui::CommandCenterLayout>>,
@@ -3724,6 +3727,7 @@ impl Engine {
             bottom_tab_bar_hits: std::cell::RefCell::new(None),
             terminal_toolbar_hits: std::cell::RefCell::new(None),
             bottom_panel_geometry: std::cell::RefCell::new(None),
+            terminal_split_layout: std::cell::RefCell::new(None),
             command_center_layout: std::cell::RefCell::new(None),
             dap_pending_launch: None,
             bottom_panel_open: false,

--- a/src/core/engine/terminal_ops.rs
+++ b/src/core/engine/terminal_ops.rs
@@ -208,6 +208,48 @@ impl Engine {
         Some(zone)
     }
 
+    /// Handle a click on the terminal content area using a
+    /// `TerminalSplitHit` from the cached layout. Sets pane focus,
+    /// starts selection, or signals a divider drag. Returns `true` if
+    /// the caller should start a split-divider drag.
+    pub fn handle_terminal_split_click(
+        &mut self,
+        hit: quadraui::TerminalSplitHit,
+    ) -> bool {
+        use quadraui::TerminalSplitHit;
+        self.terminal_has_focus = true;
+        match hit {
+            TerminalSplitHit::Divider => true,
+            TerminalSplitHit::LeftPane { col, row } => {
+                self.terminal_active = 0;
+                self.terminal_scroll_reset();
+                if let Some(term) = self.active_terminal_mut() {
+                    term.selection = Some(crate::core::terminal::TermSelection {
+                        start_row: row,
+                        start_col: col,
+                        end_row: row,
+                        end_col: col,
+                    });
+                }
+                false
+            }
+            TerminalSplitHit::RightPane { col, row } => {
+                self.terminal_active = 1;
+                self.terminal_scroll_reset();
+                if let Some(term) = self.active_terminal_mut() {
+                    term.selection = Some(crate::core::terminal::TermSelection {
+                        start_row: row,
+                        start_col: col,
+                        end_row: row,
+                        end_col: col,
+                    });
+                }
+                false
+            }
+            TerminalSplitHit::Scrollbar | TerminalSplitHit::Outside => false,
+        }
+    }
+
     /// Dispatch a click on the bottom panel tab bar using the cached
     /// `TabBarHits` from the last paint. Returns `true` if the click
     /// was consumed (tab switch or panel close).

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -566,9 +566,11 @@ pub(super) fn draw_editor(
                             term_panel,
                             q_area,
                             char_width as f32,
+                            line_height as f32,
                             visible_rows,
                             Some(6),
                         );
+                        engine.terminal_split_layout.replace(td.split);
                         {
                             let mut b = backend.borrow_mut();
                             b.set_current_theme(q_theme);

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6762,43 +6762,26 @@ impl App {
                     return;
                 }
                 self.engine.borrow_mut().terminal_has_focus = true;
-                if let BottomPanelZone::Content { row_offset } = zone {
-                    const SB_W: f64 = 6.0;
-                    // In split mode: detect a click on the divider (start drag)
-                    // or set keyboard focus to the appropriate pane.
-                    let on_divider = if self.engine.borrow().terminal_split
-                        && self.engine.borrow().terminal_panes.len() >= 2
-                    {
-                        let left_cols = {
-                            let engine = self.engine.borrow();
-                            if engine.terminal_split_left_cols > 0 {
-                                engine.terminal_split_left_cols
-                            } else {
-                                engine.terminal_panes[0].cols
-                            }
-                        };
-                        let div_x = left_cols as f64 * self.cached_char_width;
-                        if x < width - SB_W && (x - div_x).abs() < 4.0 {
+                if let BottomPanelZone::Content { .. } = zone {
+                    let split_layout = *self.engine.borrow().terminal_split_layout.borrow();
+                    if let Some(ref sl) = split_layout {
+                        let hit = sl.hit_test(x as f32, y as f32);
+                        if self.engine.borrow_mut().handle_terminal_split_click(hit) {
                             self.terminal_split_dragging = true;
-                            true
-                        } else {
-                            let mut engine = self.engine.borrow_mut();
-                            engine.terminal_active = if x < div_x { 0 } else { 1 };
-                            false
                         }
                     } else {
-                        false
-                    };
-                    if !on_divider {
                         self.terminal_resize_dragging = false;
-                        let row = row_offset;
                         let col = (x / self.cached_char_width.max(1.0)) as u16;
+                        let row_offset = match zone {
+                            BottomPanelZone::Content { row_offset } => row_offset,
+                            _ => 0,
+                        };
                         self.engine.borrow_mut().terminal_scroll_reset();
                         if let Some(term) = self.engine.borrow_mut().active_terminal_mut() {
                             term.selection = Some(crate::core::terminal::TermSelection {
-                                start_row: row,
+                                start_row: row_offset,
                                 start_col: col,
-                                end_row: row,
+                                end_row: row_offset,
                                 end_col: col,
                             });
                         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1867,7 +1867,7 @@ pub fn build_terminal_draw_data(
         width: sb_width,
     });
     if let Some(ref left_rows) = panel.split_left_rows {
-        let sb_px = sb_width.unwrap_or(0) as f32 * cell_width;
+        let sb_px = sb_width.unwrap_or(0) as f32;
         let split = quadraui::TerminalSplitLayout::new(
             area,
             panel.split_left_cols as usize,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1855,6 +1855,7 @@ pub fn build_terminal_draw_data(
     panel: &TerminalPanel,
     area: quadraui::Rect,
     cell_width: f32,
+    cell_height: f32,
     visible_rows: usize,
     sb_width: Option<u16>,
 ) -> TerminalDrawData {
@@ -1866,8 +1867,14 @@ pub fn build_terminal_draw_data(
         width: sb_width,
     });
     if let Some(ref left_rows) = panel.split_left_rows {
-        let split =
-            quadraui::TerminalSplitLayout::new(area, panel.split_left_cols as usize, cell_width);
+        let sb_px = sb_width.unwrap_or(0) as f32 * cell_width;
+        let split = quadraui::TerminalSplitLayout::new(
+            area,
+            panel.split_left_cols as usize,
+            cell_width,
+            cell_height,
+            sb_px,
+        );
         let left =
             terminal_cells_to_quadraui(left_rows, quadraui::WidgetId::new("terminal:left"), None);
         let right =
@@ -2626,13 +2633,7 @@ pub fn build_menu_defs(is_vscode_mode: bool) -> Vec<quadraui::MenuDef> {
                 .iter()
                 .map(|item| {
                     if item.separator {
-                        return quadraui::ContextMenuItem {
-                            id: None,
-                            label: quadraui::StyledText::default(),
-                            detail: None,
-                            disabled: false,
-                            ..Default::default()
-                        };
+                        return quadraui::ContextMenuItem::default();
                     }
                     let shortcut = if is_vscode_mode && !item.vscode_shortcut.is_empty() {
                         item.vscode_shortcut
@@ -3599,13 +3600,7 @@ pub fn context_menu_panel_to_quadraui_context_menu(
             ..Default::default()
         });
         if item.separator_after {
-            items.push(quadraui::ContextMenuItem {
-                id: None,
-                label: quadraui::StyledText::default(),
-                detail: None,
-                disabled: false,
-                ..Default::default()
-            });
+            items.push(quadraui::ContextMenuItem::default());
         }
     }
     let selected_idx = engine_to_quadraui

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2025,73 +2025,60 @@ pub(super) fn handle_mouse(
                     *dragging_terminal_resize = true;
                 }
             } else if let BottomPanelZone::Content { row_offset } = zone {
-                // Content row — focus split pane or start divider drag.
-                let panel_col = col.saturating_sub(editor_left);
-                if engine.terminal_split && engine.terminal_panes.len() >= 2 {
-                    // Mirror render.rs: use drag-override if set, else actual PTY cols.
-                    let div_col = if engine.terminal_split_left_cols > 0 {
-                        engine.terminal_split_left_cols
-                    } else {
-                        engine.terminal_panes[0].cols
-                    };
-                    // Allow clicking within ±1 column of the divider to start a resize drag.
-                    if panel_col.abs_diff(div_col) <= 1 {
-                        engine.terminal_has_focus = true;
-                        *dragging_terminal_split = true;
-                        return sidebar_width; // skip selection start
-                    } else {
-                        engine.terminal_active = if panel_col < div_col { 0 } else { 1 };
+                // Use cached TerminalSplitLayout for divider/pane/scrollbar
+                // detection (#430). Non-split fallback uses row_offset directly.
+                let split_layout = engine.terminal_split_layout.borrow();
+                if let Some(ref sl) = *split_layout {
+                    let abs_y = geom.top_y + geom.content_y + row_offset as f64;
+                    let hit = sl.hit_test(col as f32, abs_y as f32);
+                    drop(split_layout);
+                    match hit {
+                        quadraui::TerminalSplitHit::Scrollbar => {
+                            let track_start = (geom.top_y + geom.content_y) as u16;
+                            let track_len =
+                                (geom.height - geom.content_y).max(0.0) as u16;
+                            let total = engine
+                                .active_terminal()
+                                .map(|t| t.history.len())
+                                .unwrap_or(0);
+                            let tl = track_len as f32;
+                            drag_state.begin(quadraui::DragTarget::ScrollbarY {
+                                widget: quadraui::WidgetId::new(
+                                    "tui:terminal_scrollback",
+                                ),
+                                track_start: track_start as f32,
+                                track_length: tl,
+                                thumb_length: (tl / total.max(1) as f32).max(1.0),
+                                max_scroll: total,
+                                grab_offset: 0.0,
+                                inverted: true,
+                            });
+                            apply_scrollbar_drag(
+                                drag_state,
+                                quadraui::Point {
+                                    x: col as f32,
+                                    y: row as f32,
+                                },
+                                engine,
+                                sidebar,
+                            );
+                        }
+                        _ => {
+                            if engine.handle_terminal_split_click(hit) {
+                                *dragging_terminal_split = true;
+                            }
+                        }
                     }
-                }
-                // Check for scrollbar click first.
-                let term_width = terminal_size.map(|s| s.width).unwrap_or(80);
-                let sb_col = term_width.saturating_sub(1);
-                engine.terminal_has_focus = true;
-                if col == sb_col {
-                    // Scrollbar column — start drag through shared state.
-                    let track_start = (geom.top_y + geom.content_y) as u16;
-                    let track_len = (geom.height - geom.content_y).max(0.0) as u16;
-                    // Cap total to one screenful (vt100 API limit) so the drag range
-                    // [0, total] exactly matches what set_scroll_offset can deliver.
-                    let total = engine
-                        .active_terminal()
-                        .map(|t| t.history.len())
-                        .unwrap_or(0);
-                    // visible_rows: 0 — terminal's `set_scroll_offset` clamps
-                    // to `history.len()` (not `history.len() - viewport`),
-                    // and the renderer's thumb math uses `max_off = history.len()`.
-                    // Setting visible_rows = 0 makes dispatch_mouse_drag's
-                    // max_scroll = total, so inverting (`max - new_offset`)
-                    // reaches the very top of scrollback.
-                    let tl = track_len as f32;
-                    drag_state.begin(quadraui::DragTarget::ScrollbarY {
-                        widget: quadraui::WidgetId::new("tui:terminal_scrollback"),
-                        track_start: track_start as f32,
-                        track_length: tl,
-                        thumb_length: (tl / total.max(1) as f32).max(1.0),
-                        max_scroll: total,
-                        grab_offset: 0.0,
-                        inverted: true,
-                    });
-                    apply_scrollbar_drag(
-                        drag_state,
-                        quadraui::Point {
-                            x: col as f32,
-                            y: row as f32,
-                        },
-                        engine,
-                        sidebar,
-                    );
                 } else {
-                    // Content area — start a selection.
-                    let term_row = row_offset;
+                    drop(split_layout);
+                    engine.terminal_has_focus = true;
                     let term_col = col.saturating_sub(editor_left);
                     engine.terminal_scroll_reset();
                     if let Some(term) = engine.active_terminal_mut() {
                         term.selection = Some(crate::core::terminal::TermSelection {
-                            start_row: term_row,
+                            start_row: row_offset,
                             start_col: term_col,
-                            end_row: term_row,
+                            end_row: row_offset,
                             end_col: term_col,
                         });
                     }

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -2299,6 +2299,7 @@ pub(super) fn render_terminal_panel(
     area: Rect,
     panel: &render::TerminalPanel,
     theme: &Theme,
+    engine: &Engine,
 ) {
     if area.height == 0 {
         return;
@@ -2321,7 +2322,8 @@ pub(super) fn render_terminal_panel(
         area.width as f32,
         area.height as f32,
     );
-    let td = render::build_terminal_draw_data(panel, q_area, 1.0, content_rows, None);
+    let td = render::build_terminal_draw_data(panel, q_area, 1.0, 1.0, content_rows, None);
+    engine.terminal_split_layout.replace(td.split);
     backend.set_current_theme(q_theme);
     if let Some(split) = &td.split {
         let left = td.left.as_ref().unwrap();

--- a/src/tui_main/render_impl.rs
+++ b/src/tui_main/render_impl.rs
@@ -679,7 +679,7 @@ pub(super) fn draw_frame(
                         width: content_area.width,
                         height: content_area.height.saturating_sub(1),
                     };
-                    render_terminal_panel(frame, backend, term_content, term, theme);
+                    render_terminal_panel(frame, backend, term_content, term, theme, engine);
                     // Register terminal content area as a scroll surface.
                     engine
                         .scroll_surfaces


### PR DESCRIPTION
## Summary

- Both backends cache `TerminalSplitLayout` from rendering and use `hit_test()` for divider detection, pane focus, and selection start — same cache-then-hit-test pattern as completions (#288) and context menus (#210).
- New shared engine method `handle_terminal_split_click(TerminalSplitHit) -> bool` handles divider/pane/selection dispatch.
- Adapts to quadraui#196 API changes: `TerminalSplitLayout::new()` gains `cell_height` + `scrollbar_width` params; `ContextMenuItem` gains `checked`, `key_equivalent`, `submenu` fields.
- Net -20 lines of per-backend divider math removed.

Closes #430

## Test plan

- [ ] GTK: open terminal, split, click divider → drag works
- [ ] GTK: click left/right pane → correct pane gets focus
- [ ] TUI: same three tests
- [ ] Non-split terminal still works (selection, scrollbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)