### PR TITLE
fix: Ctrl+Space triggers full completion with empty prefix (#422)

### DIFF
--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -4632,12 +4632,12 @@ impl Engine {
             {
                 let key_char = key_name.chars().next().unwrap_or('\0');
                 if ctrl == t_ctrl && (key_char == t_ch || (key_name == "space" && t_ch == ' ')) {
-                    self.trigger_auto_completion();
+                    self.trigger_completion(true);
                     return;
                 }
             } else if ctrl && key_name == "space" {
                 // Fallback for default <C-Space> trigger
-                self.trigger_auto_completion();
+                self.trigger_completion(true);
                 return;
             }
         }
@@ -5222,7 +5222,7 @@ impl Engine {
                     }
                 }
                 if *changed {
-                    self.trigger_auto_completion();
+                    self.trigger_completion(false);
                 }
             }
             "Delete" => {
@@ -5403,7 +5403,7 @@ impl Engine {
                     }
                 }
                 if *changed {
-                    self.trigger_auto_completion();
+                    self.trigger_completion(false);
                 }
             }
         }
@@ -5470,7 +5470,7 @@ impl Engine {
         self.ensure_cursor_visible();
         self.sync_scroll_binds();
         self.update_bracket_match();
-        self.trigger_auto_completion();
+        self.trigger_completion(false);
     }
 
     /// Insert `text` at the current command-line cursor position and advance the cursor.

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -3231,27 +3231,42 @@ impl Engine {
         self.lsp_pending_completion = None;
     }
 
-    /// Trigger auto-popup completion based on current cursor prefix.
-    /// Called after each text change in Insert mode.
-    pub(crate) fn trigger_auto_completion(&mut self) {
+    /// Trigger completion popup based on current cursor prefix.
+    /// Called after each text change in Insert mode (`manual = false`) or
+    /// from an explicit user gesture like Ctrl+Space (`manual = true`).
+    ///
+    /// Empty-prefix behavior differs: auto triggers dismiss the popup (typing
+    /// shouldn't drown the user in every word in scope), while manual triggers
+    /// fall through to the LSP so the user sees all in-scope symbols (VSCode
+    /// parity).
+    pub(crate) fn trigger_completion(&mut self, manual: bool) {
         let (prefix, _) = self.completion_prefix_at_cursor();
-        if prefix.is_empty() {
+        if prefix.is_empty() && !manual {
             self.dismiss_completion();
             return;
         }
-        // Use a fast nearby-lines scan instead of scanning the entire buffer.
-        // For a 15K-line file, full scan takes 270ms; nearby scan is ~1ms.
-        let candidates = self.word_completions_nearby(&prefix);
-        if !candidates.is_empty() {
-            self.completion_start_col = self.view().cursor.col - prefix.chars().count();
-            self.completion_candidates = candidates;
-            self.completion_idx = Some(0);
-            self.completion_display_only = true;
-        } else {
-            // No buffer-word hits yet; clear popup but keep LSP pending
+        if prefix.is_empty() {
+            // Manual trigger with no prefix: skip the buffer-word scan (it would
+            // match every word in the nearby radius) and rely on the LSP response.
+            self.completion_start_col = self.view().cursor.col;
             self.completion_candidates.clear();
             self.completion_idx = None;
             self.completion_display_only = false;
+        } else {
+            // Use a fast nearby-lines scan instead of scanning the entire buffer.
+            // For a 15K-line file, full scan takes 270ms; nearby scan is ~1ms.
+            let candidates = self.word_completions_nearby(&prefix);
+            if !candidates.is_empty() {
+                self.completion_start_col = self.view().cursor.col - prefix.chars().count();
+                self.completion_candidates = candidates;
+                self.completion_idx = Some(0);
+                self.completion_display_only = true;
+            } else {
+                // No buffer-word hits yet; clear popup but keep LSP pending
+                self.completion_candidates.clear();
+                self.completion_idx = None;
+                self.completion_display_only = false;
+            }
         }
         // Async LSP source — response will update candidates if popup is still active
         self.lsp_request_completion();

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -6736,6 +6736,58 @@ fn test_auto_popup_appears_on_type() {
 }
 
 #[test]
+fn test_manual_trigger_with_empty_prefix_does_not_dismiss() {
+    // #422: Ctrl+Space should fire a completion request even with no prefix
+    // (VSCode parity — show all in-scope symbols). The auto path still bails
+    // on empty prefix to avoid drowning the user in every word while typing.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foobar\n");
+    press_char(&mut engine, 'G');
+    press_char(&mut engine, 'o'); // open new line, insert mode, no prefix yet
+
+    // Auto trigger with empty prefix: dismisses (popup state stays cleared).
+    engine.trigger_completion(false);
+    assert!(
+        engine.completion_idx.is_none(),
+        "auto trigger with empty prefix should NOT activate popup"
+    );
+
+    // Manual trigger with empty prefix: does not bail. `completion_start_col`
+    // is anchored to the cursor so an arriving LSP response can populate the
+    // popup at the right position. (No LSP in tests, so candidates stay empty.)
+    let cursor_col = engine.view().cursor.col;
+    engine.trigger_completion(true);
+    assert_eq!(
+        engine.completion_start_col, cursor_col,
+        "manual trigger should anchor completion_start_col to the cursor"
+    );
+}
+
+#[test]
+fn test_manual_trigger_with_prefix_still_scans_buffer() {
+    // Manual trigger with a non-empty prefix should behave like the auto path:
+    // run the nearby-buffer scan and populate the popup synchronously.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foobar\n");
+    press_char(&mut engine, 'G');
+    press_char(&mut engine, 'o');
+    press_char(&mut engine, 'f');
+    press_char(&mut engine, 'o');
+    // Clear popup state to simulate a re-trigger
+    engine.dismiss_completion();
+    engine.trigger_completion(true);
+    assert!(
+        engine.completion_idx.is_some(),
+        "manual trigger with prefix should populate popup from buffer scan"
+    );
+    assert!(
+        engine.completion_candidates.iter().any(|c| c == "foobar"),
+        "buffer-scan candidates should appear, got: {:?}",
+        engine.completion_candidates
+    );
+}
+
+#[test]
 fn test_auto_popup_tab_accepts() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "foobar\n");

--- a/src/core/engine/vscode.rs
+++ b/src/core/engine/vscode.rs
@@ -1356,7 +1356,7 @@ impl Engine {
                             changed = true;
                         }
                         if changed {
-                            self.trigger_auto_completion();
+                            self.trigger_completion(false);
                         }
                     }
                 }
@@ -1570,7 +1570,7 @@ impl Engine {
                                 changed = true;
                             }
                         }
-                        self.trigger_auto_completion();
+                        self.trigger_completion(false);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- `trigger_auto_completion()` bailed when the prefix was empty, so manual Ctrl+Space at a position with no typed prefix produced nothing.
- Renamed to `trigger_completion(manual: bool)`. Auto path (typing/backspace/paste/vscode bindings) still dismisses on empty prefix so the popup doesn't drown the user in every nearby word while typing. Manual path (Ctrl+Space) with empty prefix skips the buffer-word scan and anchors `completion_start_col` to the cursor so the arriving LSP response populates the popup at the right position.
- 2 new tests cover both the empty-prefix-manual and prefix-manual branches.

## Test plan

- [x] `cargo build`
- [x] `cargo test --no-default-features --lib` — 1965 pass (+2 new for #422)
- [x] `cargo fmt --check` on the changed files
- [x] Manual smoke (GTK + rust-analyzer): Ctrl+Space in Insert mode at a blank position inside a function body shows in-scope LSP symbols; Tab accepts cleanly; typing-driven auto-popup unchanged; prefix + Ctrl+Space unchanged.

## Notes

- Clippy and the full integration test suite have preexisting failures on `develop` (unrelated `engine_with` reference in `render.rs`, snake_case test names, etc.) — neither introduced by this branch.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)