### PR TITLE
fix: GTK Ctrl-P in completion popup cycles instead of opening picker (#287)

### DIFF
--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -3272,6 +3272,27 @@ impl Engine {
         self.lsp_request_completion();
     }
 
+    /// True when an insert-mode keypress would be consumed by completion
+    /// handling — used by backends to suppress global accelerators that
+    /// would otherwise win the dispatch race (#287). Mirrors the gates in
+    /// `handle_insert_key`:
+    ///
+    /// - `Ctrl+N` / `Ctrl+P` — always (start or cycle word completion).
+    /// - `Tab` / `Down` / `Up` — only while a display-only popup is active.
+    pub fn insert_completion_intercepts_key(&self, key_name: &str, ctrl: bool) -> bool {
+        if self.mode != Mode::Insert {
+            return false;
+        }
+        if ctrl && (key_name == "n" || key_name == "p") {
+            return true;
+        }
+        let popup_active = self.completion_display_only && self.completion_idx.is_some();
+        if !popup_active {
+            return false;
+        }
+        !ctrl && (key_name == "Tab" || key_name == "Down" || key_name == "Up")
+    }
+
     // ── Fold helpers ──────────────────────────────────────────────────────────
 
     /// Count leading whitespace characters (spaces = 1, tabs = tab_width).

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -6736,6 +6736,46 @@ fn test_auto_popup_appears_on_type() {
 }
 
 #[test]
+fn test_insert_completion_intercepts_key() {
+    // #287: predicate that backends consult to suppress global accelerators
+    // (Ctrl-P → fuzzy_finder, etc.) when insert-mode completion would
+    // otherwise consume the key. Mirrors the gates in handle_insert_key.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foobar\n");
+
+    // Normal mode: no interception even with a popup-like state set
+    // (popup can't actually be active outside insert mode, but check
+    // the mode gate explicitly).
+    assert!(!engine.insert_completion_intercepts_key("n", true));
+    assert!(!engine.insert_completion_intercepts_key("p", true));
+
+    // Enter insert mode with no popup active.
+    press_char(&mut engine, 'G');
+    press_char(&mut engine, 'o');
+    // Ctrl-N / Ctrl-P always intercepted in insert (they can start completion).
+    assert!(engine.insert_completion_intercepts_key("n", true));
+    assert!(engine.insert_completion_intercepts_key("p", true));
+    // Tab / Down / Up NOT intercepted without an active popup.
+    assert!(!engine.insert_completion_intercepts_key("Tab", false));
+    assert!(!engine.insert_completion_intercepts_key("Down", false));
+    assert!(!engine.insert_completion_intercepts_key("Up", false));
+    // Non-completion keys never intercepted.
+    assert!(!engine.insert_completion_intercepts_key("a", false));
+    assert!(!engine.insert_completion_intercepts_key("f", true));
+
+    // Activate a display-only popup by typing a prefix that matches.
+    press_char(&mut engine, 'f');
+    press_char(&mut engine, 'o');
+    assert!(engine.completion_display_only && engine.completion_idx.is_some());
+    // Now Tab / Down / Up are intercepted.
+    assert!(engine.insert_completion_intercepts_key("Tab", false));
+    assert!(engine.insert_completion_intercepts_key("Down", false));
+    assert!(engine.insert_completion_intercepts_key("Up", false));
+    // Ctrl variants of those keys are NOT — only the bare versions cycle.
+    assert!(!engine.insert_completion_intercepts_key("Tab", true));
+}
+
+#[test]
 fn test_manual_trigger_with_empty_prefix_does_not_dismiss() {
     // #422: Ctrl+Space should fire a completion request even with no prefix
     // (VSCode parity — show all in-scope symbols). The auto path still bails

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -1571,9 +1571,22 @@ impl SimpleComponent for App {
                                     // select_all_matches / split_editor_right /
                                     // split_editor_down / nav_back /
                                     // nav_forward).
-                                    if let Some(id) = &matched_acc_id {
-                                        if dispatch_gtk_panel_accelerator(id.as_str(), &sender, &engine) {
-                                            return gtk4::glib::Propagation::Stop;
+                                    //
+                                    // #287: yield to insert-mode completion
+                                    // for the keys it consumes (Ctrl-N /
+                                    // Ctrl-P always; Tab / Down / Up when a
+                                    // display-only popup is active) so the
+                                    // global accelerator (e.g. <C-p> →
+                                    // fuzzy_finder) doesn't win over
+                                    // candidate-cycling.
+                                    let completion_intercepts = engine
+                                        .borrow()
+                                        .insert_completion_intercepts_key(&key_name, ctrl);
+                                    if !completion_intercepts {
+                                        if let Some(id) = &matched_acc_id {
+                                            if dispatch_gtk_panel_accelerator(id.as_str(), &sender, &engine) {
+                                                return gtk4::glib::Propagation::Stop;
+                                            }
                                         }
                                     }
 


### PR DESCRIPTION
## Summary

- GTK registers panel keys (incl. `fuzzy_finder = <C-p>`) at `AcceleratorScope::Global`. The accelerator dispatcher fires before `engine.handle_key()`, so insert-mode Ctrl-P opened the file picker instead of cycling completion candidates backward.
- New engine predicate `Engine::insert_completion_intercepts_key(key_name, ctrl)` is the single source of truth for which keys insert-mode completion would consume (Ctrl-N/Ctrl-P always; Tab/Down/Up when a display-only popup is active). Mirrors the gates in `handle_insert_key`.
- GTK keypress handler at `src/gtk/mod.rs:~1574` consults the predicate before dispatching panel accelerators — yields to insert-mode completion when needed.
- Engine-level test covers all four gates and the mode/popup conditions.

## ⚠️ Needs GTK smoke test before merge

I authored this on a TUI-only server and couldn't run the GTK build. The engine predicate is unit-tested; the GTK wiring is mechanically simple (1 immutable borrow + 1 conditional wrapper around the existing dispatcher, no new code paths) and `cargo build` passes — but the actual key-routing path isn't validated.

Smoke steps:
1. GTK vimcode on any file with repeated words (e.g. `vc src/core/engine/keys.rs`).
2. `i` to enter Insert, type a short prefix (e.g. `co`) — completion popup appears.
3. **Ctrl-P** — expect: cycles backward. Was: opened file picker.
4. **Ctrl-N** — expect: cycles forward (already worked, sanity check).
5. **Tab** — expect: accepts highlighted candidate.
6. **Esc** to leave Insert, then **Ctrl-P** — expect: file picker opens normally (gate only suppresses while in Insert + popup active).

## Test plan

- [x] `cargo build`
- [x] `cargo test --no-default-features --lib` — 1966 pass (+1 new for #287)
- [x] `cargo fmt --check` on the changed files
- [ ] GTK manual smoke (per steps above) — pending machine with GUI

## Notes

- Per CLAUDE.md platform-neutrality: this is thin event-to-engine wiring. Engine owns the predicate; GTK does a 5-line guard. No new per-backend logic.
- TUI is reported as unaffected by the issue; same predicate would apply there if a similar regression appeared, but no TUI changes in this PR.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)