### PR TITLE
Fix #435: GTK engine-drawn ctx menu keyboard nav (focus + draw-time hover override)

### DIFF
--- a/src/core/engine/terminal_ops.rs
+++ b/src/core/engine/terminal_ops.rs
@@ -212,10 +212,7 @@ impl Engine {
     /// `TerminalSplitHit` from the cached layout. Sets pane focus,
     /// starts selection, or signals a divider drag. Returns `true` if
     /// the caller should start a split-divider drag.
-    pub fn handle_terminal_split_click(
-        &mut self,
-        hit: quadraui::TerminalSplitHit,
-    ) -> bool {
+    pub fn handle_terminal_split_click(&mut self, hit: quadraui::TerminalSplitHit) -> bool {
         use quadraui::TerminalSplitHit;
         self.terminal_has_focus = true;
         match hit {

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -1921,7 +1921,7 @@ pub(super) fn draw_context_menu_popup(
     editor_height: f64,
     char_width: f64,
     line_height: f64,
-    mouse_pos: (f64, f64),
+    _mouse_pos: (f64, f64),
 ) -> Option<quadraui::ContextMenuLayout> {
     let Some(cm) = &screen.context_menu else {
         return None;
@@ -1938,7 +1938,7 @@ pub(super) fn draw_context_menu_popup(
     // Convert engine-side panel → quadraui::ContextMenu (synthesises
     // `context:N` ids, lifts separator_after into separator rows). Same
     // adapter TUI uses.
-    let mut menu = render::context_menu_panel_to_quadraui_context_menu(cm);
+    let menu = render::context_menu_panel_to_quadraui_context_menu(cm);
 
     // Each non-separator row is `line_height`; separators get a
     // half-line slot to render as a thin rule.
@@ -1965,21 +1965,13 @@ pub(super) fn draw_context_menu_popup(
         item_height,
     );
 
-    // Hover from mouse position via the primitive's own hit-test, then
-    // walk visible_items to find the matching idx. This eliminates the
-    // off-by-one we'd hit using the legacy `resolve_context_menu_click`
-    // (which assumed the old +1 row top-padding).
-    if mouse_pos.0 >= 0.0 {
-        let hit = menu_layout.hit_test(mouse_pos.0 as f32, mouse_pos.1 as f32);
-        if let quadraui::ContextMenuHit::Item(id) = hit {
-            for vis in &menu_layout.visible_items {
-                if menu.items[vis.item_idx].id.as_ref() == Some(&id) {
-                    menu.selected_idx = vis.item_idx;
-                    break;
-                }
-            }
-        }
-    }
+    // #435: do NOT override menu.selected_idx from mouse_pos at draw time.
+    // The motion handler in `mod.rs` already updates
+    // `engine.context_menu.selected` from mouse position on actual motion
+    // events; the adapter copies that into `menu.selected_idx` above. Doing
+    // a redundant hover override here clobbered keyboard navigation: every
+    // queue_draw triggered by `j`/`k` would re-snap selection back to the
+    // item under the (stationary) cursor.
 
     super::quadraui_gtk::draw_context_menu(cr, &ui_layout, &menu, &menu_layout, line_height, theme);
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4632,6 +4632,19 @@ impl SimpleComponent for App {
         if !is_scrollbar_msg {
             self.sync_scrollbar();
         }
+
+        // #435: engine-drawn ctx menu keys (j/k/Enter/Esc) are dispatched on
+        // the editor DA's key controller. If the trigger click landed on a
+        // sibling DA (sidebar, ext panel) the DA never claimed focus, so keys
+        // are dead until the user clicks inside the menu. Grab focus whenever
+        // a ctx menu is open — idempotent if the DA is already focused.
+        if self.engine.borrow().context_menu.is_some() {
+            if let Some(ref drawing) = *self.drawing_area.borrow() {
+                if !drawing.has_focus() {
+                    drawing.grab_focus();
+                }
+            }
+        }
     }
 }
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -4637,12 +4637,10 @@ impl SimpleComponent for App {
         // the editor DA's key controller. If the trigger click landed on a
         // sibling DA (sidebar, ext panel) the DA never claimed focus, so keys
         // are dead until the user clicks inside the menu. Grab focus whenever
-        // a ctx menu is open — idempotent if the DA is already focused.
+        // a ctx menu is open — grab_focus is idempotent if already focused.
         if self.engine.borrow().context_menu.is_some() {
             if let Some(ref drawing) = *self.drawing_area.borrow() {
-                if !drawing.has_focus() {
-                    drawing.grab_focus();
-                }
+                drawing.grab_focus();
             }
         }
     }

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -2035,17 +2035,14 @@ pub(super) fn handle_mouse(
                     match hit {
                         quadraui::TerminalSplitHit::Scrollbar => {
                             let track_start = (geom.top_y + geom.content_y) as u16;
-                            let track_len =
-                                (geom.height - geom.content_y).max(0.0) as u16;
+                            let track_len = (geom.height - geom.content_y).max(0.0) as u16;
                             let total = engine
                                 .active_terminal()
                                 .map(|t| t.history.len())
                                 .unwrap_or(0);
                             let tl = track_len as f32;
                             drag_state.begin(quadraui::DragTarget::ScrollbarY {
-                                widget: quadraui::WidgetId::new(
-                                    "tui:terminal_scrollback",
-                                ),
+                                widget: quadraui::WidgetId::new("tui:terminal_scrollback"),
                                 track_start: track_start as f32,
                                 track_length: tl,
                                 thumb_length: (tl / total.max(1) as f32).max(1.0),


### PR DESCRIPTION
## Summary

Two bugs prevented keyboard nav (`j`/`k`/`Enter`/`Esc`) from working on the engine-drawn context menu (editor right-click, tab right-click, `…` action button, ext panel right-click):

1. **Focus not claimed on open.** If the trigger click landed on a sibling DA (sidebar, ext panel), the editor DA never claimed focus, so the key controller never fired. End-of-`update()` check grabs focus on the editor DA whenever `engine.context_menu.is_some()`.
2. **Draw-time mouse-hover override.** `draw_context_menu_popup` was running its own hit-test on every redraw and snapping `menu.selected_idx` back to the item under the cursor. Pressing `j`/`k` updated the engine, queue_draw fired, the adapter rebuilt the menu with the new selection — then this block stomped it back to the mouse-pointed item. Symptom: keys worked only when the cursor was off the menu. The motion handler in `mod.rs:3744` already maps mouse hover to `engine.context_menu.selected` on real motion events, so the draw-time override was redundant and wrong.

Also includes a stray `cargo fmt` sweep on `src/core/engine/terminal_ops.rs` and `src/tui_main/mouse.rs` left over from PR #433 — unrelated to #435, but needed to pass the fmt gate.

Same focus-on-open bug class as #273 (rasteriser dialog).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --no-default-features --lib` — 1963 passing, 0 failing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke (manual): right-click in editor with focus on a sidebar → `j`/`k` move selection immediately, no click required
- [x] Smoke: leave cursor parked over the menu, press `j`/`k` → selection moves visibly (regression of the draw-override bug)
- [x] Smoke: tab right-click, `…` action button — same

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)