### PR TITLE
fix: TUI Alt+menu_letter activates menu; rebind default panel keys off menu letters (#318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ The tab context menu offers both: "Split Right/Down" creates a Vim window split 
 
 ### Project Search
 
-- `Alt+F` — focus search panel (or click the search icon in the activity bar)
+- `Ctrl+Shift+F` — focus search panel (or click the search icon in the activity bar)
 - Type a query and press `Enter` to search all text files under the project root
 - Respects `.gitignore` rules (powered by the `ignore` crate — same walker as ripgrep)
 - Hidden files/directories and binary files are skipped; results capped at 10,000
@@ -413,7 +413,7 @@ Click the search box in the menu bar (or run `:CommandCenter`) to open the unifi
 
 #### Live Grep
 
-- `Ctrl-Shift-F` or `<leader>sg` (Normal mode) — open the live grep picker
+- `Ctrl-Shift-G` or `<leader>sg` (Normal mode) — open the live grep picker
 - `<leader>sw` — open live grep pre-filled with the word under the cursor
 - A centered floating two-column modal appears over the editor
 - Type to instantly search file *contents* across the entire project (live-as-you-type, query ≥ 2 chars)
@@ -497,7 +497,7 @@ For full details on adapters, launch.json, conditional breakpoints, and the debu
 
 ### File Explorer
 
-- `Ctrl-B` — toggle sidebar; `Alt+E` — focus explorer; `Alt+F` — focus search panel
+- `Ctrl-B` — toggle sidebar; `Ctrl+Shift+E` — focus explorer; `Ctrl+Shift+F` — focus search panel
 - Tree view with Nerd Font file-type icons
 - `j` / `k` — navigate; `l` or `Enter` — open file/expand; `h` — collapse
 - `a` — create file; `A` — create folder; `D` — delete
@@ -977,7 +977,7 @@ Full editor in the terminal via ratatui + crossterm — feature-parity with the 
 | `<leader>rn` | LSP rename symbol — pre-fills `:Rename <word>` |
 | `<leader>ca` | Show LSP code actions for current line |
 | `<leader>sf` | Open fuzzy file finder (same as Ctrl-P) |
-| `<leader>sg` | Open live grep picker (same as Ctrl-Shift-F) |
+| `<leader>sg` | Open live grep picker (same as Ctrl-Shift-G) |
 | `<leader>sw` | Grep word under cursor |
 | `<leader>sb` | Open buffer picker (fuzzy search open buffers) |
 | `<leader>sk` | Search key bindings (fuzzy-filterable reference) |
@@ -1010,7 +1010,7 @@ Full editor in the terminal via ratatui + crossterm — feature-parity with the 
 | `Ctrl-W f` | Split and open file under cursor (`:wincmd f`) |
 | `Ctrl-W d` | Split and go to definition (LSP) (`:wincmd d`) |
 | `Ctrl-P` | Open fuzzy file finder |
-| `Ctrl-Shift-F` | Open live grep picker |
+| `Ctrl-Shift-G` | Open live grep picker |
 | `Ctrl-G` | Show file info (name, line, col, %) |
 | `Ctrl-Shift-P` / `F1` | Command palette |
 | `F5` | Start debugging / continue |
@@ -1020,8 +1020,8 @@ Full editor in the terminal via ratatui + crossterm — feature-parity with the 
 | `F10` | Step over |
 | `F11` | Step into |
 | `Shift+F11` | Step out |
-| `Alt+E` | Focus / unfocus file explorer |
-| `Alt+F` | Focus / unfocus search panel |
+| `Ctrl+Shift+E` | Focus / unfocus file explorer |
+| `Ctrl+Shift+F` | Focus / unfocus search panel |
 | `Ctrl+\` | Split editor right (new editor group) |
 | `Ctrl+1` / `Ctrl+2` | Focus editor group 0 / 1 |
 | `Shift+Alt+F` | Format document (LSP) |

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -532,16 +532,19 @@ fn pk_toggle_sidebar() -> String {
     "<C-b>".to_string()
 }
 fn pk_focus_explorer() -> String {
-    "<A-e>".to_string()
+    // <A-e> moved off in #318 — clashed with menu bar Alt+E (Edit menu).
+    "<C-S-e>".to_string()
 }
 fn pk_focus_search() -> String {
-    "<A-f>".to_string()
+    // <A-f> moved off in #318 — clashed with menu bar Alt+F (File menu).
+    "<C-S-f>".to_string()
 }
 fn pk_fuzzy_finder() -> String {
     "<C-p>".to_string()
 }
 fn pk_live_grep() -> String {
-    "<C-S-f>".to_string()
+    // Moved off <C-S-f> in #318 to free that combo for focus_search.
+    "<C-S-g>".to_string()
 }
 fn pk_command_palette() -> String {
     "<C-S-p>".to_string()
@@ -570,16 +573,16 @@ pub struct PanelKeys {
     /// Toggle sidebar visibility. Default: `<C-b>`
     #[serde(default = "pk_toggle_sidebar")]
     pub toggle_sidebar: String,
-    /// Focus explorer (or return to editor if already focused). Default: `<A-e>`
+    /// Focus explorer (or return to editor if already focused). Default: `<C-S-e>`
     #[serde(default = "pk_focus_explorer")]
     pub focus_explorer: String,
-    /// Open search panel in sidebar. Default: `<A-f>`
+    /// Open search panel in sidebar. Default: `<C-S-f>`
     #[serde(default = "pk_focus_search")]
     pub focus_search: String,
     /// Open fuzzy file finder. Default: `<C-p>`
     #[serde(default = "pk_fuzzy_finder")]
     pub fuzzy_finder: String,
-    /// Open live grep modal. Default: `<C-S-f>`
+    /// Open live grep modal. Default: `<C-S-g>`
     #[serde(default = "pk_live_grep")]
     pub live_grep: String,
     /// Open command palette. Default: `<C-S-p>`
@@ -2567,10 +2570,10 @@ mod tests {
     fn test_panel_keys_defaults() {
         let pk = PanelKeys::default();
         assert_eq!(pk.toggle_sidebar, "<C-b>");
-        assert_eq!(pk.focus_explorer, "<A-e>");
-        assert_eq!(pk.focus_search, "<A-f>");
+        assert_eq!(pk.focus_explorer, "<C-S-e>");
+        assert_eq!(pk.focus_search, "<C-S-f>");
         assert_eq!(pk.fuzzy_finder, "<C-p>");
-        assert_eq!(pk.live_grep, "<C-S-f>");
+        assert_eq!(pk.live_grep, "<C-S-g>");
         assert_eq!(pk.command_palette, "<C-S-p>");
         assert_eq!(pk.add_cursor, "<A-d>");
         assert_eq!(pk.select_all_matches, "<C-S-l>");
@@ -2583,7 +2586,7 @@ mod tests {
         assert_eq!(pk.fuzzy_finder, "<C-A-p>");
         // Unspecified keep defaults
         assert_eq!(pk.toggle_sidebar, "<C-b>");
-        assert_eq!(pk.focus_explorer, "<A-e>");
+        assert_eq!(pk.focus_explorer, "<C-S-e>");
     }
 
     #[test]

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -1410,6 +1410,27 @@ fn event_loop(
             }
         }
 
+        // #318: when the menu bar is hidden, Alt+menu_letter must still
+        // activate the corresponding menu — otherwise the bare letter
+        // falls through to engine.handle_key (which ignores Alt) and
+        // triggers a Vim motion (e.g. Alt+T → t-motion). Show the bar
+        // first so the menu intercept below catches the same event.
+        //
+        // Query the live menu system rather than hardcoding letters so
+        // the truth stays in MENU_STRUCTURE (render.rs) → MenuDef.
+        if !engine.menu_bar_visible {
+            if let quadraui::UiEvent::KeyPressed { key, modifiers, .. } = &ui_event {
+                if modifiers.alt {
+                    if let quadraui::Key::Char(c) = key {
+                        let bar = engine.menu_system.borrow().menu_bar();
+                        if bar.find_alt_target(*c).is_some() {
+                            engine.menu_bar_visible = true;
+                        }
+                    }
+                }
+            }
+        }
+
         // ── MenuSystem intercept — handles all menu keyboard/mouse events ──
         if engine.menu_bar_visible {
             let cols = terminal.size().ok().map(|s| s.width).unwrap_or(80);


### PR DESCRIPTION
## Summary

Two coordinated changes so the TUI menu bar's Alt+letter shortcuts work reliably:

**1. Show the menu bar on demand for Alt+menu_letter** (commit \`d77af72\`)

When the bar was hidden, Alt+F/E/V/G/R/T/H fell through to \`engine.handle_key\` which discards the Alt modifier and treats the bare letter as a Vim motion (Alt+T → t-motion). Now: before the MenuSystem intercept, check the live menu bar via \`MenuBar::find_alt_target\` and set \`menu_bar_visible = true\` for matching Alt+letter — the existing intercept on the same event then activates the menu. Querying the menu system instead of hardcoding letters keeps the truth in MENU_STRUCTURE → MenuDef.

**2. Move conflicting default panel keys off menu letters** (commit \`425a335\`)

\`pk_focus_explorer = <A-e>\` and \`pk_focus_search = <A-f>\` registered as TUI backend accelerators, so they emitted \`UiEvent::Accelerator\` BEFORE the menu-letter check could run. Alt+E toggled the explorer panel and Alt+F toggled search instead of opening the Edit / File menus. Moved to VSCode-parity Ctrl+Shift combos:

| key | old | new |
|---|---|---|
| pk_focus_explorer | \`<A-e>\` | \`<C-S-e>\` |
| pk_focus_search   | \`<A-f>\` | \`<C-S-f>\` |
| pk_live_grep      | \`<C-S-f>\` | \`<C-S-g>\` (displaced by focus_search) |

Users with explicit custom bindings in \`~/.config/vimcode/settings.json\` are unaffected — only the defaults moved.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo test --no-default-features --lib\` — 1965 pass (no regressions, no new tests since the wiring isn't unit-testable without simulating the event loop)
- [x] PanelKeys default-asserting tests updated for new combos
- [x] README key tables updated
- [x] TUI smoke (user-tested on server):
  - Alt+F → File menu opens (was: opened search panel) ✓
  - Alt+E → Edit menu opens (was: opened explorer) ✓
  - Alt+G / Alt+T → menus open ✓
  - Ctrl+Shift+E → focuses explorer ✓
  - Menu bar already visible: existing behavior unchanged

## Out of scope

- Non-menu Alt+letter (e.g. Alt+J) still passes the bare letter to the engine and triggers Vim motions. Broader pattern worth a separate ticket if it surfaces.
- Some terminals don't deliver Alt+letter as a combined modifier event (they send ESC+letter), which causes those keys to "do nothing" or trigger unrelated actions. That's a terminal-emulator / crossterm-meta-encoding issue, not vimcode.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)