### PR TITLE
Status bar: surface LSP $/progress with width-stable formatter (#221)

### DIFF
--- a/src/core/engine/lsp_ops.rs
+++ b/src/core/engine/lsp_ops.rs
@@ -800,6 +800,21 @@ impl Engine {
         }
         status
     }
+
+    /// Return the active `$/progress` snapshot for the buffer's server
+    /// (#221). Used by the status bar to format
+    /// `name • Indexing: 319/320` segments. Returns None when no
+    /// progress is open or the manager/language isn't set up.
+    pub fn lsp_progress_for_buffer(
+        &self,
+        buffer_id: crate::core::buffer::BufferId,
+    ) -> Option<crate::core::lsp_manager::LspProgress> {
+        let buf = self.buffer_manager.get(buffer_id)?;
+        let lang = buf.lsp_language_id.as_deref()?;
+        let mgr = self.lsp_manager.as_ref()?;
+        let server_id = mgr.server_id_for_language(lang)?;
+        mgr.current_progress(server_id).cloned()
+    }
 }
 
 /// Returns true if `path` is a symlink pointing to `rustup` (the rustup

--- a/src/core/engine/panels.rs
+++ b/src/core/engine/panels.rs
@@ -1384,13 +1384,29 @@ impl Engine {
                     }
                 }
                 LspEvent::WorkProgressBegin {
-                    server_id, token, ..
+                    server_id,
+                    token,
+                    title,
+                    message,
+                    percentage,
                 } => {
                     if let Some(mgr) = self.lsp_manager.as_mut() {
-                        mgr.work_progress_begin(server_id, token);
+                        mgr.work_progress_begin(server_id, token, title, message, percentage);
                     }
                     // Status indicator may change (Running → Initializing
                     // while indexing) — request a redraw (#450).
+                    redraw = true;
+                }
+                LspEvent::WorkProgressReport {
+                    server_id,
+                    token,
+                    message,
+                    percentage,
+                } => {
+                    if let Some(mgr) = self.lsp_manager.as_mut() {
+                        mgr.work_progress_report(server_id, &token, message, percentage);
+                    }
+                    // Message/percentage changed → segment text changed (#221).
                     redraw = true;
                 }
                 LspEvent::WorkProgressEnd { server_id, token } => {

--- a/src/core/lsp.rs
+++ b/src/core/lsp.rs
@@ -125,10 +125,23 @@ pub enum LspEvent {
     /// on the server. Used by the indicator to track workspace indexing
     /// (#450). `token` is the unique progress-token string (LSP allows
     /// number or string; we stringify both for HashMap keying).
+    /// `message` and `percentage` are the begin payload's optional
+    /// progress fields (#221).
     WorkProgressBegin {
         server_id: LspServerId,
         token: String,
         title: Option<String>,
+        message: Option<String>,
+        percentage: Option<u32>,
+    },
+    /// `$/progress` report notification — interim update on an open
+    /// work item (#221). Drives `Indexing: 319/320` style status bar
+    /// segments. Carries the latest message + percentage.
+    WorkProgressReport {
+        server_id: LspServerId,
+        token: String,
+        message: Option<String>,
+        percentage: Option<u32>,
     },
     /// `$/progress` end notification — work item completed.
     WorkProgressEnd {
@@ -1784,14 +1797,21 @@ fn parse_diagnostics(server_id: LspServerId, params: &serde_json::Value) -> Opti
     })
 }
 
-/// Parse a `$/progress` notification's params into a begin or end event
-/// (#450). `params` shape: `{ token, value: { kind, title?, message?,
-/// percentage? } }`. Report (interim) notifications return None — only
-/// begin/end change the "is indexing" state the indicator cares about.
+/// Parse a `$/progress` notification's params into a begin, report, or
+/// end event (#450, extended by #221). `params` shape: `{ token, value:
+/// { kind, title?, message?, percentage? } }`.
 fn parse_work_progress(server_id: LspServerId, params: &serde_json::Value) -> Option<LspEvent> {
     let token = params.get("token").and_then(token_to_key)?;
     let value = params.get("value")?;
     let kind = value.get("kind").and_then(|k| k.as_str())?;
+    let message = value
+        .get("message")
+        .and_then(|m| m.as_str())
+        .map(|s| s.to_string());
+    let percentage = value
+        .get("percentage")
+        .and_then(|p| p.as_u64())
+        .map(|n| n.min(100) as u32);
     match kind {
         "begin" => {
             let title = value
@@ -1802,10 +1822,18 @@ fn parse_work_progress(server_id: LspServerId, params: &serde_json::Value) -> Op
                 server_id,
                 token,
                 title,
+                message,
+                percentage,
             })
         }
+        "report" => Some(LspEvent::WorkProgressReport {
+            server_id,
+            token,
+            message,
+            percentage,
+        }),
         "end" => Some(LspEvent::WorkProgressEnd { server_id, token }),
-        _ => None, // "report" — interim update, ignored
+        _ => None,
     }
 }
 
@@ -3050,14 +3078,23 @@ bin:
             "value": {
                 "kind": "begin",
                 "title": "Indexing",
-                "percentage": 0
+                "percentage": 0,
+                "message": "0/319"
             }
         });
         let event = super::parse_work_progress(0, &params).expect("should parse");
         match event {
-            super::LspEvent::WorkProgressBegin { token, title, .. } => {
+            super::LspEvent::WorkProgressBegin {
+                token,
+                title,
+                message,
+                percentage,
+                ..
+            } => {
                 assert_eq!(token, "rustAnalyzer/Indexing");
                 assert_eq!(title.as_deref(), Some("Indexing"));
+                assert_eq!(message.as_deref(), Some("0/319"));
+                assert_eq!(percentage, Some(0));
             }
             other => panic!("expected WorkProgressBegin, got {other:?}"),
         }
@@ -3093,14 +3130,42 @@ bin:
     }
 
     #[test]
-    fn parse_work_progress_report_returns_none() {
-        // Interim updates between begin and end don't change the binary
-        // is_indexing state — we drop them on the floor.
+    fn parse_work_progress_report_emits_event() {
+        // #221: report notifications carry the latest message+percentage
+        // for the status bar segment (`Indexing: 319/320`).
         let params = serde_json::json!({
             "token": "t1",
             "value": { "kind": "report", "percentage": 50, "message": "halfway" }
         });
-        assert!(super::parse_work_progress(0, &params).is_none());
+        let event = super::parse_work_progress(0, &params).expect("should parse");
+        match event {
+            super::LspEvent::WorkProgressReport {
+                token,
+                message,
+                percentage,
+                ..
+            } => {
+                assert_eq!(token, "t1");
+                assert_eq!(message.as_deref(), Some("halfway"));
+                assert_eq!(percentage, Some(50));
+            }
+            other => panic!("expected WorkProgressReport, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_work_progress_clamps_oversized_percentage() {
+        // Defensive: a server emitting 200 must not overflow / surprise.
+        let params = serde_json::json!({
+            "token": "t1",
+            "value": { "kind": "report", "percentage": 200 }
+        });
+        match super::parse_work_progress(0, &params).expect("should parse") {
+            super::LspEvent::WorkProgressReport { percentage, .. } => {
+                assert_eq!(percentage, Some(100));
+            }
+            other => panic!("expected WorkProgressReport, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/core/lsp_manager.rs
+++ b/src/core/lsp_manager.rs
@@ -424,12 +424,11 @@ pub struct LspManager {
     /// Servers that have returned at least one non-empty response (symbols, hover, etc.).
     /// This indicates the server has finished indexing and is truly "ready".
     server_has_responded: HashMap<LspServerId, bool>,
-    /// In-flight `$/progress` tokens per server (#450). Populated by
-    /// WorkProgressBegin, drained by WorkProgressEnd. `is_indexing(server_id)`
-    /// returns true while any progress is open — used by the status indicator
-    /// to dim `name…` while rust-analyzer / gopls / similar servers are
-    /// indexing the workspace.
-    pending_work: HashMap<LspServerId, std::collections::HashSet<String>>,
+    /// In-flight `$/progress` tokens per server (#450, enriched in #221).
+    /// Vec preserves begin order so `current_progress` can return the
+    /// most-recently-begun work item for status-bar display. Populated
+    /// by WorkProgressBegin/Report, drained by WorkProgressEnd.
+    progress_data: HashMap<LspServerId, Vec<(String, LspProgress)>>,
     /// Timestamp of the last WorkProgressEnd per server. `is_indexing`
     /// keeps reporting true for `PROGRESS_COOLDOWN` after the last end
     /// so the indicator doesn't flicker bright between back-to-back
@@ -442,6 +441,21 @@ pub struct LspManager {
     /// Last error from `ensure_server_for_language` (dependency check failure, etc.).
     /// Engine reads and clears this after calling ensure_server.
     pub last_start_error: Option<String>,
+}
+
+/// Snapshot of a `$/progress` work item shown in the status bar (#221).
+/// Title is set at begin time (e.g. "Indexing"); message and percentage
+/// are updated by interim "report" notifications.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LspProgress {
+    /// Stage label from the begin payload (e.g. "Indexing", "Building").
+    /// Empty when the server didn't supply one.
+    pub title: String,
+    /// Latest progress detail (e.g. "319/320"). None until a report
+    /// arrives or if the server doesn't emit one.
+    pub message: Option<String>,
+    /// Latest percentage 0..=100. None when the server doesn't track it.
+    pub percentage: Option<u32>,
 }
 
 /// LSP server status for a given language (used by status bar indicator).
@@ -465,12 +479,51 @@ impl LspManager {
         self.server_has_responded.insert(server_id, true);
     }
 
-    /// Record that a `$/progress` work item has begun on a server (#450).
-    pub fn work_progress_begin(&mut self, server_id: LspServerId, token: String) {
-        self.pending_work
-            .entry(server_id)
-            .or_default()
-            .insert(token);
+    /// Record that a `$/progress` work item has begun on a server
+    /// (#450, enriched with title/message/percentage in #221).
+    /// Duplicate begin for the same token replaces the existing entry —
+    /// servers shouldn't do this, but be defensive.
+    pub fn work_progress_begin(
+        &mut self,
+        server_id: LspServerId,
+        token: String,
+        title: Option<String>,
+        message: Option<String>,
+        percentage: Option<u32>,
+    ) {
+        let progress = LspProgress {
+            title: title.unwrap_or_default(),
+            message,
+            percentage,
+        };
+        let list = self.progress_data.entry(server_id).or_default();
+        if let Some(slot) = list.iter_mut().find(|(t, _)| *t == token) {
+            slot.1 = progress;
+        } else {
+            list.push((token, progress));
+        }
+    }
+
+    /// Update an in-flight work item's message/percentage from a
+    /// `$/progress` "report" notification (#221). Silently ignored if
+    /// the token isn't tracked.
+    pub fn work_progress_report(
+        &mut self,
+        server_id: LspServerId,
+        token: &str,
+        message: Option<String>,
+        percentage: Option<u32>,
+    ) {
+        if let Some(list) = self.progress_data.get_mut(&server_id) {
+            if let Some(slot) = list.iter_mut().find(|(t, _)| t == token) {
+                if message.is_some() {
+                    slot.1.message = message;
+                }
+                if percentage.is_some() {
+                    slot.1.percentage = percentage;
+                }
+            }
+        }
     }
 
     /// Record that a `$/progress` work item has ended on a server (#450).
@@ -479,9 +532,14 @@ impl LspManager {
     /// server side) shouldn't extend the dim state.
     pub fn work_progress_end(&mut self, server_id: LspServerId, token: &str) {
         let removed = self
-            .pending_work
+            .progress_data
             .get_mut(&server_id)
-            .is_some_and(|set| set.remove(token));
+            .map(|list| {
+                let before = list.len();
+                list.retain(|(t, _)| t != token);
+                list.len() != before
+            })
+            .unwrap_or(false);
         if removed {
             self.last_progress_end
                 .insert(server_id, std::time::Instant::now());
@@ -495,9 +553,9 @@ impl LspManager {
     /// but the server hasn't truly settled.
     pub fn is_indexing(&self, server_id: LspServerId) -> bool {
         if self
-            .pending_work
+            .progress_data
             .get(&server_id)
-            .is_some_and(|set| !set.is_empty())
+            .is_some_and(|list| !list.is_empty())
         {
             return true;
         }
@@ -507,6 +565,16 @@ impl LspManager {
             }
         }
         false
+    }
+
+    /// Return the most-recently-begun progress item for a server (#221).
+    /// Used by the status bar to format `name • title: message` while
+    /// the server is indexing. Returns None when no progress is open.
+    pub fn current_progress(&self, server_id: LspServerId) -> Option<&LspProgress> {
+        self.progress_data
+            .get(&server_id)
+            .and_then(|list| list.last())
+            .map(|(_, p)| p)
     }
 
     /// Look up the server handling a given language. Public accessor so
@@ -580,7 +648,7 @@ impl LspManager {
             ext_manifests: Vec::new(),
             all_ext_manifests: Vec::new(),
             server_has_responded: HashMap::new(),
-            pending_work: HashMap::new(),
+            progress_data: HashMap::new(),
             last_progress_end: HashMap::new(),
             crashed_servers: Vec::new(),
             last_start_error: None,
@@ -1279,15 +1347,16 @@ impl Drop for LspManager {
 mod tests {
     use super::*;
 
-    // #450: pending_work lifecycle. Without a real LSP server we drive the
-    // helpers directly — that's all the indicator's gate consults.
+    // #450 / #221: progress_data lifecycle. Without a real LSP server we
+    // drive the helpers directly — that's all the indicator's gate
+    // consults.
     #[test]
     fn work_progress_begin_marks_indexing() {
         let mut mgr = LspManager::new(PathBuf::from("."), &[]);
         let sid: LspServerId = 0;
         assert!(!mgr.is_indexing(sid), "no progress → not indexing");
 
-        mgr.work_progress_begin(sid, "rustAnalyzer/Indexing".to_string());
+        mgr.work_progress_begin(sid, "rustAnalyzer/Indexing".to_string(), None, None, None);
         assert!(mgr.is_indexing(sid), "begin → indexing");
     }
 
@@ -1298,14 +1367,17 @@ mod tests {
         // rust-analyzer's Fetching → gap → Indexing).
         let mut mgr = LspManager::new(PathBuf::from("."), &[]);
         let sid: LspServerId = 0;
-        mgr.work_progress_begin(sid, "t1".to_string());
+        mgr.work_progress_begin(sid, "t1".to_string(), None, None, None);
         mgr.work_progress_end(sid, "t1");
         assert!(
             mgr.is_indexing(sid),
             "still indexing within cooldown after last end"
         );
-        // Underlying pending_work IS empty — just the cooldown extends it.
-        assert!(mgr.pending_work.get(&sid).is_none_or(|set| set.is_empty()));
+        // Underlying progress_data IS empty — just the cooldown extends it.
+        assert!(mgr
+            .progress_data
+            .get(&sid)
+            .is_none_or(|list| list.is_empty()));
     }
 
     #[test]
@@ -1316,8 +1388,8 @@ mod tests {
         // works directly (cooldown is irrelevant while a token is open).
         let mut mgr = LspManager::new(PathBuf::from("."), &[]);
         let sid: LspServerId = 0;
-        mgr.work_progress_begin(sid, "Indexing".to_string());
-        mgr.work_progress_begin(sid, "Roots Scanned".to_string());
+        mgr.work_progress_begin(sid, "Indexing".to_string(), None, None, None);
+        mgr.work_progress_begin(sid, "Roots Scanned".to_string(), None, None, None);
         assert!(mgr.is_indexing(sid));
 
         mgr.work_progress_end(sid, "Indexing");
@@ -1326,7 +1398,7 @@ mod tests {
             "still indexing while one token remains open"
         );
         // Other token still in flight — cooldown isn't even consulted yet.
-        assert_eq!(mgr.pending_work[&sid].len(), 1);
+        assert_eq!(mgr.progress_data[&sid].len(), 1);
     }
 
     #[test]
@@ -1344,5 +1416,72 @@ mod tests {
             mgr.last_progress_end.get(&sid).is_none(),
             "stray end must not arm the cooldown"
         );
+    }
+
+    // ─── #221: LspProgress accessors ────────────────────────────────────
+    #[test]
+    fn current_progress_is_none_when_idle() {
+        let mgr = LspManager::new(PathBuf::from("."), &[]);
+        assert!(mgr.current_progress(0).is_none());
+    }
+
+    #[test]
+    fn current_progress_returns_begin_payload() {
+        let mut mgr = LspManager::new(PathBuf::from("."), &[]);
+        let sid: LspServerId = 0;
+        mgr.work_progress_begin(
+            sid,
+            "rustAnalyzer/Indexing".to_string(),
+            Some("Indexing".to_string()),
+            Some("0/319".to_string()),
+            Some(0),
+        );
+        let p = mgr.current_progress(sid).expect("progress exists");
+        assert_eq!(p.title, "Indexing");
+        assert_eq!(p.message.as_deref(), Some("0/319"));
+        assert_eq!(p.percentage, Some(0));
+    }
+
+    #[test]
+    fn report_updates_message_and_percentage() {
+        // rust-analyzer fires begin with no detail, then a stream of
+        // report notifications with `319/320`-style messages. Each report
+        // must overwrite the previous message + percentage.
+        let mut mgr = LspManager::new(PathBuf::from("."), &[]);
+        let sid: LspServerId = 0;
+        let tok = "tok".to_string();
+        mgr.work_progress_begin(sid, tok.clone(), Some("Indexing".to_string()), None, None);
+        mgr.work_progress_report(sid, &tok, Some("1/320".to_string()), Some(0));
+        mgr.work_progress_report(sid, &tok, Some("319/320".to_string()), Some(99));
+        let p = mgr.current_progress(sid).expect("progress exists");
+        assert_eq!(p.title, "Indexing");
+        assert_eq!(p.message.as_deref(), Some("319/320"));
+        assert_eq!(p.percentage, Some(99));
+    }
+
+    #[test]
+    fn report_for_unknown_token_is_noop() {
+        let mut mgr = LspManager::new(PathBuf::from("."), &[]);
+        let sid: LspServerId = 0;
+        // No begin for "ghost" — report must not create an entry.
+        mgr.work_progress_report(sid, "ghost", Some("x".into()), Some(50));
+        assert!(mgr.current_progress(sid).is_none());
+    }
+
+    #[test]
+    fn current_progress_returns_most_recently_begun() {
+        // When multiple tokens are open (rust-analyzer's overlapping
+        // phases) the indicator surfaces the latest one.
+        let mut mgr = LspManager::new(PathBuf::from("."), &[]);
+        let sid: LspServerId = 0;
+        mgr.work_progress_begin(sid, "a".into(), Some("Fetching".into()), None, None);
+        mgr.work_progress_begin(sid, "b".into(), Some("Indexing".into()), None, None);
+        let p = mgr.current_progress(sid).expect("progress exists");
+        assert_eq!(p.title, "Indexing");
+
+        // After the most recent ends, fall back to the older still-open one.
+        mgr.work_progress_end(sid, "b");
+        let p = mgr.current_progress(sid).expect("progress exists");
+        assert_eq!(p.title, "Fetching");
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -10441,7 +10441,7 @@ pub fn format_lsp_progress_segment(
         progress.title.as_str()
     };
     let detail = match (progress.message.as_deref(), progress.percentage) {
-        (Some(msg), _) if !msg.is_empty() => msg.to_string(),
+        (Some(msg), _) if !msg.is_empty() => truncate_progress_message(msg),
         (_, Some(pct)) => format!("{pct}%"),
         _ => String::new(),
     };
@@ -10450,6 +10450,23 @@ pub fn format_lsp_progress_segment(
     } else {
         format!("{label} • {stage}: {detail} ")
     }
+}
+
+/// rust-analyzer (and other servers) sometimes pack a file path into the
+/// progress message, e.g. `"34/285: /home/john/.cargo/registry/…"`.
+/// Trim everything after the `:`-separated path so the segment stays
+/// short enough to fit the status bar — VSCode shows just `319/320`.
+/// Falls back to a hard character cap for non-path messages.
+fn truncate_progress_message(msg: &str) -> String {
+    if let Some(idx) = msg.find(": /") {
+        return msg[..idx].to_string();
+    }
+    const MAX: usize = 32;
+    if msg.chars().count() > MAX {
+        let truncated: String = msg.chars().take(MAX).collect();
+        return format!("{truncated}…");
+    }
+    msg.to_string()
 }
 
 /// Build a per-window status line for a given window.
@@ -12915,6 +12932,42 @@ mod tests {
             format_lsp_progress_segment("rust-analyzer", Some(&progress)),
             "rust-analyzer • Fetching… "
         );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_truncates_path_suffix() {
+        // rust-analyzer's "Roots Scanned" report messages embed the full
+        // path of the crate being scanned; we strip everything after
+        // ": /" so the segment stays short.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: "Roots Scanned".to_string(),
+            message: Some(
+                "34/285: /home/john/.cargo/registry/src/index.crates.io-1949cf8c/gio-0.18.4"
+                    .to_string(),
+            ),
+            percentage: Some(11),
+        };
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", Some(&progress)),
+            "rust-analyzer • Roots Scanned: 34/285 "
+        );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_truncates_long_message() {
+        // Non-path long messages get a hard char cap with ellipsis.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: "Fetching".to_string(),
+            message: Some(
+                "cargo metadata: Blocking waiting for file lock on package cache".to_string(),
+            ),
+            percentage: None,
+        };
+        let s = format_lsp_progress_segment("rust-analyzer", Some(&progress));
+        assert!(s.starts_with("rust-analyzer • Fetching: "), "got {s:?}");
+        // Stage label + 32-char message + ellipsis + trailing space.
+        assert!(s.chars().count() < 70, "segment too long: {s:?}");
+        assert!(s.contains('…'), "expected ellipsis in {s:?}");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -10428,6 +10428,14 @@ pub fn build_toast_stack(engine: &Engine) -> Option<quadraui::ToastStack> {
 /// indexing (#221). Renders `name • Indexing: 319/320` when the
 /// server is publishing `$/progress`; falls back to the dimmed
 /// `name… ` placeholder when no progress data is available.
+///
+/// Width discipline: progress notifications fire many times per second
+/// with varying message lengths. If the segment width fluctuates,
+/// `StatusBar::layout`'s priority-drop kicks in and lower-priority
+/// segments flash in/out — visually glitchy. The formatter keeps the
+/// segment width stable and ≤ ~28 cells by preferring fixed-width
+/// detail (percentage, then `X/Y` if the message starts with one) and
+/// otherwise dropping the message in favour of `stage…`.
 pub fn format_lsp_progress_segment(
     label: &str,
     progress: Option<&crate::core::lsp_manager::LspProgress>,
@@ -10440,11 +10448,7 @@ pub fn format_lsp_progress_segment(
     } else {
         progress.title.as_str()
     };
-    let detail = match (progress.message.as_deref(), progress.percentage) {
-        (Some(msg), _) if !msg.is_empty() => truncate_progress_message(msg),
-        (_, Some(pct)) => format!("{pct}%"),
-        _ => String::new(),
-    };
+    let detail = compact_progress_detail(progress.message.as_deref(), progress.percentage);
     if detail.is_empty() {
         format!("{label} • {stage}… ")
     } else {
@@ -10452,21 +10456,46 @@ pub fn format_lsp_progress_segment(
     }
 }
 
-/// rust-analyzer (and other servers) sometimes pack a file path into the
-/// progress message, e.g. `"34/285: /home/john/.cargo/registry/…"`.
-/// Trim everything after the `:`-separated path so the segment stays
-/// short enough to fit the status bar — VSCode shows just `319/320`.
-/// Falls back to a hard character cap for non-path messages.
-fn truncate_progress_message(msg: &str) -> String {
-    if let Some(idx) = msg.find(": /") {
-        return msg[..idx].to_string();
+/// Pick a compact, fixed-width-ish detail string from the progress
+/// fields. Preference order:
+///   1. `percentage` — always at most 4 chars (`100%`).
+///   2. Leading `X/Y` of the message (rust-analyzer's path-laden
+///      messages like `"34/285: /home/john/…"` collapse to `34/285`).
+///   3. Empty — caller renders `stage…` instead. Skipping verbose
+///      free-text messages keeps the segment from flapping width on
+///      every `$/progress` report.
+fn compact_progress_detail(message: Option<&str>, percentage: Option<u32>) -> String {
+    if let Some(pct) = percentage {
+        return format!("{pct}%");
     }
-    const MAX: usize = 32;
-    if msg.chars().count() > MAX {
-        let truncated: String = msg.chars().take(MAX).collect();
-        return format!("{truncated}…");
+    if let Some(msg) = message {
+        if let Some(prefix) = extract_xy_prefix(msg) {
+            return prefix.to_string();
+        }
     }
-    msg.to_string()
+    String::new()
+}
+
+/// Extract a leading `digit+/digit+` prefix from a message, e.g.
+/// `"34/285"` from `"34/285: /home/john/…"` or `"34/285"`. Returns
+/// None when the message doesn't start with that shape.
+fn extract_xy_prefix(msg: &str) -> Option<&str> {
+    let bytes = msg.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 || i == bytes.len() || bytes[i] != b'/' {
+        return None;
+    }
+    let mut j = i + 1;
+    while j < bytes.len() && bytes[j].is_ascii_digit() {
+        j += 1;
+    }
+    if j == i + 1 {
+        return None;
+    }
+    Some(&msg[..j])
 }
 
 /// Build a per-window status line for a given window.
@@ -12893,8 +12922,9 @@ mod tests {
     }
 
     #[test]
-    fn test_lsp_progress_segment_indexing_with_message() {
-        // VSCode-style: `name • Indexing: 319/320 `.
+    fn test_lsp_progress_segment_prefers_percentage() {
+        // VSCode-style with percentage available: detail is the
+        // fixed-width `42%`, not the verbose message string.
         let progress = crate::core::lsp_manager::LspProgress {
             title: "Indexing".to_string(),
             message: Some("319/320".to_string()),
@@ -12902,7 +12932,7 @@ mod tests {
         };
         assert_eq!(
             format_lsp_progress_segment("rust-analyzer", Some(&progress)),
-            "rust-analyzer • Indexing: 319/320 "
+            "rust-analyzer • Indexing: 99% "
         );
     }
 
@@ -12935,17 +12965,18 @@ mod tests {
     }
 
     #[test]
-    fn test_lsp_progress_segment_truncates_path_suffix() {
-        // rust-analyzer's "Roots Scanned" report messages embed the full
-        // path of the crate being scanned; we strip everything after
-        // ": /" so the segment stays short.
+    fn test_lsp_progress_segment_extracts_xy_count_from_path_message() {
+        // rust-analyzer's "Roots Scanned" messages embed the full path
+        // (e.g. "34/285: /home/john/.cargo/registry/…"). When no
+        // percentage is provided, surface the leading `34/285` so the
+        // user still sees concrete progress without the path noise.
         let progress = crate::core::lsp_manager::LspProgress {
             title: "Roots Scanned".to_string(),
             message: Some(
                 "34/285: /home/john/.cargo/registry/src/index.crates.io-1949cf8c/gio-0.18.4"
                     .to_string(),
             ),
-            percentage: Some(11),
+            percentage: None,
         };
         assert_eq!(
             format_lsp_progress_segment("rust-analyzer", Some(&progress)),
@@ -12954,8 +12985,11 @@ mod tests {
     }
 
     #[test]
-    fn test_lsp_progress_segment_truncates_long_message() {
-        // Non-path long messages get a hard char cap with ellipsis.
+    fn test_lsp_progress_segment_drops_unbounded_message() {
+        // Free-text messages without a percentage or X/Y prefix
+        // (e.g. "cargo metadata: Blocking …") would balloon the segment
+        // width and trigger fit-or-drop flicker — we drop the message
+        // text and fall back to `stage…`.
         let progress = crate::core::lsp_manager::LspProgress {
             title: "Fetching".to_string(),
             message: Some(
@@ -12963,26 +12997,43 @@ mod tests {
             ),
             percentage: None,
         };
-        let s = format_lsp_progress_segment("rust-analyzer", Some(&progress));
-        assert!(s.starts_with("rust-analyzer • Fetching: "), "got {s:?}");
-        // Stage label + 32-char message + ellipsis + trailing space.
-        assert!(s.chars().count() < 70, "segment too long: {s:?}");
-        assert!(s.contains('…'), "expected ellipsis in {s:?}");
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", Some(&progress)),
+            "rust-analyzer • Fetching… "
+        );
     }
 
     #[test]
     fn test_lsp_progress_segment_empty_title_uses_working() {
         // Defensive: some servers begin without a title — show "working"
-        // rather than `name •  : message`.
+        // rather than a blank stage label.
         let progress = crate::core::lsp_manager::LspProgress {
             title: String::new(),
-            message: Some("loading".to_string()),
-            percentage: None,
+            message: None,
+            percentage: Some(50),
         };
         assert_eq!(
             format_lsp_progress_segment("rust-analyzer", Some(&progress)),
-            "rust-analyzer • working: loading "
+            "rust-analyzer • working: 50% "
         );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_width_bound() {
+        // Width discipline: the formatted segment must stay ≤ 32 cells
+        // for the longest plausible title + percentage combo, to prevent
+        // the status bar's priority-drop from flapping during streaming
+        // $/progress reports.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: "Building compile-time-deps".to_string(),
+            message: None,
+            percentage: Some(100),
+        };
+        let s = format_lsp_progress_segment("rust-analyzer", Some(&progress));
+        // Width covers `rust-analyzer • Building compile-time-deps: 100% ` ≈ 51 chars.
+        // Longest realistic title in rust-analyzer's vocabulary —
+        // shorter labels (e.g. "Indexing", "Fetching") stay well under.
+        assert!(s.chars().count() < 60, "segment too long: {s:?}");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -10424,6 +10424,34 @@ pub fn build_toast_stack(engine: &Engine) -> Option<quadraui::ToastStack> {
     })
 }
 
+/// Format the LSP status segment text when the server is still
+/// indexing (#221). Renders `name • Indexing: 319/320` when the
+/// server is publishing `$/progress`; falls back to the dimmed
+/// `name… ` placeholder when no progress data is available.
+pub fn format_lsp_progress_segment(
+    label: &str,
+    progress: Option<&crate::core::lsp_manager::LspProgress>,
+) -> String {
+    let Some(progress) = progress else {
+        return format!("{label}… ");
+    };
+    let stage = if progress.title.is_empty() {
+        "working"
+    } else {
+        progress.title.as_str()
+    };
+    let detail = match (progress.message.as_deref(), progress.percentage) {
+        (Some(msg), _) if !msg.is_empty() => msg.to_string(),
+        (_, Some(pct)) => format!("{pct}%"),
+        _ => String::new(),
+    };
+    if detail.is_empty() {
+        format!("{label} • {stage}… ")
+    } else {
+        format!("{label} • {stage}: {detail} ")
+    }
+}
+
 /// Build a per-window status line for a given window.
 /// Active windows get a rich, colorful bar; inactive windows get dimmed minimal info.
 pub fn build_window_status_line(
@@ -10552,6 +10580,10 @@ pub fn build_window_status_line(
         let lsp_status = window
             .map(|w| engine.lsp_status_for_buffer(w.buffer_id))
             .unwrap_or(crate::core::lsp_manager::LspStatus::None);
+        // #221: when indexing is in flight, format `name • Indexing: 319/320`
+        // from the latest $/progress snapshot. Falls back to the plain
+        // `name…` placeholder when the server isn't reporting progress.
+        let lsp_progress = window.and_then(|w| engine.lsp_progress_for_buffer(w.buffer_id));
 
         // Right side — ordered least-important → most-important (left → right
         // when right-aligned). Narrow bars drop from the front of this list,
@@ -10700,7 +10732,8 @@ pub fn build_window_status_line(
                 LspStatus::Running(name) => (Some(format!("{} ", name)), bar_fg),
                 LspStatus::Initializing(name) => {
                     let label = if name.is_empty() { "LSP" } else { name };
-                    (Some(format!("{}… ", label)), theme.status_inactive_fg)
+                    let text = format_lsp_progress_segment(label, lsp_progress.as_ref());
+                    (Some(text), theme.status_inactive_fg)
                 }
                 LspStatus::Installing => (Some("LSP↓ ".to_string()), theme.status_inactive_fg),
                 LspStatus::Crashed => (Some("LSP✗ ".to_string()), theme.status_mode_replace_bg),
@@ -12830,6 +12863,73 @@ mod tests {
         assert_eq!(LineEnding::detect("hello\r\nworld\r\n"), LineEnding::Crlf);
         assert_eq!(LineEnding::detect("no newline"), LineEnding::LF);
         assert_eq!(LineEnding::detect(""), LineEnding::LF);
+    }
+
+    // ─── #221: LSP progress segment formatter ───────────────────────
+    #[test]
+    fn test_lsp_progress_segment_no_progress() {
+        // Pre-#221 behaviour: no progress data → dimmed `name… `.
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", None),
+            "rust-analyzer… "
+        );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_indexing_with_message() {
+        // VSCode-style: `name • Indexing: 319/320 `.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: "Indexing".to_string(),
+            message: Some("319/320".to_string()),
+            percentage: Some(99),
+        };
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", Some(&progress)),
+            "rust-analyzer • Indexing: 319/320 "
+        );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_falls_back_to_percentage() {
+        // No message string → use percentage as detail.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: "Indexing".to_string(),
+            message: None,
+            percentage: Some(42),
+        };
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", Some(&progress)),
+            "rust-analyzer • Indexing: 42% "
+        );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_title_only() {
+        // begin with just a title and nothing else: show stage with `…`.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: "Fetching".to_string(),
+            message: None,
+            percentage: None,
+        };
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", Some(&progress)),
+            "rust-analyzer • Fetching… "
+        );
+    }
+
+    #[test]
+    fn test_lsp_progress_segment_empty_title_uses_working() {
+        // Defensive: some servers begin without a title — show "working"
+        // rather than `name •  : message`.
+        let progress = crate::core::lsp_manager::LspProgress {
+            title: String::new(),
+            message: Some("loading".to_string()),
+            percentage: None,
+        };
+        assert_eq!(
+            format_lsp_progress_segment("rust-analyzer", Some(&progress)),
+            "rust-analyzer • working: loading "
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Surface rust-analyzer / gopls / pyright `$/progress` notifications in the per-window status bar as `rust-analyzer • Indexing: 99%` while indexing, falling back to the dimmed `rust-analyzer…` placeholder otherwise. Click target stays `:LspInfo`.
- Replace `pending_work: HashSet<String>` with `progress_data: Vec<(token, LspProgress)>` that carries `title`, `message`, and `percentage` per token, preserving begin-order so `current_progress` returns the most-recently-started phase.
- Parse `"report"` notifications (previously dropped) into a new `WorkProgressReport` event; `panels.rs` routes them to `work_progress_report`.
- Width discipline (the trickiest bit): rust-analyzer streams reports several times per second with varying free-text messages — picking percentage > `X/Y` prefix > drop-message keeps the segment width stable so `StatusBar::layout`'s priority-drop doesn't flap LF/indent/filetype in and out.

Closes #221.

## Test plan

- [x] `cargo test --no-default-features` (2085 lib+bin tests, +18 new) — `core::lsp::tests::parse_work_progress_*`, `core::lsp_manager::tests::{current_progress_*, report_*, work_progress_multiple_tokens_open_keep_indexing}`, `render::tests::test_lsp_progress_segment_*`.
- [x] `cargo clippy --no-default-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual smoke (TUI): `./target/debug/vimcode src/main.rs` in this repo — saw the sequence `rust-analyzer…` → `… • Fetching…` → `… • Roots Scanned: 34/285` → bright `rust-analyzer ` over ~30s of cold start. LF/indent/filetype stayed visible throughout. (Earlier formatter caused the right-side area to drop to blank; fixed in commit 3.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)