### PR TITLE
fix: Open to the Side opens target on the right (#226)

### DIFF
--- a/src/core/engine/windows.rs
+++ b/src/core/engine/windows.rs
@@ -21,10 +21,28 @@ impl Engine {
 
     /// Split the active window in the given direction.
     pub fn split_window(&mut self, direction: SplitDirection, file_path: Option<&Path>) {
+        // Respect splitbelow / splitright. new_first=true means the new
+        // window goes first (top / left).
+        let new_first = match direction {
+            SplitDirection::Horizontal => !self.settings.splitbelow,
+            SplitDirection::Vertical => !self.settings.splitright,
+        };
+        self.split_window_with_new_first(direction, file_path, new_first);
+    }
+
+    /// Split the active window with an explicit `new_first` placement,
+    /// ignoring splitbelow/splitright. Used by UI actions like
+    /// "Open to the Side" whose label commits to a specific side
+    /// regardless of the user's vim defaults.
+    pub fn split_window_with_new_first(
+        &mut self,
+        direction: SplitDirection,
+        file_path: Option<&Path>,
+        new_first: bool,
+    ) {
         let current_buffer_id = self.active_buffer_id();
         let current_window_id = self.active_window_id();
 
-        // Determine which buffer the new window should show
         let new_buffer_id = if let Some(path) = file_path {
             match self.buffer_manager.open_file(path) {
                 Ok(id) => {
@@ -38,27 +56,18 @@ impl Engine {
                 }
             }
         } else {
-            // Same buffer as current window
             current_buffer_id
         };
 
-        // Create new window
         let new_window_id = self.new_window_id();
         let mut new_window = Window::new(new_window_id, new_buffer_id);
 
-        // Copy view state if same buffer
         if new_buffer_id == current_buffer_id {
             new_window.view = self.active_window().view.clone();
         }
 
         self.windows.insert(new_window_id, new_window);
 
-        // Update layout — respect splitbelow / splitright settings.
-        // new_first=true means the *new* window goes first (top / left).
-        let new_first = match direction {
-            SplitDirection::Horizontal => !self.settings.splitbelow,
-            SplitDirection::Vertical => !self.settings.splitright,
-        };
         let tab = self.active_tab_mut();
         tab.layout
             .split_at(current_window_id, direction, new_window_id, new_first);
@@ -1218,12 +1227,14 @@ impl Engine {
                     }
                     "open_side" => {
                         self.open_editor_group(crate::core::window::SplitDirection::Vertical);
-                        // Replace the cloned buffer with the target file.
-                        let path_str = path.display().to_string();
-                        self.execute_command(&format!("e {path_str}"));
+                        let _ = self.open_file_with_mode(path, OpenMode::Permanent);
                     }
                     "open_side_vsplit" => {
-                        self.split_window(SplitDirection::Vertical, None);
+                        // "Open to the Side" always places the target on the
+                        // right, regardless of splitright (#226). Split first
+                        // with new_first=false, then load the target file into
+                        // the new (right, now-active) window.
+                        self.split_window_with_new_first(SplitDirection::Vertical, None, false);
                         let _ = self.open_file_with_mode(path, OpenMode::Permanent);
                     }
                     // new_file, new_folder, rename, delete are handled by the UI backend
@@ -1292,7 +1303,7 @@ impl Engine {
                 }
                 "open_side_vsplit" => {
                     if let Some(path) = self.file_path().map(|p| p.to_path_buf()) {
-                        self.split_window(SplitDirection::Vertical, None);
+                        self.split_window_with_new_first(SplitDirection::Vertical, None, false);
                         let _ = self.open_file_with_mode(&path, OpenMode::Permanent);
                     }
                 }

--- a/tests/context_menu.rs
+++ b/tests/context_menu.rs
@@ -475,6 +475,38 @@ fn test_open_side_from_context_menu() {
     assert_eq!(action.as_deref(), Some("open_side"));
     // Should have created a new editor group
     assert!(e.editor_groups.len() >= 2);
+    // #226: the new group's active window must hold the target file's buffer,
+    // not a clone of the prior tab. open_editor_group clones the current buffer
+    // into the new group; open_side then has to replace it with the target.
+    assert_eq!(
+        e.file_path().map(|p| p.as_path()),
+        Some(path.as_path()),
+        "open_side should leave the target file in the new group's active window"
+    );
+}
+
+#[test]
+fn test_open_side_path_with_spaces() {
+    // Regression for #226: the prior implementation used `:e {path}` which
+    // tokenised on whitespace and silently dropped paths containing spaces.
+    let dir = std::env::temp_dir().join(format!("ctx_openside spaces {}", rand_name()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("my file.txt");
+    std::fs::write(&path, "content").unwrap();
+
+    let mut e = engine_with("hello");
+    e.open_explorer_context_menu(path.clone(), false, 5, 10);
+    let idx = e
+        .context_menu
+        .as_ref()
+        .unwrap()
+        .items
+        .iter()
+        .position(|i| i.action == "open_side")
+        .unwrap();
+    e.context_menu.as_mut().unwrap().selected = idx;
+    e.context_menu_confirm();
+    assert_eq!(e.file_path().map(|p| p.as_path()), Some(path.as_path()));
 }
 
 #[test]
@@ -1056,6 +1088,78 @@ fn test_explorer_open_side_vsplit_creates_split() {
     assert_eq!(e.file_path().unwrap(), &path);
 
     std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_explorer_open_side_vsplit_target_on_right_regardless_of_splitright() {
+    // #226: "Open to the Side" must place the target on the right
+    // regardless of the user's splitright setting. With vim's default
+    // splitright=false, a plain :vsplit would put the new window on the
+    // left — but the menu label commits to "to the side" semantics.
+    use vimcode_core::core::engine::OpenMode;
+    use vimcode_core::core::window::WindowRect;
+
+    for splitright in [false, true] {
+        let dir =
+            std::env::temp_dir().join(format!("expl_vsplit_side_{}_{}", splitright, rand_name()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_a = dir.join("original.txt");
+        let file_b = dir.join("target.txt");
+        std::fs::write(&file_a, "A").unwrap();
+        std::fs::write(&file_b, "B").unwrap();
+
+        let mut e = engine_with("");
+        e.settings.splitright = splitright;
+        e.open_file_with_mode(&file_a, OpenMode::Permanent).unwrap();
+
+        e.open_explorer_context_menu(file_b.clone(), false, 5, 10);
+        let idx = e
+            .context_menu
+            .as_ref()
+            .unwrap()
+            .items
+            .iter()
+            .position(|i| i.action == "open_side_vsplit")
+            .unwrap();
+        e.context_menu.as_mut().unwrap().selected = idx;
+        e.context_menu_confirm();
+
+        let editor_bounds = WindowRect::new(0.0, 0.0, 1000.0, 600.0);
+        let (window_rects, _) = e.calculate_group_window_rects(editor_bounds, 20.0);
+        assert_eq!(window_rects.len(), 2);
+
+        // The target window (file_b) must be at x >= the other window's x.
+        let target_x = window_rects
+            .iter()
+            .find_map(|(wid, rect)| {
+                let buf_id = e.windows.get(wid).unwrap().buffer_id;
+                let bs = e.buffer_manager.get(buf_id).unwrap();
+                if bs.file_path.as_deref() == Some(&file_b) {
+                    Some(rect.x)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        let other_x = window_rects
+            .iter()
+            .find_map(|(wid, rect)| {
+                let buf_id = e.windows.get(wid).unwrap().buffer_id;
+                let bs = e.buffer_manager.get(buf_id).unwrap();
+                if bs.file_path.as_deref() == Some(&file_a) {
+                    Some(rect.x)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert!(
+            target_x > other_x,
+            "splitright={splitright}: target x={target_x} should be greater than original x={other_x} (target on right)"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two bugs in the explorer right-click "Open to the Side" handlers:

- **`open_side`** called `execute_command("e {path}")`, which returns `EngineAction::OpenFile(path)` — but the action was discarded so the target file never replaced the cloned tab. Now calls `open_file_with_mode` directly. Side benefit: handles paths with spaces (the old `:e` form tokenised on whitespace).
- **`open_side_vsplit`** routed through `split_window`, which derives `new_first` from `settings.splitright`. With vim's default `splitright=false`, the target landed on the LEFT. The menu label commits to "to the side" semantics; `split_window` body extracted into `split_window_with_new_first` so UI actions can force `new_first=false` regardless of user settings. Both explorer and editor `open_side_vsplit` paths now use it.

Closes #226.

## Test plan

- [x] `cargo test --no-default-features --test context_menu` — all 73 tests pass, including 3 new/strengthened:
  - `test_open_side_from_context_menu` — asserts target ends up in active group
  - `test_open_side_path_with_spaces` — regression for the `:e` tokenisation bug
  - `test_explorer_open_side_vsplit_target_on_right_regardless_of_splitright` — loops both `splitright` values, asserts target's `x > original's x` via `calculate_group_window_rects`
- [x] `cargo build`
- [x] `cargo clippy --no-default-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] Smoke-tested in GTK by user (Open to the Side, vsplit variant, path with spaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)