### PR TITLE
feat(gtk): migrate global status bar to quadraui::ScreenLayout (#446)

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -793,20 +793,16 @@ pub(super) fn draw_editor(
         if let Some(ref wm) = screen.wildmenu {
             let bar = render::wildmenu_to_status_bar(wm, &theme);
             {
-                use quadraui::{ScreenLayout as QScreenLayout, Surface};
+                use quadraui::Backend;
                 backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                     b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                     b.set_current_line_height(line_height);
-                    let rect =
-                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32);
-                    let mut frame = QScreenLayout::new();
-                    frame.push(Surface::StatusBar {
-                        rect,
-                        bar: &bar,
-                        hovered: None,
-                        pressed: None,
-                    });
-                    frame.draw(b);
+                    b.draw_status_bar(
+                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32),
+                        &bar,
+                        None,
+                        None,
+                    );
                 });
             }
             next_y += line_height;
@@ -824,20 +820,16 @@ pub(super) fn draw_editor(
         // No terminal: original layout with per-window or global status at bottom
         let status_y = height as f64 - status_bar_height;
         if let Some(ref bar) = screen.global_status_bar {
-            use quadraui::{ScreenLayout as QScreenLayout, Surface};
+            use quadraui::Backend;
             backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                 b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                 b.set_current_line_height(line_height);
-                let rect =
-                    quadraui::Rect::new(0.0, status_y as f32, width as f32, line_height as f32);
-                let mut frame = QScreenLayout::new();
-                frame.push(Surface::StatusBar {
-                    rect,
+                b.draw_status_bar(
+                    quadraui::Rect::new(0.0, status_y as f32, width as f32, line_height as f32),
                     bar,
-                    hovered: None,
-                    pressed: None,
-                });
-                frame.draw(b);
+                    None,
+                    None,
+                );
             });
         }
         let mut next_y = if per_window_status {
@@ -848,20 +840,16 @@ pub(super) fn draw_editor(
         if let Some(ref wm) = screen.wildmenu {
             let bar = render::wildmenu_to_status_bar(wm, &theme);
             {
-                use quadraui::{ScreenLayout as QScreenLayout, Surface};
+                use quadraui::Backend;
                 backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                     b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                     b.set_current_line_height(line_height);
-                    let rect =
-                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32);
-                    let mut frame = QScreenLayout::new();
-                    frame.push(Surface::StatusBar {
-                        rect,
-                        bar: &bar,
-                        hovered: None,
-                        pressed: None,
-                    });
-                    frame.draw(b);
+                    b.draw_status_bar(
+                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32),
+                        &bar,
+                        None,
+                        None,
+                    );
                 });
             }
             next_y += line_height;
@@ -1106,21 +1094,16 @@ pub(super) fn draw_tab_bar(
     let ui_font_desc = FontDescription::from_string(&UI_FONT());
     layout.set_font_description(Some(&ui_font_desc));
 
-    use quadraui::{Backend, ScreenLayout as QScreenLayout, Surface};
-    let tab_row_h = (line_height * 1.6).ceil();
-    let rect = quadraui::Rect::new(0.0, y_offset as f32, width as f32, tab_row_h as f32);
+    use quadraui::Backend;
     let hits = backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
-        let mut frame = QScreenLayout::new();
-        frame.push(Surface::TabBar {
-            rect,
+        let tab_row_h = (line_height * 1.6).ceil();
+        b.draw_tab_bar(
+            quadraui::Rect::new(0.0, y_offset as f32, width as f32, tab_row_h as f32),
             bar,
-            hovered_close: hovered_close_tab,
-        });
-        frame.draw(b);
-        // Recover hits via the post-paint layout call (#446 / quadraui#210).
-        b.tab_bar_layout(rect, bar)
+            hovered_close_tab,
+        )
     });
 
     layout.set_font_description(Some(&saved_font));
@@ -1175,13 +1158,10 @@ pub(super) fn draw_tab_bar(
     )
 }
 
-/// Draw the breadcrumb bar via the quadraui `ScreenLayout` frame pipeline.
+/// Draw the breadcrumb bar via `Backend::draw_status_bar`.
 ///
 /// The pre-built `quadraui::StatusBar` primitive comes from
-/// `render::ScreenLayout` (built by `render::build_screen_layout`).
-/// Paint pushes a `Surface::StatusBar` onto a one-shot frame; the
-/// `StatusBarLayout` used by the hit-test cache is recovered via the
-/// post-paint `status_bar_layout()` call on the backend (#446 / quadraui#210).
+/// `ScreenLayout` (built by `render::build_screen_layout`).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_breadcrumb_bar(
     backend: &Rc<RefCell<super::backend::GtkBackend>>,
@@ -1193,7 +1173,7 @@ pub(super) fn draw_breadcrumb_bar(
     line_height: f64,
     y_offset: f64,
 ) -> quadraui::StatusBarLayout {
-    use quadraui::{Backend, ScreenLayout as QScreenLayout, Surface};
+    use quadraui::Backend;
     let mut result = quadraui::StatusBarLayout {
         bar_width: 0.0,
         bar_height: 0.0,
@@ -1201,19 +1181,15 @@ pub(super) fn draw_breadcrumb_bar(
         hit_regions: Vec::new(),
         resolved_right_start: 0,
     };
-    let rect = quadraui::Rect::new(0.0, y_offset as f32, width as f32, line_height as f32);
     backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
-        let mut frame = QScreenLayout::new();
-        frame.push(Surface::StatusBar {
-            rect,
+        result = b.draw_status_bar(
+            quadraui::Rect::new(0.0, y_offset as f32, width as f32, line_height as f32),
             bar,
-            hovered: None,
-            pressed: None,
-        });
-        frame.draw(b);
-        result = b.status_bar_layout(rect, bar);
+            None,
+            None,
+        );
     });
     result
 }

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -820,16 +820,23 @@ pub(super) fn draw_editor(
         // No terminal: original layout with per-window or global status at bottom
         let status_y = height as f64 - status_bar_height;
         if let Some(ref bar) = screen.global_status_bar {
-            use quadraui::Backend;
+            // #446: route paint through quadraui's ScreenLayout. Layout return
+            // is discarded — the global status bar isn't a click target so it
+            // doesn't need the StatusBarLayout cached for hit-test.
+            use quadraui::{ScreenLayout as QScreenLayout, Surface};
             backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                 b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                 b.set_current_line_height(line_height);
-                b.draw_status_bar(
-                    quadraui::Rect::new(0.0, status_y as f32, width as f32, line_height as f32),
+                let rect =
+                    quadraui::Rect::new(0.0, status_y as f32, width as f32, line_height as f32);
+                let mut frame = QScreenLayout::new();
+                frame.push(Surface::StatusBar {
+                    rect,
                     bar,
-                    None,
-                    None,
-                );
+                    hovered: None,
+                    pressed: None,
+                });
+                frame.draw(b);
             });
         }
         let mut next_y = if per_window_status {

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -793,16 +793,20 @@ pub(super) fn draw_editor(
         if let Some(ref wm) = screen.wildmenu {
             let bar = render::wildmenu_to_status_bar(wm, &theme);
             {
-                use quadraui::Backend;
+                use quadraui::{ScreenLayout as QScreenLayout, Surface};
                 backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                     b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                     b.set_current_line_height(line_height);
-                    b.draw_status_bar(
-                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32),
-                        &bar,
-                        None,
-                        None,
-                    );
+                    let rect =
+                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32);
+                    let mut frame = QScreenLayout::new();
+                    frame.push(Surface::StatusBar {
+                        rect,
+                        bar: &bar,
+                        hovered: None,
+                        pressed: None,
+                    });
+                    frame.draw(b);
                 });
             }
             next_y += line_height;
@@ -820,16 +824,20 @@ pub(super) fn draw_editor(
         // No terminal: original layout with per-window or global status at bottom
         let status_y = height as f64 - status_bar_height;
         if let Some(ref bar) = screen.global_status_bar {
-            use quadraui::Backend;
+            use quadraui::{ScreenLayout as QScreenLayout, Surface};
             backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                 b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                 b.set_current_line_height(line_height);
-                b.draw_status_bar(
-                    quadraui::Rect::new(0.0, status_y as f32, width as f32, line_height as f32),
+                let rect =
+                    quadraui::Rect::new(0.0, status_y as f32, width as f32, line_height as f32);
+                let mut frame = QScreenLayout::new();
+                frame.push(Surface::StatusBar {
+                    rect,
                     bar,
-                    None,
-                    None,
-                );
+                    hovered: None,
+                    pressed: None,
+                });
+                frame.draw(b);
             });
         }
         let mut next_y = if per_window_status {
@@ -840,16 +848,20 @@ pub(super) fn draw_editor(
         if let Some(ref wm) = screen.wildmenu {
             let bar = render::wildmenu_to_status_bar(wm, &theme);
             {
-                use quadraui::Backend;
+                use quadraui::{ScreenLayout as QScreenLayout, Surface};
                 backend.borrow_mut().enter_frame_scope(cr, &layout, |b| {
                     b.set_current_theme(super::quadraui_gtk::q_theme(&theme));
                     b.set_current_line_height(line_height);
-                    b.draw_status_bar(
-                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32),
-                        &bar,
-                        None,
-                        None,
-                    );
+                    let rect =
+                        quadraui::Rect::new(0.0, next_y as f32, width as f32, line_height as f32);
+                    let mut frame = QScreenLayout::new();
+                    frame.push(Surface::StatusBar {
+                        rect,
+                        bar: &bar,
+                        hovered: None,
+                        pressed: None,
+                    });
+                    frame.draw(b);
                 });
             }
             next_y += line_height;
@@ -1094,16 +1106,21 @@ pub(super) fn draw_tab_bar(
     let ui_font_desc = FontDescription::from_string(&UI_FONT());
     layout.set_font_description(Some(&ui_font_desc));
 
-    use quadraui::Backend;
+    use quadraui::{Backend, ScreenLayout as QScreenLayout, Surface};
+    let tab_row_h = (line_height * 1.6).ceil();
+    let rect = quadraui::Rect::new(0.0, y_offset as f32, width as f32, tab_row_h as f32);
     let hits = backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
-        let tab_row_h = (line_height * 1.6).ceil();
-        b.draw_tab_bar(
-            quadraui::Rect::new(0.0, y_offset as f32, width as f32, tab_row_h as f32),
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::TabBar {
+            rect,
             bar,
-            hovered_close_tab,
-        )
+            hovered_close: hovered_close_tab,
+        });
+        frame.draw(b);
+        // Recover hits via the post-paint layout call (#446 / quadraui#210).
+        b.tab_bar_layout(rect, bar)
     });
 
     layout.set_font_description(Some(&saved_font));
@@ -1158,10 +1175,13 @@ pub(super) fn draw_tab_bar(
     )
 }
 
-/// Draw the breadcrumb bar via `Backend::draw_status_bar`.
+/// Draw the breadcrumb bar via the quadraui `ScreenLayout` frame pipeline.
 ///
 /// The pre-built `quadraui::StatusBar` primitive comes from
-/// `ScreenLayout` (built by `render::build_screen_layout`).
+/// `render::ScreenLayout` (built by `render::build_screen_layout`).
+/// Paint pushes a `Surface::StatusBar` onto a one-shot frame; the
+/// `StatusBarLayout` used by the hit-test cache is recovered via the
+/// post-paint `status_bar_layout()` call on the backend (#446 / quadraui#210).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_breadcrumb_bar(
     backend: &Rc<RefCell<super::backend::GtkBackend>>,
@@ -1173,7 +1193,7 @@ pub(super) fn draw_breadcrumb_bar(
     line_height: f64,
     y_offset: f64,
 ) -> quadraui::StatusBarLayout {
-    use quadraui::Backend;
+    use quadraui::{Backend, ScreenLayout as QScreenLayout, Surface};
     let mut result = quadraui::StatusBarLayout {
         bar_width: 0.0,
         bar_height: 0.0,
@@ -1181,15 +1201,19 @@ pub(super) fn draw_breadcrumb_bar(
         hit_regions: Vec::new(),
         resolved_right_start: 0,
     };
+    let rect = quadraui::Rect::new(0.0, y_offset as f32, width as f32, line_height as f32);
     backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
         b.set_current_theme(super::quadraui_gtk::q_theme(theme));
         b.set_current_line_height(line_height);
-        result = b.draw_status_bar(
-            quadraui::Rect::new(0.0, y_offset as f32, width as f32, line_height as f32),
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::StatusBar {
+            rect,
             bar,
-            None,
-            None,
-        );
+            hovered: None,
+            pressed: None,
+        });
+        frame.draw(b);
+        result = b.status_bar_layout(rect, bar);
     });
     result
 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -3310,30 +3310,22 @@ impl SimpleComponent for App {
             let engine_d = engine.clone();
             let hits_d = activity_bar_hits.clone();
             let hover_d = activity_bar_hover.clone();
-            let bk_ad = backend.clone();
             widgets.activity_bar.set_draw_func(move |da, cr, _w, _h| {
-                use quadraui::{Backend, ScreenLayout as QScreenLayout, Surface};
                 let engine = engine_d.borrow();
                 let theme = Theme::from_name(&engine.settings.colorscheme);
                 let pango_ctx = pangocairo::create_context(cr);
                 let layout = pango::Layout::new(&pango_ctx);
                 let bar = build_gtk_activity_bar_primitive(&engine, &theme);
                 let hovered = hover_d.get();
-                let rect = quadraui::Rect::new(0.0, 0.0, da.width() as f32, da.height() as f32);
-                let hits = bk_ad.borrow_mut().enter_frame_scope(cr, &layout, |b| {
-                    b.set_current_theme(crate::gtk::quadraui_gtk::q_theme(&theme));
-                    b.set_current_line_height(layout.pixel_size().1.max(1) as f64);
-                    let mut frame = QScreenLayout::new();
-                    frame.push(Surface::ActivityBar {
-                        rect,
-                        bar: &bar,
-                        hovered,
-                    });
-                    frame.draw(b);
-                    // Recover row hits via the post-paint layout call
-                    // (#446 / quadraui#210).
-                    b.activity_bar_layout(rect, &bar)
-                });
+                let hits = quadraui::gtk::draw_activity_bar(
+                    cr,
+                    &layout,
+                    da.width() as f64,
+                    da.height() as f64,
+                    &bar,
+                    &crate::gtk::quadraui_gtk::q_theme(&theme),
+                    hovered,
+                );
                 *hits_d.borrow_mut() = hits;
             });
         }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -3310,22 +3310,30 @@ impl SimpleComponent for App {
             let engine_d = engine.clone();
             let hits_d = activity_bar_hits.clone();
             let hover_d = activity_bar_hover.clone();
+            let bk_ad = backend.clone();
             widgets.activity_bar.set_draw_func(move |da, cr, _w, _h| {
+                use quadraui::{Backend, ScreenLayout as QScreenLayout, Surface};
                 let engine = engine_d.borrow();
                 let theme = Theme::from_name(&engine.settings.colorscheme);
                 let pango_ctx = pangocairo::create_context(cr);
                 let layout = pango::Layout::new(&pango_ctx);
                 let bar = build_gtk_activity_bar_primitive(&engine, &theme);
                 let hovered = hover_d.get();
-                let hits = quadraui::gtk::draw_activity_bar(
-                    cr,
-                    &layout,
-                    da.width() as f64,
-                    da.height() as f64,
-                    &bar,
-                    &crate::gtk::quadraui_gtk::q_theme(&theme),
-                    hovered,
-                );
+                let rect = quadraui::Rect::new(0.0, 0.0, da.width() as f32, da.height() as f32);
+                let hits = bk_ad.borrow_mut().enter_frame_scope(cr, &layout, |b| {
+                    b.set_current_theme(crate::gtk::quadraui_gtk::q_theme(&theme));
+                    b.set_current_line_height(layout.pixel_size().1.max(1) as f64);
+                    let mut frame = QScreenLayout::new();
+                    frame.push(Surface::ActivityBar {
+                        rect,
+                        bar: &bar,
+                        hovered,
+                    });
+                    frame.draw(b);
+                    // Recover row hits via the post-paint layout call
+                    // (#446 / quadraui#210).
+                    b.activity_bar_layout(rect, &bar)
+                });
                 *hits_d.borrow_mut() = hits;
             });
         }


### PR DESCRIPTION
## Summary

First foothold of #446 — paint the global status bar via `quadraui::ScreenLayout::draw()` instead of a direct `b.draw_status_bar` call.

\`\`\`rust
// Before:
b.draw_status_bar(rect, bar, None, None);

// After:
let mut frame = quadraui::ScreenLayout::new();
frame.push(Surface::StatusBar { rect, bar, hovered: None, pressed: None });
frame.draw(b);
\`\`\`

Layout return is discarded — the global status bar isn't a click target so the `StatusBarLayout` doesn't need to be cached for hit-test.

## Why only one surface?

The other four chrome surfaces (wildmenu, breadcrumb, tab bar, activity bar) were attempted in commit `0803fcd` and reverted in `ec588f0` after smoke-testing surfaced regressions. Root cause: quadraui's `status_bar_layout()` / `tab_bar_layout()` / `activity_bar_layout()` methods don't reproduce the GTK rasteriser's geometry byte-for-byte — they use `self.pango_ctx` (UI font, set at app startup) and the generic primitive `layout()` fn, while the rasterisers measure via the cairo context's pango layout (editor monospace in `draw_editor`) and apply per-rasteriser geometry constants (tab_pad / inner_gap / outer_gap, italic for previews, etc.). Result: hit-data drifts.

Wildmenu paint also broke for a still-unexplained reason despite having an identical call shape to the global status bar — flagged separately in the issue comment.

Full analysis: https://github.com/JDonaghy/vimcode/issues/446#issuecomment-4478930179

The remaining 4 surfaces land once quadraui ships the rasteriser/`_layout` geometry-source unification.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo clippy --no-default-features -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test --no-default-features --lib\` — 1989 lib tests pass
- [x] Smoke-tested in GTK: global status bar paints correctly at bottom of window (per-window status OFF, no terminal panel) — confirmed by user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)