### PR TITLE
feat(gtk): migrate 7 popup/overlay surfaces to ScreenLayout::draw() (#463)

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -372,11 +372,19 @@ pub(super) fn draw_editor(
 
     // 5b. Draw completion popup (on top of everything else). Cache
     //     the layout so the click handler can hit-test items.
-    *completion_layout_out.borrow_mut() =
-        draw_completion_popup(cr, &layout, &screen, &theme, line_height, char_width);
+    *completion_layout_out.borrow_mut() = draw_completion_popup(
+        backend,
+        cr,
+        &layout,
+        &screen,
+        &theme,
+        line_height,
+        char_width,
+    );
 
     // 5c. Draw hover popup (on top of everything else)
     draw_hover_popup(
+        backend,
         cr,
         &layout,
         &screen,
@@ -389,6 +397,7 @@ pub(super) fn draw_editor(
 
     // 5c2. Draw signature-help popup (on top of everything else, shown in insert mode)
     draw_signature_popup(
+        backend,
         cr,
         &layout,
         &screen,
@@ -401,6 +410,7 @@ pub(super) fn draw_editor(
 
     // 5c3. Draw diff peek popup (inline git hunk preview)
     draw_diff_peek_popup(
+        backend,
         cr,
         &layout,
         &screen,
@@ -907,6 +917,7 @@ pub(super) fn draw_editor(
     ));
 
     let (btn_rects, popup_rect) = draw_dialog_popup(
+        backend,
         cr,
         &layout,
         &screen,
@@ -933,6 +944,7 @@ pub(super) fn draw_editor(
         None
     } else {
         draw_context_menu_popup(
+            backend,
             cr,
             &layout,
             &screen,
@@ -1308,6 +1320,7 @@ pub(super) fn draw_window_separators(
 /// `quadraui_gtk::draw_completions` shim. Returns the resolved
 /// `CompletionsLayout` so the click handler can hit-test items.
 pub(super) fn draw_completion_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -1353,13 +1366,28 @@ pub(super) fn draw_completion_popup(
         |_| quadraui::CompletionItemMeasure::new(line_height_f),
     );
 
-    super::quadraui_gtk::draw_completions(cr, layout, &completions, &q_layout, theme);
+    // #463: route paint through quadraui::ScreenLayout. The
+    // CompletionsLayout returned by `completions.layout(...)` is what
+    // both paint and click consume — one source of truth.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        b.set_current_char_width(char_width);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::Completions {
+            completions: &completions,
+            layout: &q_layout,
+        });
+        frame.draw(b);
+    });
 
     Some(q_layout)
 }
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_hover_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -1413,15 +1441,20 @@ pub(super) fn draw_hover_popup(
         0.0,
     );
 
-    super::quadraui_gtk::draw_tooltip(
-        cr,
-        layout,
-        &tooltip,
-        &tip_layout,
-        line_height,
-        char_width,
-        theme,
-    );
+    // #463: route paint through quadraui::ScreenLayout. Tooltip is
+    // non-interactive — no hit data to recover.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        b.set_current_char_width(char_width);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::Tooltip {
+            tooltip: &tooltip,
+            layout: &tip_layout,
+        });
+        frame.draw(b);
+    });
 }
 
 /// Draw the LSP/editor hover popup via the `quadraui::RichTextPopup`
@@ -1498,6 +1531,12 @@ pub(super) fn draw_editor_hover_popup(
         },
     );
 
+    // #463: rich text popup migration reverted — paint goes through
+    // the legacy quadraui_gtk shim which returns link rects directly.
+    // Migration to Surface::RichTextPopup caused click hit-test
+    // regression (links + scrollbar track/thumb fell through to editor
+    // scrollbar underneath). Needs deeper investigation; tracked under
+    // #463 follow-up.
     let link_rects = super::quadraui_gtk::draw_rich_text_popup(
         cr,
         layout,
@@ -1537,6 +1576,7 @@ pub(super) fn draw_editor_hover_popup(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_diff_peek_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -1620,19 +1660,24 @@ pub(super) fn draw_diff_peek_popup(
         0.0,
     );
 
-    super::quadraui_gtk::draw_tooltip(
-        cr,
-        layout,
-        &tooltip,
-        &tip_layout,
-        line_height,
-        char_width,
-        theme,
-    );
+    // #463: route paint through quadraui::ScreenLayout.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        b.set_current_char_width(char_width);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::Tooltip {
+            tooltip: &tooltip,
+            layout: &tip_layout,
+        });
+        frame.draw(b);
+    });
 }
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_signature_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -1710,15 +1755,19 @@ pub(super) fn draw_signature_popup(
         0.0,
     );
 
-    super::quadraui_gtk::draw_tooltip(
-        cr,
-        layout,
-        &tooltip,
-        &tip_layout,
-        line_height,
-        char_width,
-        theme,
-    );
+    // #463: route paint through quadraui::ScreenLayout.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        b.set_current_char_width(char_width);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::Tooltip {
+            tooltip: &tooltip,
+            layout: &tip_layout,
+        });
+        frame.draw(b);
+    });
 }
 
 /// Draw the inline find/replace overlay at the top-right of the editor.
@@ -1857,6 +1906,7 @@ fn draw_tab_switcher_popup_list(
 ///   click-outside-to-dismiss to mis-fire.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub(super) fn draw_dialog_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -1959,8 +2009,32 @@ pub(super) fn draw_dialog_popup(
         dialog_layout.bounds.height as f64,
     );
 
-    let btn_rects =
-        super::quadraui_gtk::draw_dialog(cr, layout, &dialog, &dialog_layout, line_height, theme);
+    // #463: route paint through quadraui::ScreenLayout. Button click
+    // rectangles are already carried by `DialogLayout.visible_buttons`,
+    // so no need for a second backend call to recover them.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::Dialog {
+            dialog: &dialog,
+            layout: &dialog_layout,
+        });
+        frame.draw(b);
+    });
+    let btn_rects: Vec<(f64, f64, f64, f64)> = dialog_layout
+        .visible_buttons
+        .iter()
+        .map(|vb| {
+            (
+                vb.bounds.x as f64,
+                vb.bounds.y as f64,
+                vb.bounds.width as f64,
+                vb.bounds.height as f64,
+            )
+        })
+        .collect();
     (btn_rects, Some(popup_rect))
 }
 
@@ -1968,6 +2042,7 @@ pub(super) fn draw_dialog_popup(
 /// Uses the same data as TUI/Win-GUI for visual consistency.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_context_menu_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     _layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -2037,7 +2112,18 @@ pub(super) fn draw_context_menu_popup(
     // queue_draw triggered by `j`/`k` would re-snap selection back to the
     // item under the (stationary) cursor.
 
-    super::quadraui_gtk::draw_context_menu(cr, &ui_layout, &menu, &menu_layout, line_height, theme);
+    // #463: route paint through quadraui::ScreenLayout.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, &ui_layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::ContextMenu {
+            menu: &menu,
+            layout: &menu_layout,
+        });
+        frame.draw(b);
+    });
 
     Some(menu_layout)
 }
@@ -2049,6 +2135,7 @@ pub(super) fn draw_context_menu_popup(
 /// `ContextMenuLayout` for the click/motion hit-test cache.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_explorer_context_menu_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     _layout: &pango::Layout,
     engine: &Engine,
@@ -2118,7 +2205,18 @@ pub(super) fn draw_explorer_context_menu_popup(
         item_height,
     );
 
-    super::quadraui_gtk::draw_context_menu(cr, &ui_layout, &menu, &menu_layout, line_height, theme);
+    // #463: route paint through quadraui::ScreenLayout.
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, &ui_layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::ContextMenu {
+            menu: &menu,
+            layout: &menu_layout,
+        });
+        frame.draw(b);
+    });
 
     Some(menu_layout)
 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -2672,6 +2672,7 @@ impl SimpleComponent for App {
             {
                 let engine_d = engine.clone();
                 let ctx_layout_d = explorer_ctx_menu_layout.clone();
+                let bk_ctx = backend.clone();
                 ctx_overlay_da.set_draw_func(move |da, cr, _w, _h| {
                     let engine = engine_d.borrow();
                     let on_explorer = matches!(
@@ -2698,6 +2699,7 @@ impl SimpleComponent for App {
                     let w = da.width() as f64;
                     let h = da.height() as f64;
                     *ctx_layout_d.borrow_mut() = crate::gtk::draw::draw_explorer_context_menu_popup(
+                        &bk_ctx,
                         cr,
                         &layout,
                         &engine,

--- a/src/gtk/quadraui_gtk.rs
+++ b/src/gtk/quadraui_gtk.rs
@@ -1,10 +1,10 @@
-//! GTK backend for `quadraui` primitives.
+//! GTK backend for `quadraui` primitives — vimcode-side helpers.
 //!
-//! Cairo + Pango equivalent of `src/tui_main/quadraui_tui.rs`. Each
-//! `draw_*` function consumes a `quadraui` primitive description and
-//! rasterises it onto the provided `cairo::Context`. Currently supports
-//! `TreeView` (A.1b), `Form` (A.3c), `ListView` (A.5b), and `Palette`
-//! (A.4b).
+//! Most primitive paint paths now go through `Backend::draw_X` via
+//! `quadraui::ScreenLayout::draw()` (#446, chunks B+D). What remains
+//! here is `q_theme()` — the theme adapter every GTK draw call uses —
+//! plus a couple of rich-text-popup constants re-exported for the
+//! click-side scrollbar geometry helper.
 
 use super::*;
 
@@ -12,92 +12,6 @@ pub(super) fn q_theme(theme: &Theme) -> quadraui::Theme {
     render::to_quadraui_theme(theme)
 }
 
-// ─── Activity bar / Terminal lift (B5c.5) ───────────────────────────────────
-//
-// `draw_activity_bar` and `draw_terminal_cells` lifted to
-// `quadraui::gtk::*` (taking `quadraui::Theme`). Vimcode call sites
-// invoke them directly via `quadraui::gtk::draw_activity_bar` /
-// `quadraui::gtk::draw_terminal_cells`, building the
-// `quadraui::Theme` via `q_theme()`. The previous in-tree
-// `ActivityBarHit` struct has been replaced by
-// `quadraui::ActivityBarRowHit` (same field shape).
-
-/// Draw a `quadraui::Tooltip` at its resolved layout position.
-///
-/// Per D6, the caller computes anchor + viewport + content measurement
-/// and asks `tooltip.layout()` for the resolved bounds; this rasteriser
-/// paints the box (background + 1px border) plus either the plain
-/// `text` or per-row `styled_lines`.
-///
-/// `padding_x` is the horizontal padding (in pixels) from the left
-/// border to the start of text — consumers typically pass the same
-/// `char_width` they used when computing the tooltip's measured width.
-pub(super) fn draw_tooltip(
-    cr: &Context,
-    layout: &pango::Layout,
-    tooltip: &quadraui::Tooltip,
-    tooltip_layout: &quadraui::TooltipLayout,
-    line_height: f64,
-    padding_x: f64,
-    theme: &Theme,
-) {
-    quadraui::gtk::draw_tooltip(
-        cr,
-        layout,
-        tooltip,
-        tooltip_layout,
-        line_height,
-        padding_x,
-        &q_theme(theme),
-    );
-}
-/// Draw a `quadraui::Dialog` at its resolved layout. Returns the button
-/// hit-rectangles (in the same `(x, y, w, h)` shape the legacy renderer
-/// returned) so the caller's click handler keeps working unchanged.
-///
-/// Per D6, the caller measures title/body/buttons in pixels and asks
-/// `dialog.layout()` for the resolved sub-bounds; this rasteriser paints
-/// the box (background + 1px border), title bar, body text, optional
-/// input, and buttons (with the default-button highlight on the
-/// primary).
-pub(super) fn draw_dialog(
-    cr: &Context,
-    layout: &pango::Layout,
-    dialog: &quadraui::Dialog,
-    dialog_layout: &quadraui::DialogLayout,
-    line_height: f64,
-    theme: &Theme,
-) -> Vec<(f64, f64, f64, f64)> {
-    let ui_font_desc = pango::FontDescription::from_string(&super::draw::UI_FONT());
-    quadraui::gtk::draw_dialog(
-        cr,
-        layout,
-        &ui_font_desc,
-        dialog,
-        dialog_layout,
-        line_height,
-        &q_theme(theme),
-    )
-}
-
-/// Draw a `quadraui::ContextMenu` at its resolved layout. Returns the
-/// per-clickable-item hit-rectangles `(x, y, w, h, item_idx)` so the
-/// caller's click handler can map a click to the original
-/// `ContextMenuItem` index without re-running layout. Hover state is
-/// owned by the primitive (`menu.selected_idx`) — the highlight
-/// follows whatever the app sets, so callers update `selected_idx`
-/// from mouse motion before invoking this rasteriser.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn draw_context_menu(
-    cr: &Context,
-    layout: &pango::Layout,
-    menu: &quadraui::ContextMenu,
-    menu_layout: &quadraui::ContextMenuLayout,
-    line_height: f64,
-    theme: &Theme,
-) -> Vec<(f64, f64, f64, f64, quadraui::WidgetId)> {
-    quadraui::gtk::draw_context_menu(cr, layout, menu, menu_layout, line_height, &q_theme(theme))
-}
 /// Visible width of the rich-text-popup scrollbar in pixels. Wider
 /// than the layout's 1px border so the bar is paint+click-friendly.
 /// Shared with `draw_editor_hover_popup` so paint and hit-test
@@ -108,22 +22,6 @@ pub(super) const RICH_TEXT_POPUP_SB_WIDTH: f64 = quadraui::gtk::RICH_TEXT_POPUP_
 /// right border. Same role as `RICH_TEXT_POPUP_SB_WIDTH`.
 pub(super) const RICH_TEXT_POPUP_SB_INSET: f64 = quadraui::gtk::RICH_TEXT_POPUP_SB_INSET;
 
-/// Draw a `quadraui::Completions` popup at its resolved
-/// `CompletionsLayout` via the lifted `quadraui::gtk::draw_completions`
-/// rasteriser (#285). Vimcode's shim role is to map the rich
-/// `render::Theme` to the smaller `quadraui::Theme` via `q_theme()` —
-/// the body of the rasteriser lives in the quadraui crate. Mirrors
-/// the TUI shim at `src/tui_main/quadraui_tui.rs::draw_completions`.
-pub(super) fn draw_completions(
-    cr: &Context,
-    layout: &pango::Layout,
-    completions: &quadraui::Completions,
-    completions_layout: &quadraui::CompletionsLayout,
-    theme: &Theme,
-) {
-    quadraui::gtk::draw_completions(cr, layout, completions, completions_layout, &q_theme(theme));
-}
-
 /// Draw a `quadraui::RichTextPopup` at its resolved layout. Returns
 /// per-link hit regions in `(x, y, w, h, url)` form. Each visible
 /// line is rendered as a SINGLE Pango call with an `AttrList` —
@@ -131,6 +29,9 @@ pub(super) fn draw_completions(
 /// attribute ranges. This avoids the per-span manual-advance bug
 /// where proportional Pango widths drift from monospace
 /// `char_width * char_count` math (#214 first-cut regression).
+///
+/// Kept as a shim while the Surface::RichTextPopup migration (#463)
+/// is investigated — paint via the trait broke click hit-test.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_rich_text_popup(
     cr: &Context,


### PR DESCRIPTION
## Summary

Chunk D of #446. Route paint through `quadraui::ScreenLayout::draw()` for 7 popup primitives.

| Surface | Helper | Hit-data sink |
|---|---|---|
| LSP hover tooltip | `draw_hover_popup` | (non-interactive) |
| Signature help tooltip | `draw_signature_popup` | (non-interactive) |
| Diff peek tooltip | `draw_diff_peek_popup` | (non-interactive) |
| Completion popup | `draw_completion_popup` | `CompletionsLayout` cached |
| Dialog popup | `draw_dialog_popup` | `DialogLayout.visible_buttons` |
| Editor context menu | `draw_context_menu_popup` | `ContextMenuLayout` cached |
| Explorer context menu | `draw_explorer_context_menu_popup` | `ContextMenuLayout` cached |

Each helper gained a `backend: &Rc<RefCell<GtkBackend>>` parameter, wraps its body in `enter_frame_scope`, and pushes a `Surface::X` entry onto a one-shot frame. Five dead shim wrappers removed from `quadraui_gtk.rs`; `q_theme()` + the `RICH_TEXT_POPUP_SB_*` constants stay.

## Why this chunk was easy

Popup primitives carry their pre-computed `XLayout` struct around — paint and click both consume the same instance. So this chunk didn't depend on the rasteriser/`_layout()` geometry-sharing fixes that chunks B+C needed (quadraui#211 / #213 / #215). The only round-trip was extracting button rects from `DialogLayout.visible_buttons` (which the layout already carries) instead of from the rasteriser's return.

## Not migrated — rich text popup

Attempted `Surface::RichTextPopup` for the editor markdown hover (`draw_editor_hover_popup`). Popup paints correctly but click hit-test for **links + scrollbar track + thumb drag** falls through to the editor scrollbar underneath. Both paint and rect computation use the same `popup_layout` instance — geometry should agree by construction — so the root cause isn't obvious. Reverted to the legacy shim on this branch; filed as **#469** for follow-up investigation.

## Test plan

Smoke-tested in GTK by user:

- [x] LSP hover tooltip
- [x] Signature help tooltip
- [x] Diff peek tooltip
- [x] Completion popup click (correct item applied)
- [x] Dialog popup — single-button OK + click outside dismiss + multi-button (Save/Discard/Cancel)
- [x] Editor right-click context menu (hover + click + dismiss)
- [x] Explorer right-click context menu (file + directory contexts, vertical scroll positions)

Build / clippy / fmt / 1989 lib tests all pass.

## Pre-existing bugs surfaced during smoke

- **#467** — completion filter: typing more characters of a valid prefix can shrink the match list past where fuzzy-matching should keep items. Engine code, untouched by this PR.
- **#468** — editor hover "Go to Definition" link does nothing on click; the click handler routes `command:` URLs through `execute_command_uri` (plugin commands path) but those links need `execute_hover_goto` (LSP path). Reproduces on develop.

## Closes

Closes #463. #446 remains open (chunk C complex surfaces still ahead). #469 tracks the rich text popup migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)