### PR TITLE
Fix zh/zl/zH/zL: pull cursor onto viewport so scroll persists

### DIFF
--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -3663,14 +3663,52 @@ impl Engine {
     }
 
     /// zh — scroll view left by `count` columns.
+    ///
+    /// Decreases `scroll_left`, which exposes more of the line to the left of
+    /// the viewport (cursor's visible position shifts right). The cursor is
+    /// pulled onto the new viewport if the scroll has left it off-screen — if
+    /// we didn't do that, `ensure_cursor_visible` (called after every key in
+    /// `handle_key`) would snap `scroll_left` back to track the cursor and
+    /// effectively undo the scroll.
     pub(crate) fn scroll_left_by(&mut self, count: usize) {
         let sl = self.view().scroll_left;
-        self.view_mut().scroll_left = sl.saturating_sub(count);
+        let new_sl = sl.saturating_sub(count);
+        self.view_mut().scroll_left = new_sl;
+        self.clamp_cursor_to_horizontal_viewport(new_sl);
     }
 
     /// zl — scroll view right by `count` columns.
+    ///
+    /// Increases `scroll_left`, which exposes more of the line to the right of
+    /// the viewport. The cursor is pulled onto the new viewport so that
+    /// `ensure_cursor_visible` does not snap the scroll back (see
+    /// `scroll_left_by`).
     pub(crate) fn scroll_right_by(&mut self, count: usize) {
-        self.view_mut().scroll_left += count;
+        let new_sl = self.view().scroll_left + count;
+        self.view_mut().scroll_left = new_sl;
+        self.clamp_cursor_to_horizontal_viewport(new_sl);
+    }
+
+    /// Move the cursor's column onto the horizontal viewport at `scroll_left`.
+    ///
+    /// If `viewport_cols` is 0 (uninitialised), this is a no-op so that
+    /// headless / uninitialised engines still let scroll commands shift
+    /// `scroll_left` freely. Otherwise, the cursor column is clamped to
+    /// `[scroll_left, scroll_left + viewport_cols)`. This is the cursor
+    /// adjustment Vim performs for `zh`/`zl`/`zH`/`zL` when the scroll would
+    /// leave the cursor off-screen.
+    fn clamp_cursor_to_horizontal_viewport(&mut self, scroll_left: usize) {
+        let viewport_cols = self.view().viewport_cols;
+        if viewport_cols == 0 {
+            return;
+        }
+        let right_edge = scroll_left + viewport_cols;
+        let cursor_col = self.view().cursor.col;
+        if cursor_col < scroll_left {
+            self.view_mut().cursor.col = scroll_left;
+        } else if cursor_col >= right_edge {
+            self.view_mut().cursor.col = right_edge - 1;
+        }
     }
 
     /// zH — scroll half screen width left.

--- a/tests/z_commands.rs
+++ b/tests/z_commands.rs
@@ -255,10 +255,19 @@ fn test_z_minus_scroll_bottom_first_nonblank() {
 
 // ── zh/zl: horizontal scroll ────────────────────────────────────────────────
 
+// NOTE on test setup: `ensure_cursor_visible` runs after every key press
+// (see `handle_key` in keys.rs) and snaps `scroll_left` to keep the cursor
+// inside the viewport. If the test sets `scroll_left` without also placing
+// the cursor inside the new visible range, the very first key press
+// (including the `z` that only sets `pending_key`) will reset `scroll_left`
+// to follow the cursor. So these tests set cursor.col consistently with
+// scroll_left — the same invariant the engine maintains in real usage.
+
 #[test]
 fn test_zh_scroll_left() {
     let mut e = engine_with("hello world\n");
     e.view_mut().scroll_left = 5;
+    e.view_mut().cursor.col = 5;
     type_chars(&mut e, "zh");
     assert_eq!(e.view().scroll_left, 4);
 }
@@ -274,6 +283,7 @@ fn test_zl_scroll_right() {
 fn test_zh_with_count() {
     let mut e = engine_with("hello world\n");
     e.view_mut().scroll_left = 10;
+    e.view_mut().cursor.col = 10;
     type_chars(&mut e, "3zh");
     assert_eq!(e.view().scroll_left, 7);
 }
@@ -291,6 +301,7 @@ fn test_zl_with_count() {
 fn test_zh_big_scroll_half_left() {
     let mut e = engine_with("hello world\n");
     e.view_mut().scroll_left = 50;
+    e.view_mut().cursor.col = 50;
     e.view_mut().viewport_cols = 80;
     type_chars(&mut e, "zH");
     assert_eq!(e.view().scroll_left, 10); // 50 - 40 = 10


### PR DESCRIPTION
## Summary
- Fixes #453 — `zh`/`zl`/`zH`/`zL` now pull the cursor onto the new viewport, so `ensure_cursor_visible` (which runs after every key) doesn't snap `scroll_left` back and undo the scroll.
- Test setup updated to position the cursor consistently with `scroll_left`, matching the invariant the engine now maintains.

## Test plan
- [x] `cargo test --no-default-features --test z_commands` — all 6 horizontal-scroll tests pass
- [ ] `cargo test --no-default-features` — full suite green
- [ ] `cargo clippy -- -D warnings`
- [ ] `cargo fmt --check`

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)