### PR TITLE
refactor(tui): migrate Extension Panel to quadraui TreeView (#476)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -7478,6 +7478,160 @@ pub fn ext_sidebar_to_tree_view(ext: &ExtSidebarData) -> quadraui::TreeView {
     }
 }
 
+/// Adapt the engine-side `ExtPanelData` (extension-provided sidebar
+/// panel) into a `quadraui::TreeView` for rendering via the shared
+/// `draw_tree` primitive (#476).
+///
+/// Tree shape:
+/// - Path `[s]` — section `s` header (`Decoration::Header`, chevron
+///   reflects `section.expanded`).
+/// - Path `[s, i]` — visible item `i` in section `s`. `indent` mirrors
+///   `ExtPanelItem.indent + 1` so children of section headers start at
+///   indent 1 (matching the legacy renderer). Tree-expandable items
+///   carry `is_expanded: Some(item.expanded)` so the primitive draws
+///   the chevron; non-expandable items leave `is_expanded` as `None`.
+///
+/// `ExtPanelStyle` maps to `Decoration` as:
+/// - `Header → Decoration::Header`
+/// - `Dim → Decoration::Muted`
+/// - `Normal → Decoration::Normal`
+/// - `Accent → Decoration::Normal` with the row text wrapped in a
+///   `StyledSpan` coloured by `theme.keyword` (no first-class accent
+///   decoration on the primitive).
+///
+/// Badges and action labels are concatenated into a single
+/// right-aligned `Badge`, matching the legacy `[badge] ⟨action⟩ hint`
+/// hint format. Separator rows (`item.is_separator`) become a single
+/// `Decoration::Muted` row with a `─` glyph; the primitive doesn't
+/// have a first-class separator decoration so this is a visual
+/// approximation rather than a full-width rule.
+///
+/// `panel.selected` is a flat row index across visible rows (section
+/// headers count, items in collapsed sections do not). The matching
+/// `selected_path` is computed by walking the same flat enumeration
+/// while emitting rows.
+///
+/// Tree-item expansion state (`engine.ext_panel_tree_expanded`) is
+/// expected to have already been resolved into `item.expanded` by
+/// `build_ext_panel_data` before this function is called.
+pub fn ext_panel_to_tree_view(panel: &ExtPanelData, theme: &Theme) -> quadraui::TreeView {
+    use crate::core::plugin::ExtPanelStyle;
+    use quadraui::{
+        Badge, Decoration, SelectionMode, StyledSpan, StyledText, TreeRow, TreeStyle, TreeView,
+        WidgetId,
+    };
+
+    let accent_color = to_quadraui_color(theme.keyword);
+    let mut rows: Vec<TreeRow> = Vec::new();
+    let mut selected_path: Option<Vec<u16>> = None;
+    let mut flat_idx = 0usize;
+
+    for (s, section) in panel.sections.iter().enumerate() {
+        if panel.has_focus && flat_idx == panel.selected {
+            selected_path = Some(vec![s as u16]);
+        }
+        rows.push(TreeRow {
+            path: vec![s as u16],
+            indent: 0,
+            icon: None,
+            text: StyledText::plain(section.name.clone()),
+            badge: None,
+            is_expanded: Some(section.expanded),
+            decoration: Decoration::Header,
+            edit: None,
+        });
+        flat_idx += 1;
+
+        if !section.expanded {
+            continue;
+        }
+
+        for (i, item) in section.items.iter().enumerate() {
+            let row_path = vec![s as u16, i as u16];
+            if panel.has_focus && flat_idx == panel.selected {
+                selected_path = Some(row_path.clone());
+            }
+
+            if item.is_separator {
+                rows.push(TreeRow {
+                    path: row_path,
+                    indent: 0,
+                    icon: None,
+                    text: StyledText::plain("\u{2500}".to_string()),
+                    badge: None,
+                    is_expanded: None,
+                    decoration: Decoration::Muted,
+                    edit: None,
+                });
+                flat_idx += 1;
+                continue;
+            }
+
+            let (decoration, text) = match item.style {
+                ExtPanelStyle::Header => (Decoration::Header, StyledText::plain(item.text.clone())),
+                ExtPanelStyle::Dim => (Decoration::Muted, StyledText::plain(item.text.clone())),
+                ExtPanelStyle::Accent => (
+                    Decoration::Normal,
+                    StyledText {
+                        spans: vec![StyledSpan::with_fg(item.text.clone(), accent_color)],
+                    },
+                ),
+                ExtPanelStyle::Normal => (Decoration::Normal, StyledText::plain(item.text.clone())),
+            };
+
+            let mut parts: Vec<String> = Vec::new();
+            for badge in &item.badges {
+                parts.push(format!("[{}]", badge.text));
+            }
+            for action in &item.actions {
+                parts.push(format!("\u{27e8}{}\u{27e9}", action.label));
+            }
+            if !item.hint.is_empty() {
+                parts.push(item.hint.clone());
+            }
+            let badge = if parts.is_empty() {
+                None
+            } else {
+                Some(Badge::plain(parts.join(" ")))
+            };
+
+            let icon = if item.icon.is_empty() {
+                None
+            } else {
+                Some(quadraui::Icon::new(item.icon.clone(), item.icon.clone()))
+            };
+
+            let is_expanded = if item.expandable {
+                Some(item.expanded)
+            } else {
+                None
+            };
+
+            rows.push(TreeRow {
+                path: row_path,
+                indent: item.indent as u16 + 1,
+                icon,
+                text,
+                badge,
+                is_expanded,
+                decoration,
+                edit: None,
+            });
+            flat_idx += 1;
+        }
+    }
+
+    TreeView {
+        id: WidgetId::new("ext-panel-tree"),
+        rows,
+        selection_mode: SelectionMode::Single,
+        selected_path,
+        scroll_offset: panel.scroll_top,
+        style: TreeStyle::default(),
+        has_focus: panel.has_focus,
+    }
+}
+
 /// Adapt the engine-side `ExtSidebarData` into a `quadraui::MultiSectionView`
 /// (#293).
 ///
@@ -8022,7 +8176,22 @@ fn build_ext_panel_data(engine: &Engine) -> Option<ExtPanelData> {
             let visible_indices = engine.ext_panel_visible_indices(panel_name, &all_items);
             let items: Vec<_> = visible_indices
                 .into_iter()
-                .filter_map(|idx| all_items.get(idx).cloned())
+                .filter_map(|idx| {
+                    all_items.get(idx).cloned().map(|mut item| {
+                        // Resolve user-toggled tree expansion state into the
+                        // item so `ext_panel_to_tree_view` doesn't need engine
+                        // access. The engine map is the source of truth once
+                        // the user has toggled; `item.expanded` is the plugin
+                        // default otherwise.
+                        if item.expandable {
+                            let key = (panel_name.clone(), item.id.clone());
+                            if let Some(&v) = engine.ext_panel_tree_expanded.get(&key) {
+                                item.expanded = v;
+                            }
+                        }
+                        item
+                    })
+                })
                 .collect();
             ExtPanelSectionData {
                 name: name.clone(),
@@ -12462,6 +12631,139 @@ pub fn matches_key_binding(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_ext_panel_to_tree_view_shape() {
+        use crate::core::plugin::{ExtPanelAction, ExtPanelBadge, ExtPanelItem, ExtPanelStyle};
+        use quadraui::Decoration;
+
+        let mut item_a = ExtPanelItem {
+            text: "Item A".into(),
+            id: "a".into(),
+            indent: 0,
+            style: ExtPanelStyle::Normal,
+            expandable: true,
+            expanded: true,
+            badges: vec![ExtPanelBadge {
+                text: "main".into(),
+                color: "green".into(),
+            }],
+            actions: vec![ExtPanelAction {
+                label: "Stage".into(),
+                key: "s".into(),
+            }],
+            hint: "h".into(),
+            ..Default::default()
+        };
+        item_a.icon = "\u{f04b}".into();
+
+        let item_b_child = ExtPanelItem {
+            text: "Child".into(),
+            id: "a_child".into(),
+            indent: 1,
+            parent_id: "a".into(),
+            style: ExtPanelStyle::Accent,
+            ..Default::default()
+        };
+
+        let item_c_dim = ExtPanelItem {
+            text: "Dim".into(),
+            id: "c".into(),
+            style: ExtPanelStyle::Dim,
+            ..Default::default()
+        };
+
+        let item_sep = ExtPanelItem {
+            is_separator: true,
+            ..Default::default()
+        };
+
+        let panel = ExtPanelData {
+            name: "my_ext".into(),
+            title: "MY EXT".into(),
+            sections: vec![
+                ExtPanelSectionData {
+                    name: "Open".into(),
+                    items: vec![item_a, item_b_child, item_sep, item_c_dim],
+                    expanded: true,
+                },
+                ExtPanelSectionData {
+                    name: "Closed".into(),
+                    items: vec![ExtPanelItem {
+                        text: "Hidden".into(),
+                        ..Default::default()
+                    }],
+                    expanded: false,
+                },
+            ],
+            // Select the second visible item (`Child`, flat idx 2: header=0, item_a=1, child=2).
+            selected: 2,
+            has_focus: true,
+            scroll_top: 0,
+            input_text: String::new(),
+            input_active: false,
+            help_open: false,
+            help_bindings: vec![],
+        };
+
+        let theme = Theme::onedark();
+        let tv = ext_panel_to_tree_view(&panel, &theme);
+
+        // Expect rows: [0]=Open header, [0,0]=Item A, [0,1]=Child, [0,2]=separator,
+        // [0,3]=Dim, [1]=Closed header (collapsed → no children).
+        assert_eq!(tv.rows.len(), 6, "rows: {:?}", tv.rows.len());
+        assert_eq!(tv.rows[0].path, vec![0]);
+        assert_eq!(tv.rows[0].decoration, Decoration::Header);
+        assert_eq!(tv.rows[0].is_expanded, Some(true));
+        assert_eq!(tv.rows[1].path, vec![0, 0]);
+        assert_eq!(tv.rows[1].indent, 1);
+        assert_eq!(tv.rows[1].is_expanded, Some(true)); // expandable item
+        assert!(
+            tv.rows[1].badge.is_some(),
+            "badges + action + hint combined"
+        );
+        assert!(tv.rows[1].icon.is_some(), "icon converted");
+        assert_eq!(tv.rows[2].path, vec![0, 1]);
+        assert_eq!(tv.rows[2].indent, 2); // indent 1 + 1
+        assert_eq!(tv.rows[2].is_expanded, None); // not expandable
+                                                  // Separator is muted line glyph.
+        assert_eq!(tv.rows[3].decoration, Decoration::Muted);
+        assert_eq!(tv.rows[3].text.spans[0].text, "\u{2500}");
+        // Dim item maps to Muted.
+        assert_eq!(tv.rows[4].decoration, Decoration::Muted);
+        // Collapsed section: header only, no children.
+        assert_eq!(tv.rows[5].path, vec![1]);
+        assert_eq!(tv.rows[5].is_expanded, Some(false));
+
+        // Selection: flat idx 2 = Child → path [0, 1].
+        assert_eq!(tv.selected_path, Some(vec![0, 1]));
+        assert_eq!(tv.scroll_offset, 0);
+        assert!(tv.has_focus);
+    }
+
+    #[test]
+    fn test_ext_panel_to_tree_view_no_focus_no_selection() {
+        let panel = ExtPanelData {
+            name: "x".into(),
+            title: "X".into(),
+            sections: vec![ExtPanelSectionData {
+                name: "S".into(),
+                items: vec![],
+                expanded: true,
+            }],
+            selected: 0,
+            has_focus: false,
+            scroll_top: 5,
+            input_text: String::new(),
+            input_active: false,
+            help_open: false,
+            help_bindings: vec![],
+        };
+        let tv = ext_panel_to_tree_view(&panel, &Theme::onedark());
+        assert_eq!(tv.selected_path, None);
+        assert_eq!(tv.scroll_offset, 5);
+        assert!(!tv.has_focus);
+    }
 
     #[test]
     fn test_try_from_hex() {

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -132,7 +132,11 @@ pub(super) fn render_sidebar(
 
     // Extension panel (plugin-provided)
     if sidebar.ext_panel_name.is_some() {
-        render_ext_panel(buf, area, engine, theme);
+        // Drop the buffer borrow before passing frame to render_ext_panel
+        // — the new TreeView-based renderer takes the backend + frame so it
+        // can route draw calls through quadraui primitives.
+        let _ = buf;
+        render_ext_panel(backend, frame, area, engine, theme);
         return;
     }
 
@@ -1170,14 +1174,20 @@ pub(super) fn render_source_control(
 // ─── Extension panel (plugin-provided) ───────────────────────────────────────
 
 /// Render an extension-provided sidebar panel.
+///
+/// Migrated to `quadraui::TreeView` (#476). Header + search-input chrome
+/// route through `quadraui::tui::draw_settings_chrome`; the body rows
+/// (sections + expandable tree items + badges + action labels) flow
+/// through `render::ext_panel_to_tree_view()` + `Backend::draw_tree`.
+/// The help-popup overlay and the scrollbar/scroll-surface registration
+/// are panel-specific chrome that don't fit TreeView and stay inline.
 pub(super) fn render_ext_panel(
-    buf: &mut ratatui::buffer::Buffer,
+    backend: &mut super::backend::TuiBackend,
+    frame: &mut ratatui::Frame,
     area: Rect,
     engine: &Engine,
     theme: &Theme,
 ) {
-    use crate::core::plugin::ExtPanelStyle;
-
     if area.height == 0 {
         return;
     }
@@ -1186,262 +1196,101 @@ pub(super) fn render_ext_panel(
         return;
     };
 
-    let hdr_fg = rc(theme.status_fg);
-    let hdr_bg = rc(theme.status_bg);
-    let item_fg = rc(theme.foreground);
-    let dim_fg = rc(theme.line_number_fg);
-    let accent_fg = rc(theme.keyword);
-    let sel_bg = rc(theme.fuzzy_selected_bg);
-    let row_bg = rc(theme.tab_bar_bg);
-
-    // Clear area
-    for cy in area.y..area.y + area.height {
-        for cx in area.x..area.x + area.width {
-            set_cell(buf, cx, cy, ' ', item_fg, row_bg);
-        }
-    }
-
-    // Row 0: header
-    for x in area.x..area.x + area.width {
-        set_cell(buf, x, area.y, ' ', hdr_fg, hdr_bg);
-    }
-    let title = format!("  {}", panel.title);
-    for (i, ch) in title.chars().enumerate().take(area.width as usize) {
-        set_cell(buf, area.x + i as u16, area.y, ch, hdr_fg, hdr_bg);
-    }
-
-    if area.height < 2 {
-        return;
-    }
-
-    // Row 1: search input field (when active or has text)
-    let input_row_count = if panel.input_active || !panel.input_text.is_empty() {
-        1
-    } else {
-        0
+    // ── Chrome: header (always) + search input (only when active or text). ─
+    let input_visible = panel.input_active || !panel.input_text.is_empty();
+    let chrome_h: u16 = (if input_visible { 2 } else { 1 }).min(area.height);
+    let header_title = format!(" {}", panel.title);
+    let chrome_area = Rect {
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: chrome_h,
     };
-    if input_row_count > 0 {
-        let iy = area.y + 1;
-        let search_bg = rc(theme.tab_bar_bg);
-        let search_fg = if panel.input_active {
-            rc(theme.foreground)
-        } else {
-            dim_fg
-        };
-        for x in area.x..area.x + area.width {
-            set_cell(buf, x, iy, ' ', search_fg, search_bg);
-        }
-        let prefix = " / ";
-        for (i, ch) in prefix.chars().enumerate() {
-            let x = area.x + i as u16;
-            if x < area.x + area.width {
-                set_cell(buf, x, iy, ch, dim_fg, search_bg);
-            }
-        }
-        let text_start = area.x + prefix.len() as u16;
-        for (i, ch) in panel.input_text.chars().enumerate() {
-            let x = text_start + i as u16;
-            if x < area.x + area.width {
-                set_cell(buf, x, iy, ch, search_fg, search_bg);
-            }
-        }
-        if panel.input_active {
-            let cursor_x = text_start + panel.input_text.chars().count() as u16;
-            if cursor_x < area.x + area.width {
-                set_cell(buf, cursor_x, iy, '▏', rc(theme.cursor), search_bg);
-            }
-        }
-    }
+    quadraui::tui::draw_settings_chrome(
+        frame.buffer_mut(),
+        chrome_area,
+        &header_title,
+        &panel.input_text,
+        "",
+        panel.input_active,
+        &super::quadraui_tui::q_theme(theme),
+    );
 
-    // Build flat list of rows
-    let content_area_height = (area.height - 1 - input_row_count as u16) as usize;
-    let mut flat_rows: Vec<(String, String, bool, bool)> = Vec::new(); // (text, hint, is_header, is_selected)
-    let mut flat_idx = 0usize;
-    for section in &panel.sections {
-        let is_sel = flat_idx == panel.selected;
-        let arrow = if section.expanded { "▼" } else { "▶" };
-        flat_rows.push((
-            format!(" {} {}", arrow, section.name),
-            String::new(),
-            true,
-            is_sel,
-        ));
-        flat_idx += 1;
-        if section.expanded {
-            for item in &section.items {
-                if item.is_separator {
-                    flat_rows.push(("─".repeat(area.width as usize), String::new(), false, false));
-                    flat_idx += 1;
-                    continue;
-                }
-                let is_sel = flat_idx == panel.selected;
-                let indent = "  ".repeat(item.indent as usize + 1);
-                let icon_part = if item.icon.is_empty() {
-                    String::new()
-                } else {
-                    format!("{} ", item.icon)
-                };
-                // Tree chevron for expandable items
-                let chevron = if item.expandable {
-                    let tree_key = (panel.name.clone(), item.id.clone());
-                    let is_expanded = engine
-                        .ext_panel_tree_expanded
-                        .get(&tree_key)
-                        .copied()
-                        .unwrap_or(item.expanded);
-                    if is_expanded {
-                        "▼ "
-                    } else {
-                        "▶ "
-                    }
-                } else {
-                    ""
-                };
-                let fg_marker = match item.style {
-                    ExtPanelStyle::Header => 'H',
-                    ExtPanelStyle::Dim => 'D',
-                    ExtPanelStyle::Accent => 'A',
-                    ExtPanelStyle::Normal => 'N',
-                };
-                // Build hint with optional badges and action labels
-                let mut hint_parts = Vec::new();
-                for badge in &item.badges {
-                    hint_parts.push(format!("[{}]", badge.text));
-                }
-                for action in &item.actions {
-                    hint_parts.push(format!("⟨{}⟩", action.label));
-                }
-                if !item.hint.is_empty() {
-                    hint_parts.push(item.hint.clone());
-                }
-                let hint_combined = hint_parts.join(" ");
-                flat_rows.push((
-                    format!("{}{}{}{}", indent, chevron, icon_part, item.text),
-                    format!("{}|{}", fg_marker, hint_combined),
-                    false,
-                    is_sel,
-                ));
-                flat_idx += 1;
-            }
-        }
-    }
-
-    // Apply scroll
-    let scroll = panel.scroll_top;
-    let visible_rows = &flat_rows[scroll.min(flat_rows.len())..];
-
-    for (ri, (text, hint_raw, is_header, is_sel)) in
-        visible_rows.iter().enumerate().take(content_area_height)
-    {
-        let y = area.y + 1 + input_row_count as u16 + ri as u16;
-        let bg = if *is_sel && panel.has_focus {
-            sel_bg
-        } else {
-            row_bg
-        };
-        let fg = if *is_header {
-            hdr_fg
-        } else if hint_raw.starts_with('D') {
-            dim_fg
-        } else if hint_raw.starts_with('A') {
-            accent_fg
-        } else {
-            item_fg
-        };
-
-        for x in area.x..area.x + area.width {
-            set_cell(buf, x, y, ' ', fg, bg);
-        }
-
-        let w = area.width as usize;
-
-        // Right-aligned hint (skip the style marker char and pipe)
-        let hint = if hint_raw.len() > 2 {
-            &hint_raw[2..]
-        } else {
-            ""
-        };
-        let hint_len = hint.chars().count();
-
-        // Truncate text before the hint area, adding "…" if clipped
-        let text_max = if !hint.is_empty() {
-            w.saturating_sub(hint_len + 2) // 1 space gap + 1 for safety
-        } else {
-            w
-        };
-        let text_char_count = text.chars().count();
-        if text_char_count > text_max && text_max > 1 {
-            for (i, ch) in text.chars().take(text_max - 1).enumerate() {
-                set_cell(buf, area.x + i as u16, y, ch, fg, bg);
-            }
-            set_cell(buf, area.x + (text_max - 1) as u16, y, '…', fg, bg);
-        } else {
-            for (i, ch) in text.chars().enumerate().take(text_max) {
-                set_cell(buf, area.x + i as u16, y, ch, fg, bg);
-            }
-        }
-
-        if !hint.is_empty() {
-            let start = w.saturating_sub(hint_len + 1);
-            for (i, ch) in hint.chars().enumerate() {
-                let x = area.x + (start + i) as u16;
-                if x < area.x + area.width {
-                    set_cell(buf, x, y, ch, dim_fg, bg);
-                }
-            }
-        }
-    }
-
-    // Scrollbar
-    let total = flat_rows.len();
-    let ext_panel_scrollbar = if total > content_area_height && content_area_height > 0 {
-        let sb_x = area.x + area.width - 1;
-        let track_h = content_area_height;
-        let thumb_h = (track_h * content_area_height / total).max(1);
-        let thumb_top = scroll * track_h / total;
-        let sb_thumb = rc(theme.scrollbar_thumb);
-        let sb_track = rc(theme.scrollbar_track);
-        let sb_bg = rc(theme.background);
-        for i in 0..track_h {
-            let y = area.y + 1 + input_row_count as u16 + i as u16;
-            let (ch, cfp) = if i >= thumb_top && i < thumb_top + thumb_h {
-                ('█', sb_thumb)
-            } else {
-                ('░', sb_track)
-            };
-            set_cell(buf, sb_x, y, ch, cfp, sb_bg);
-        }
-        let track_start_y = (area.y + 1 + input_row_count as u16) as f32;
-        Some(quadraui::SurfaceScrollbar {
-            axis: quadraui::ScrollAxis::Vertical,
-            track_bounds: quadraui::Rect::new(sb_x as f32, track_start_y, 1.0, track_h as f32),
-            thumb_bounds: quadraui::Rect::new(
-                sb_x as f32,
-                track_start_y + thumb_top as f32,
-                1.0,
-                thumb_h as f32,
-            ),
-            total_items: total,
-            visible_items: content_area_height,
-            scroll_offset: scroll,
-            inverted: false,
-        })
-    } else {
-        None
-    };
-    engine
-        .scroll_surfaces
-        .borrow_mut()
-        .push(quadraui::ScrollSurface {
-            id: quadraui::WidgetId::new("ext_panel:sb"),
-            bounds: quadraui::Rect::new(
-                area.x as f32,
-                area.y as f32,
-                area.width as f32,
-                area.height as f32,
-            ),
-            scrollbar: ext_panel_scrollbar,
+    // ── Body: TreeView rasterised via the shared primitive. ────────────────
+    let body_h = area.height.saturating_sub(chrome_h);
+    if body_h > 0 {
+        let body_w = area.width.saturating_sub(1); // 1 col reserved for scrollbar
+        let tree = render::ext_panel_to_tree_view(panel, theme);
+        let body_q_rect = quadraui::Rect::new(
+            area.x as f32,
+            (area.y + chrome_h) as f32,
+            body_w as f32,
+            body_h as f32,
+        );
+        backend.set_current_theme(super::quadraui_tui::q_theme(theme));
+        backend.enter_frame_scope(frame, |b| {
+            use quadraui::Backend;
+            b.draw_tree(body_q_rect, &tree);
         });
+
+        // Manual scrollbar: `draw_tree` doesn't render scrollbars yet.
+        // Total visible rows = tree.rows.len() (sections + their expanded
+        // items, separators included — same flat count the legacy renderer
+        // produced).
+        let buf = frame.buffer_mut();
+        let total = tree.rows.len();
+        let track_h = body_h as usize;
+        let ext_panel_scrollbar = if total > track_h && track_h > 0 {
+            let scroll = panel.scroll_top;
+            let sb_x = area.x + area.width - 1;
+            let thumb_h = (track_h * track_h / total).max(1);
+            let thumb_top = scroll * track_h / total;
+            let sb_thumb = rc(theme.scrollbar_thumb);
+            let sb_track = rc(theme.scrollbar_track);
+            let sb_bg = rc(theme.background);
+            for i in 0..track_h {
+                let y = area.y + chrome_h + i as u16;
+                let (ch, cfp) = if i >= thumb_top && i < thumb_top + thumb_h {
+                    ('\u{2588}', sb_thumb)
+                } else {
+                    ('\u{2591}', sb_track)
+                };
+                set_cell(buf, sb_x, y, ch, cfp, sb_bg);
+            }
+            let track_start_y = (area.y + chrome_h) as f32;
+            Some(quadraui::SurfaceScrollbar {
+                axis: quadraui::ScrollAxis::Vertical,
+                track_bounds: quadraui::Rect::new(sb_x as f32, track_start_y, 1.0, track_h as f32),
+                thumb_bounds: quadraui::Rect::new(
+                    sb_x as f32,
+                    track_start_y + thumb_top as f32,
+                    1.0,
+                    thumb_h as f32,
+                ),
+                total_items: total,
+                visible_items: track_h,
+                scroll_offset: scroll,
+                inverted: false,
+            })
+        } else {
+            None
+        };
+        engine
+            .scroll_surfaces
+            .borrow_mut()
+            .push(quadraui::ScrollSurface {
+                id: quadraui::WidgetId::new("ext_panel:sb"),
+                bounds: quadraui::Rect::new(
+                    area.x as f32,
+                    area.y as f32,
+                    area.width as f32,
+                    area.height as f32,
+                ),
+                scrollbar: ext_panel_scrollbar,
+            });
+    }
+
+    let buf = frame.buffer_mut();
 
     // ── Help popup overlay ──────────────────────────────────────────────────
     if panel.help_open && !panel.help_bindings.is_empty() {


### PR DESCRIPTION
## Summary

- New `render::ext_panel_to_tree_view()` adapts `ExtPanelData` into `quadraui::TreeView` (section headers + indented items + chevrons + combined badges/action labels).
- TUI `render_ext_panel()` rewired: chrome via `quadraui::tui::draw_settings_chrome`, body via `Backend::draw_tree`. Manual scrollbar + scroll-surface registration kept (TreeView doesn't paint scrollbars yet); help-popup overlay unchanged.
- `build_ext_panel_data()` now resolves `engine.ext_panel_tree_expanded` overrides into the cloned `item.expanded` so the builder stays engine-free, matching the `ext_sidebar_to_tree_view()` pattern.

Net: `panels.rs −252 / +101`, `render.rs +154` (builder + 2 unit tests).

## Known visual difference

Separator rows (`item.is_separator`) render as a single `─` glyph instead of the full-width rule the legacy renderer drew — the TreeView primitive has no `Decoration::Separator`. No shipping plugin uses separators today; if we want the full rule back, file a quadraui gap for the primitive.

## Pre-existing bugs surfaced during smoke testing (not introduced by this PR)

`mouse.rs` is unchanged by this PR. Three behaviors flagged during smoke test that are byte-for-byte identical to `develop`:

1. `/` activates search input but typing doesn't filter — engine fires `panel_input` to the plugin; filtering is the plugin's job.
2. Click on a section header doesn't toggle expand (Enter does) — click handler calls the same `handle_ext_panel_key(\"Return\", ...)` Enter does. Likely an Alacritty Down/Up quirk similar to #451.
3. Scroll wheel doesn't work though scrollbar drag does — registration + dispatch identical to `develop`.

Filed as separate follow-ups.

## Test plan

- [x] `cargo build --no-default-features`
- [x] `cargo test --no-default-features` (43 binaries, 0 failures, 2 new render tests covering tree shape + focus state)
- [x] `cargo clippy --no-default-features -- -D warnings`
- [x] `cargo fmt`
- [x] Smoke test against `git_insights` plugin: title renders, chrome shows search row when active, j/k navigates, Enter expands sections, scrollbar thumb tracks, help popup unaffected
- [ ] Need a plugin with separators to confirm the visual approximation looks acceptable (none in tree today)

Closes #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)