### PR TITLE
Migrate draw_editor_hover_popup to Surface::RichTextPopup (#469)

### DIFF
--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -423,8 +423,15 @@ pub(super) fn draw_editor(
     );
 
     // 5c4. Draw editor hover popup (gh key, diagnostic/annotation/plugin hovers)
-    let (eh_rect, eh_links, eh_sb) =
-        draw_editor_hover_popup(backend, cr, &layout, &screen, &theme, line_height, char_width);
+    let (eh_rect, eh_links, eh_sb) = draw_editor_hover_popup(
+        backend,
+        cr,
+        &layout,
+        &screen,
+        &theme,
+        line_height,
+        char_width,
+    );
     editor_hover_rect_out.set(eh_rect);
     *editor_hover_link_rects_out.borrow_mut() = eh_links;
     editor_hover_scrollbar_out.set(eh_sb);

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -424,7 +424,7 @@ pub(super) fn draw_editor(
 
     // 5c4. Draw editor hover popup (gh key, diagnostic/annotation/plugin hovers)
     let (eh_rect, eh_links, eh_sb) =
-        draw_editor_hover_popup(cr, &layout, &screen, &theme, line_height, char_width);
+        draw_editor_hover_popup(backend, cr, &layout, &screen, &theme, line_height, char_width);
     editor_hover_rect_out.set(eh_rect);
     *editor_hover_link_rects_out.borrow_mut() = eh_links;
     editor_hover_scrollbar_out.set(eh_sb);
@@ -1497,8 +1497,9 @@ pub(super) fn draw_hover_popup(
 /// primitive. Returns `(popup_bounds, link_rects, scrollbar_hit)` —
 /// scrollbar geometry feeds the click + drag handlers in `mod.rs`
 /// (#215).
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub(super) fn draw_editor_hover_popup(
+    backend: &Rc<RefCell<super::backend::GtkBackend>>,
     cr: &Context,
     layout: &pango::Layout,
     screen: &render::ScreenLayout,
@@ -1567,21 +1568,40 @@ pub(super) fn draw_editor_hover_popup(
         },
     );
 
-    // #463: rich text popup migration reverted — paint goes through
-    // the legacy quadraui_gtk shim which returns link rects directly.
-    // Migration to Surface::RichTextPopup caused click hit-test
-    // regression (links + scrollbar track/thumb fell through to editor
-    // scrollbar underneath). Needs deeper investigation; tracked under
-    // #463 follow-up.
-    let link_rects = super::quadraui_gtk::draw_rich_text_popup(
-        cr,
-        layout,
-        &popup,
-        &popup_layout,
-        line_height,
-        char_width,
-        theme,
-    );
+    // #469: route paint through quadraui::ScreenLayout. Recovers link
+    // hit regions from `popup_layout.link_hit_regions` (which is the
+    // same instance used by paint, so paint + click agree by
+    // construction).
+    use quadraui::{ScreenLayout as QScreenLayout, Surface};
+    backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
+        b.set_current_theme(super::quadraui_gtk::q_theme(theme));
+        b.set_current_line_height(line_height);
+        b.set_current_char_width(char_width);
+        let mut frame = QScreenLayout::new();
+        frame.push(Surface::RichTextPopup {
+            popup: &popup,
+            layout: &popup_layout,
+        });
+        frame.draw(b);
+    });
+    let link_rects: Vec<(f64, f64, f64, f64, String)> = popup_layout
+        .link_hit_regions
+        .iter()
+        .map(|(rect, idx)| {
+            let url = popup
+                .links
+                .get(*idx)
+                .map(|l| l.url.clone())
+                .unwrap_or_default();
+            (
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                url,
+            )
+        })
+        .collect();
     let popup_rect = Some((
         popup_layout.bounds.x as f64,
         popup_layout.bounds.y as f64,

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6672,6 +6672,22 @@ impl App {
                         }
                     }
                     // Check if click hit a link rect.
+                    {
+                        let lr = self.editor_hover_link_rects.borrow();
+                        eprintln!(
+                            "[#469-url] click @({:.0},{:.0}); {} link rects:",
+                            x,
+                            y,
+                            lr.len()
+                        );
+                        for (i, (lx, ly, lw, lh, url)) in lr.iter().enumerate() {
+                            let hit = x >= *lx && x <= lx + lw && y >= *ly && y <= ly + lh;
+                            eprintln!(
+                                "[#469-url]   [{}] ({:.0},{:.0},{:.0},{:.0}) hit={} url={}",
+                                i, lx, ly, lw, lh, hit, url
+                            );
+                        }
+                    }
                     let link_hit = self
                         .editor_hover_link_rects
                         .borrow()
@@ -6681,9 +6697,12 @@ impl App {
                         })
                         .cloned();
                     if let Some((_, _, _, _, url)) = link_hit {
+                        eprintln!("[#469-url] LINK HIT: url={}", url);
                         if url.starts_with("command:") {
-                            self.engine.borrow_mut().execute_command_uri(&url);
+                            let res = self.engine.borrow_mut().execute_command_uri(&url);
+                            eprintln!("[#469-url]   execute_command_uri returned {}", res);
                         } else {
+                            eprintln!("[#469-url]   calling open_url({})", url);
                             open_url(&url);
                         }
                         self.engine.borrow_mut().dismiss_editor_hover();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6641,8 +6641,14 @@ impl App {
         }
 
         // Editor hover: click on the popup focuses it; click elsewhere dismisses it
+        eprintln!("[#469] reached editor_hover check");
         {
             let engine = self.engine.borrow();
+            eprintln!(
+                "[#469]   editor_hover.is_some()={}, has_focus={}",
+                engine.editor_hover.is_some(),
+                engine.editor_hover_has_focus,
+            );
             if engine.editor_hover.is_some() {
                 let rect = self.editor_hover_popup_rect.get();
                 let on_popup = if let Some((px, py, pw, ph)) = rect {
@@ -6652,6 +6658,7 @@ impl App {
                 };
                 let has_focus = engine.editor_hover_has_focus;
                 drop(engine);
+                eprintln!("[#469]   on_popup={} rect={:?}", on_popup, rect);
                 if on_popup {
                     // Scrollbar hit-test (#215). Track click jumps to that
                     // offset and arms a drag so mouse-move updates the
@@ -6668,6 +6675,12 @@ impl App {
                             && cx < sb_hit.track.x + sb_hit.track.width
                             && cy >= sb_hit.track.y
                             && cy < sb_hit.track.y + sb_hit.track.height;
+                        eprintln!(
+                            "[#469]   sb: thumb=({},{},{},{}) track=({},{},{},{}) on_thumb={} on_track={}",
+                            sb_hit.thumb.x, sb_hit.thumb.y, sb_hit.thumb.width, sb_hit.thumb.height,
+                            sb_hit.track.x, sb_hit.track.y, sb_hit.track.width, sb_hit.track.height,
+                            on_thumb, on_track,
+                        );
                         if on_track || on_thumb {
                             if on_track {
                                 let max_scroll = sb_hit.total.saturating_sub(sb_hit.visible_rows);
@@ -6694,6 +6707,16 @@ impl App {
                         }
                     }
                     // Check if click hit a link rect.
+                    {
+                        let lr = self.editor_hover_link_rects.borrow();
+                        eprintln!("[#469]   link_rects.len()={}", lr.len());
+                        for (i, (lx, ly, lw, lh, url)) in lr.iter().enumerate() {
+                            eprintln!(
+                                "[#469]     link[{}]: ({},{},{},{}) url={}",
+                                i, lx, ly, lw, lh, url
+                            );
+                        }
+                    }
                     let link_hit = self
                         .editor_hover_link_rects
                         .borrow()
@@ -6702,6 +6725,10 @@ impl App {
                             x >= *lx && x <= lx + lw && y >= *ly && y <= ly + lh
                         })
                         .cloned();
+                    eprintln!(
+                        "[#469]   link_hit={:?}",
+                        link_hit.as_ref().map(|(_, _, _, _, url)| url.clone())
+                    );
                     if let Some((_, _, _, _, url)) = link_hit {
                         if url.starts_with("command:") {
                             self.engine.borrow_mut().execute_command_uri(&url);

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -5980,7 +5980,16 @@ impl App {
         let engine = self.engine.borrow();
         let visible = engine.editor_hover.is_some();
         let rect = self.editor_hover_popup_rect.get();
+        let link_count = self.editor_hover_link_rects.borrow().len();
+        let sb_present = self.editor_hover_scrollbar.get().is_some();
         drop(engine);
+        // #469 debug: trace what reconcile sees so we can confirm whether
+        // the migrated paint set the popup rect / link rects / scrollbar
+        // hit correctly. Remove once root-causation lands.
+        eprintln!(
+            "[#469] reconcile_editor_hover_modal: visible={} rect={:?} links={} sb={}",
+            visible, rect, link_count, sb_present,
+        );
         let stack_rc = self.backend.borrow().modal_stack_handle();
         let mut stack = stack_rc.borrow_mut();
         match (visible, rect) {
@@ -6043,6 +6052,19 @@ impl App {
                 quadraui::MouseButton::Left,
                 Default::default(),
             );
+            // #469 debug: trace dispatch_click so we can see if the
+            // editor_hover modal is being hit at click time, or if the
+            // click is falling through to a scroll surface (the editor
+            // scrollbar). Remove once root-causation lands.
+            eprintln!(
+                "[#469] dispatch_click @({x:.0},{y:.0}) -> {} events; modal_top={:?} surfaces={}",
+                click_events.len(),
+                modal.top().map(|m| m.id.as_str().to_string()),
+                surfaces.len(),
+            );
+            for ev in &click_events {
+                eprintln!("[#469]   event: {:?}", ev);
+            }
             *self.backend.borrow().drag_state_handle().borrow_mut() = drag;
             for cev in &click_events {
                 match cev {

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -6672,22 +6672,6 @@ impl App {
                         }
                     }
                     // Check if click hit a link rect.
-                    {
-                        let lr = self.editor_hover_link_rects.borrow();
-                        eprintln!(
-                            "[#469-url] click @({:.0},{:.0}); {} link rects:",
-                            x,
-                            y,
-                            lr.len()
-                        );
-                        for (i, (lx, ly, lw, lh, url)) in lr.iter().enumerate() {
-                            let hit = x >= *lx && x <= lx + lw && y >= *ly && y <= ly + lh;
-                            eprintln!(
-                                "[#469-url]   [{}] ({:.0},{:.0},{:.0},{:.0}) hit={} url={}",
-                                i, lx, ly, lw, lh, hit, url
-                            );
-                        }
-                    }
                     let link_hit = self
                         .editor_hover_link_rects
                         .borrow()
@@ -6697,12 +6681,9 @@ impl App {
                         })
                         .cloned();
                     if let Some((_, _, _, _, url)) = link_hit {
-                        eprintln!("[#469-url] LINK HIT: url={}", url);
                         if url.starts_with("command:") {
-                            let res = self.engine.borrow_mut().execute_command_uri(&url);
-                            eprintln!("[#469-url]   execute_command_uri returned {}", res);
+                            self.engine.borrow_mut().execute_command_uri(&url);
                         } else {
-                            eprintln!("[#469-url]   calling open_url({})", url);
                             open_url(&url);
                         }
                         self.engine.borrow_mut().dismiss_editor_hover();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -5980,16 +5980,7 @@ impl App {
         let engine = self.engine.borrow();
         let visible = engine.editor_hover.is_some();
         let rect = self.editor_hover_popup_rect.get();
-        let link_count = self.editor_hover_link_rects.borrow().len();
-        let sb_present = self.editor_hover_scrollbar.get().is_some();
         drop(engine);
-        // #469 debug: trace what reconcile sees so we can confirm whether
-        // the migrated paint set the popup rect / link rects / scrollbar
-        // hit correctly. Remove once root-causation lands.
-        eprintln!(
-            "[#469] reconcile_editor_hover_modal: visible={} rect={:?} links={} sb={}",
-            visible, rect, link_count, sb_present,
-        );
         let stack_rc = self.backend.borrow().modal_stack_handle();
         let mut stack = stack_rc.borrow_mut();
         match (visible, rect) {
@@ -6052,19 +6043,6 @@ impl App {
                 quadraui::MouseButton::Left,
                 Default::default(),
             );
-            // #469 debug: trace dispatch_click so we can see if the
-            // editor_hover modal is being hit at click time, or if the
-            // click is falling through to a scroll surface (the editor
-            // scrollbar). Remove once root-causation lands.
-            eprintln!(
-                "[#469] dispatch_click @({x:.0},{y:.0}) -> {} events; modal_top={:?} surfaces={}",
-                click_events.len(),
-                modal.top().map(|m| m.id.as_str().to_string()),
-                surfaces.len(),
-            );
-            for ev in &click_events {
-                eprintln!("[#469]   event: {:?}", ev);
-            }
             *self.backend.borrow().drag_state_handle().borrow_mut() = drag;
             for cev in &click_events {
                 match cev {
@@ -6641,14 +6619,8 @@ impl App {
         }
 
         // Editor hover: click on the popup focuses it; click elsewhere dismisses it
-        eprintln!("[#469] reached editor_hover check");
         {
             let engine = self.engine.borrow();
-            eprintln!(
-                "[#469]   editor_hover.is_some()={}, has_focus={}",
-                engine.editor_hover.is_some(),
-                engine.editor_hover_has_focus,
-            );
             if engine.editor_hover.is_some() {
                 let rect = self.editor_hover_popup_rect.get();
                 let on_popup = if let Some((px, py, pw, ph)) = rect {
@@ -6658,7 +6630,6 @@ impl App {
                 };
                 let has_focus = engine.editor_hover_has_focus;
                 drop(engine);
-                eprintln!("[#469]   on_popup={} rect={:?}", on_popup, rect);
                 if on_popup {
                     // Scrollbar hit-test (#215). Track click jumps to that
                     // offset and arms a drag so mouse-move updates the
@@ -6675,12 +6646,6 @@ impl App {
                             && cx < sb_hit.track.x + sb_hit.track.width
                             && cy >= sb_hit.track.y
                             && cy < sb_hit.track.y + sb_hit.track.height;
-                        eprintln!(
-                            "[#469]   sb: thumb=({},{},{},{}) track=({},{},{},{}) on_thumb={} on_track={}",
-                            sb_hit.thumb.x, sb_hit.thumb.y, sb_hit.thumb.width, sb_hit.thumb.height,
-                            sb_hit.track.x, sb_hit.track.y, sb_hit.track.width, sb_hit.track.height,
-                            on_thumb, on_track,
-                        );
                         if on_track || on_thumb {
                             if on_track {
                                 let max_scroll = sb_hit.total.saturating_sub(sb_hit.visible_rows);
@@ -6707,16 +6672,6 @@ impl App {
                         }
                     }
                     // Check if click hit a link rect.
-                    {
-                        let lr = self.editor_hover_link_rects.borrow();
-                        eprintln!("[#469]   link_rects.len()={}", lr.len());
-                        for (i, (lx, ly, lw, lh, url)) in lr.iter().enumerate() {
-                            eprintln!(
-                                "[#469]     link[{}]: ({},{},{},{}) url={}",
-                                i, lx, ly, lw, lh, url
-                            );
-                        }
-                    }
                     let link_hit = self
                         .editor_hover_link_rects
                         .borrow()
@@ -6725,10 +6680,6 @@ impl App {
                             x >= *lx && x <= lx + lw && y >= *ly && y <= ly + lh
                         })
                         .cloned();
-                    eprintln!(
-                        "[#469]   link_hit={:?}",
-                        link_hit.as_ref().map(|(_, _, _, _, url)| url.clone())
-                    );
                     if let Some((_, _, _, _, url)) = link_hit {
                         if url.starts_with("command:") {
                             self.engine.borrow_mut().execute_command_uri(&url);

--- a/src/gtk/quadraui_gtk.rs
+++ b/src/gtk/quadraui_gtk.rs
@@ -1,10 +1,10 @@
 //! GTK backend for `quadraui` primitives — vimcode-side helpers.
 //!
 //! Most primitive paint paths now go through `Backend::draw_X` via
-//! `quadraui::ScreenLayout::draw()` (#446, chunks B+D). What remains
-//! here is `q_theme()` — the theme adapter every GTK draw call uses —
-//! plus a couple of rich-text-popup constants re-exported for the
-//! click-side scrollbar geometry helper.
+//! `quadraui::ScreenLayout::draw()` (#446, chunks B+D, #469). What
+//! remains here is `q_theme()` — the theme adapter every GTK draw call
+//! uses — plus a couple of rich-text-popup constants re-exported for
+//! the click-side scrollbar geometry helper.
 
 use super::*;
 
@@ -21,35 +21,3 @@ pub(super) const RICH_TEXT_POPUP_SB_WIDTH: f64 = quadraui::gtk::RICH_TEXT_POPUP_
 /// Pixels of inset between the scrollbar's right edge and the popup's
 /// right border. Same role as `RICH_TEXT_POPUP_SB_WIDTH`.
 pub(super) const RICH_TEXT_POPUP_SB_INSET: f64 = quadraui::gtk::RICH_TEXT_POPUP_SB_INSET;
-
-/// Draw a `quadraui::RichTextPopup` at its resolved layout. Returns
-/// per-link hit regions in `(x, y, w, h, url)` form. Each visible
-/// line is rendered as a SINGLE Pango call with an `AttrList` —
-/// per-span fg/bold/italic + per-character selection bg become
-/// attribute ranges. This avoids the per-span manual-advance bug
-/// where proportional Pango widths drift from monospace
-/// `char_width * char_count` math (#214 first-cut regression).
-///
-/// Kept as a shim while the Surface::RichTextPopup migration (#463)
-/// is investigated — paint via the trait broke click hit-test.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn draw_rich_text_popup(
-    cr: &Context,
-    pango_layout: &pango::Layout,
-    popup: &quadraui::RichTextPopup,
-    layout: &quadraui::RichTextPopupLayout,
-    line_height: f64,
-    char_width: f64,
-    theme: &Theme,
-) -> Vec<(f64, f64, f64, f64, String)> {
-    let _ = (line_height, char_width);
-    let ui_font_desc = pango::FontDescription::from_string(&super::draw::UI_FONT());
-    quadraui::gtk::draw_rich_text_popup(
-        cr,
-        pango_layout,
-        &ui_font_desc,
-        popup,
-        layout,
-        &q_theme(theme),
-    )
-}


### PR DESCRIPTION
## Summary

Reapplies the rich-text-popup migration that was reverted in #463 (chunk D continuation). Routes \`draw_editor_hover_popup\` paint through \`Surface::RichTextPopup\` via \`enter_frame_scope\` + \`frame.draw(b)\`, matching the pattern used by the other 7 popup surfaces. Removes the now-dead \`quadraui_gtk::draw_rich_text_popup\` shim. All paint surfaces in GTK now route through \`ScreenLayout::draw()\` — chunk D of #446 fully complete.

Closes #469.

## What changed

- \`draw_editor_hover_popup\` (\`src/gtk/draw.rs:1501\`): paint via \`enter_frame_scope\` + \`Surface::RichTextPopup\` push instead of direct shim call. Recovers \`link_hit_regions\` from the shared \`popup_layout\` instance (same source the rasteriser uses, so paint + click geometry agree by construction). Adds \`backend: &Rc<RefCell<GtkBackend>>\` parameter mirroring the other 7 migrated popup helpers.
- Caller in \`draw_editor\` (\`src/gtk/draw.rs:427\`): passes the backend through.
- \`quadraui_gtk::draw_rich_text_popup\` shim deleted (40 lines, dead after migration). \`RICH_TEXT_POPUP_SB_WIDTH\` / \`RICH_TEXT_POPUP_SB_INSET\` re-exports kept — still consumed by the hit-test scrollbar geometry helper.

## Why this stuck the first time

#463's original migration attempt was reverted because clicks on links + scrollbar inside the popup appeared to fall through. The follow-up investigation on this branch instrumented the click pipeline with \`[#469]\` eprintln traces and ran the user through a smoke test. The traces confirmed:

- \`reconcile_editor_hover_modal\` correctly pushes the popup rect on the modal stack.
- \`dispatch_click\` correctly returns \`MouseDown { widget: Some(\"editor_hover\") }\` for clicks inside the popup.
- The editor_hover branch in \`handle_mouse_click_msg\` is reached every time.
- \`command:\` link clicks resolve correctly through \`editor_hover_link_rects\` and fire \`execute_command_uri\`.

So the migrated path **does** work. The fall-through symptom that motivated #463's revert reproduces identically on \`develop\` (with the shim) when the popup's right edge overlaps the editor's vertical scrollbar — that's a separate, pre-existing bug caused by GTK widget-tree z-order: the editor scrollbar is a native \`gtk4::Scrollbar\` widget added via \`overlay.add_overlay(...)\`, which intercepts clicks before they reach the editor \`DrawingArea\`. The popup's modal stack can't arbitrate clicks that never enter the DA dispatch path. Filed as #486.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test --no-default-features\` — 1989 tests pass, no regressions
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Smoke tested by user: hover over Rust symbols in an open file, click on \`command:definition\` link → resolves correctly. Click on popup body → focuses the popup. Click outside → dismisses.
- [x] Confirmed: bug-symptom regression in #469 issue body reproduces identically on \`develop\` with the shim — i.e., it is not caused by this PR. Tracked in #486.

## Related

- Closes #469
- Continues #463 (chunk D)
- Filed follow-up: #486 (gtk4::Scrollbar overlay z-order — pre-existing bug surfaced by investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)