### PR TITLE
fix: completion popup narrows on prefix extension instead of clearing (#467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "pangocairo",
  "ratatui",
  "serde",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/src/core/engine/keys.rs
+++ b/src/core/engine/keys.rs
@@ -4761,8 +4761,13 @@ impl Engine {
             return;
         }
 
-        // Clear completion state on any non-completion key.
-        if self.completion_idx.is_some() {
+        // Clear completion state on non-completion keys. Word characters
+        // pass through — `trigger_completion` will either narrow (prefix
+        // extension) or clear (new word) after the char is inserted. Any
+        // non-word key (space, punctuation, navigation) means the user
+        // has left the current word, so the popup should dismiss.
+        let extends_word = unicode.is_some_and(Self::is_word_char) && !ctrl;
+        if self.completion_idx.is_some() && !extends_word {
             self.dismiss_completion();
         }
 

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2525,6 +2525,12 @@ pub struct Engine {
     /// True when the popup was triggered automatically (typing/Ctrl-Space):
     /// Tab accepts the highlighted item. False for Ctrl-N/P (inserts immediately as before).
     pub completion_display_only: bool,
+    /// Prefix the current `completion_candidates` were last filtered against.
+    /// Used to detect when typing extends the prefix (`S` → `Sc`) so the list
+    /// can be narrowed instead of wholesale-replaced — keeps items the user
+    /// already saw from being silently dropped when a fresh LSP / buffer-word
+    /// scan happens to return a smaller set (#467).
+    pub completion_filter_prefix: String,
 
     // --- Project search state ---
     /// Current text typed in the project search input box.
@@ -3534,6 +3540,7 @@ impl Engine {
             completion_idx: None,
             completion_start_col: 0,
             completion_display_only: false,
+            completion_filter_prefix: String::new(),
             project_search_query: String::new(),
             project_search_results: Vec::new(),
             project_search_options: SearchOptions::default(),

--- a/src/core/engine/motions.rs
+++ b/src/core/engine/motions.rs
@@ -3228,6 +3228,7 @@ impl Engine {
         self.completion_candidates.clear();
         self.completion_idx = None;
         self.completion_display_only = false;
+        self.completion_filter_prefix.clear();
         self.lsp_pending_completion = None;
     }
 
@@ -3239,12 +3240,20 @@ impl Engine {
     /// shouldn't drown the user in every word in scope), while manual triggers
     /// fall through to the LSP so the user sees all in-scope symbols (VSCode
     /// parity).
+    ///
+    /// When the new prefix **extends** the previous one (`S` → `Sc`), existing
+    /// candidates are narrowed by `starts_with(new_prefix)` and merged with
+    /// new buffer-word hits, instead of being wholesale-replaced. This keeps
+    /// items the user already saw from disappearing when a fresh nearby-word
+    /// scan or LSP request happens to return a smaller set (#467).
     pub(crate) fn trigger_completion(&mut self, manual: bool) {
         let (prefix, _) = self.completion_prefix_at_cursor();
         if prefix.is_empty() && !manual {
             self.dismiss_completion();
             return;
         }
+        let prev_prefix = std::mem::take(&mut self.completion_filter_prefix);
+        let extends = !prev_prefix.is_empty() && prefix.starts_with(&prev_prefix);
         if prefix.is_empty() {
             // Manual trigger with no prefix: skip the buffer-word scan (it would
             // match every word in the nearby radius) and rely on the LSP response.
@@ -3253,21 +3262,31 @@ impl Engine {
             self.completion_idx = None;
             self.completion_display_only = false;
         } else {
+            // Narrow existing candidates by the new prefix when it extends the
+            // previous one; otherwise start fresh.
+            if extends {
+                self.completion_candidates
+                    .retain(|c| c.starts_with(&prefix));
+            } else {
+                self.completion_candidates.clear();
+            }
             // Use a fast nearby-lines scan instead of scanning the entire buffer.
             // For a 15K-line file, full scan takes 270ms; nearby scan is ~1ms.
-            let candidates = self.word_completions_nearby(&prefix);
-            if !candidates.is_empty() {
+            for word in self.word_completions_nearby(&prefix) {
+                if !self.completion_candidates.iter().any(|c| c == &word) {
+                    self.completion_candidates.push(word);
+                }
+            }
+            if !self.completion_candidates.is_empty() {
                 self.completion_start_col = self.view().cursor.col - prefix.chars().count();
-                self.completion_candidates = candidates;
                 self.completion_idx = Some(0);
                 self.completion_display_only = true;
             } else {
-                // No buffer-word hits yet; clear popup but keep LSP pending
-                self.completion_candidates.clear();
                 self.completion_idx = None;
                 self.completion_display_only = false;
             }
         }
+        self.completion_filter_prefix = prefix;
         // Async LSP source — response will update candidates if popup is still active
         self.lsp_request_completion();
     }

--- a/src/core/engine/panels.rs
+++ b/src/core/engine/panels.rs
@@ -905,9 +905,24 @@ impl Engine {
                             if !lsp_cands.is_empty() {
                                 self.completion_start_col =
                                     self.view().cursor.col - cur_prefix.chars().count();
-                                self.completion_candidates = lsp_cands;
-                                self.completion_idx = Some(0);
+                                // #467: merge into existing candidates instead
+                                // of replacing — fresh LSP fetches at narrower
+                                // prefixes can return a smaller set than the
+                                // previous response, and items the user already
+                                // saw shouldn't silently disappear. The narrow
+                                // step in `trigger_completion` already pruned
+                                // anything that no longer matches the prefix,
+                                // so existing candidates are still valid.
+                                for cand in lsp_cands {
+                                    if !self.completion_candidates.iter().any(|c| c == &cand) {
+                                        self.completion_candidates.push(cand);
+                                    }
+                                }
+                                if self.completion_idx.is_none() {
+                                    self.completion_idx = Some(0);
+                                }
                                 self.completion_display_only = true;
+                                self.completion_filter_prefix = cur_prefix;
                                 redraw = true;
                             }
                         }

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -6828,6 +6828,83 @@ fn test_manual_trigger_with_prefix_still_scans_buffer() {
 }
 
 #[test]
+fn test_completion_narrows_on_prefix_extension() {
+    // #467: typing more characters of an exact prefix should retain items
+    // the user already saw. Even when a fresh scan / LSP request at the
+    // narrower prefix would return fewer items, anything already in
+    // `completion_candidates` that still matches the new prefix must stay.
+    //
+    // Simulates an LSP response having populated extra items (Scrollbar,
+    // ScrollAxis) at prefix `S` that are NOT present in the buffer. When
+    // the user types `c`, the nearby-buffer scan at prefix `Sc` would
+    // return nothing — but the previously-collected items should survive
+    // the narrow step.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "let foo = ");
+    // Position cursor at end of line and enter insert mode at end.
+    press_char(&mut engine, 'A');
+    press_char(&mut engine, 'S');
+    // After typing `S`, the buffer-word scan produces no matches (the only
+    // word in the buffer is `foo`). Simulate an LSP-driven population of
+    // the popup at prefix `S` with three items.
+    engine.completion_candidates = vec![
+        "Scrollbar".to_string(),
+        "ScrollAxis".to_string(),
+        "ScreenLayout".to_string(),
+        "SomethingElse".to_string(), // matches `S` but not `Sc`
+    ];
+    engine.completion_idx = Some(0);
+    engine.completion_display_only = true;
+    engine.completion_filter_prefix = "S".to_string();
+    engine.completion_start_col = engine.view().cursor.col;
+    // Type `c` — prefix becomes `Sc`. Narrow-on-extension should retain the
+    // three `Sc*` items and drop the one that doesn't match.
+    press_char(&mut engine, 'c');
+    let cands = &engine.completion_candidates;
+    assert!(
+        cands.iter().any(|c| c == "Scrollbar"),
+        "Scrollbar should be retained, got: {cands:?}"
+    );
+    assert!(
+        cands.iter().any(|c| c == "ScrollAxis"),
+        "ScrollAxis should be retained, got: {cands:?}"
+    );
+    assert!(
+        cands.iter().any(|c| c == "ScreenLayout"),
+        "ScreenLayout should be retained, got: {cands:?}"
+    );
+    assert!(
+        !cands.iter().any(|c| c == "SomethingElse"),
+        "SomethingElse should be dropped (does not match Sc), got: {cands:?}"
+    );
+    assert_eq!(
+        engine.completion_filter_prefix, "Sc",
+        "completion_filter_prefix should track the current prefix"
+    );
+}
+
+#[test]
+fn test_completion_replaces_when_prefix_changes_unrelated() {
+    // Sanity check: when the new prefix doesn't extend the previous one
+    // (cursor moved to a new word entirely), candidates are cleared and
+    // repopulated from sources — not narrowed against the old set.
+    let mut engine = Engine::new();
+    engine.buffer_mut().insert(0, "foobar\n");
+    press_char(&mut engine, 'G');
+    press_char(&mut engine, 'o');
+    // Simulate state from an earlier completion at prefix `S`.
+    engine.completion_candidates = vec!["Scrollbar".to_string()];
+    engine.completion_filter_prefix = "S".to_string();
+    // Now type a completely different word — prefix becomes `f`.
+    press_char(&mut engine, 'f');
+    let cands = &engine.completion_candidates;
+    assert!(
+        !cands.iter().any(|c| c == "Scrollbar"),
+        "Scrollbar should be cleared on unrelated prefix change, got: {cands:?}"
+    );
+}
+
+#[test]
 fn test_auto_popup_tab_accepts() {
     let mut engine = Engine::new();
     engine.buffer_mut().insert(0, "foobar\n");


### PR DESCRIPTION
## Summary

Typing an additional word character after the completion popup opens (e.g. \`S\` → \`Sc\`) used to dismiss the popup and re-trigger from scratch. With the popup dismissed, the previous candidates were gone, and the fresh nearby-buffer scan / LSP request at the narrower prefix often returned a smaller set — items the user already saw silently disappeared.

Three-part engine-side fix (no per-backend code):

1. **\`handle_insert_key\` (keys.rs:4764)** — no longer dismisses the popup when the typed key is a word character. Non-word keys (space, punctuation, navigation) still dismiss as before.
2. **\`trigger_completion\` (motions.rs:3242)** — tracks new \`Engine.completion_filter_prefix\`. When the new prefix extends the previous one, existing candidates are narrowed in place via \`retain(|c| c.starts_with(new_prefix))\` and merged with the buffer-word scan, instead of being wholesale-replaced.
3. **\`CompletionResponse\` handler (panels.rs:887)** — merges new LSP items into existing candidates instead of replacing.

Two regression tests added covering both branches (prefix extension retains, unrelated prefix change clears).

Closes #467.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo test --no-default-features\` — 1991 + 2083 tests pass; 8/8 completion tests pass including the 2 new ones
- [x] \`cargo clippy -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] GTK smoke test (user-driven): opened a Rust file with rust-analyzer active, typed \`quadraui::S\` then \`c\`, verified \`Sc*\` items remain visible

## Notes

- 6 TUI snapshot tests (\`snapshot_normal_mode\` etc.) fail on \`develop\` independently of this PR. Verified by stashing the changes and re-running on a clean develop checkout. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)