### PR TITLE
fix(tui): ext panel filter + wheel routing + sidebar section toggle (#483 #484 #485)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "pangocairo",
  "ratatui",
  "serde",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/src/core/engine/dap_ops.rs
+++ b/src/core/engine/dap_ops.rs
@@ -755,8 +755,14 @@ impl Engine {
                 self.dispatch_dap_sidebar_row_activated(section, path);
                 true
             }
+            quadraui::SidebarEvent::HeaderActivated { section } => {
+                let mut sys = self.dap_sidebar_system.borrow_mut();
+                let collapsed = sys.is_collapsed(section);
+                sys.set_collapsed(section, !collapsed);
+                true
+            }
             quadraui::SidebarEvent::Ignored => false,
-            _ => true, // StateChanged, Consumed, ScrollChanged, HeaderActivated → redraw
+            _ => true,
         }
     }
 

--- a/src/core/engine/ext_panel.rs
+++ b/src/core/engine/ext_panel.rs
@@ -1706,6 +1706,12 @@ impl Engine {
                 self.ext_sidebar_input_active = false;
                 true
             }
+            quadraui::SidebarEvent::HeaderActivated { section } => {
+                let mut sys = self.ext_sidebar_system.borrow_mut();
+                let collapsed = sys.is_collapsed(section);
+                sys.set_collapsed(section, !collapsed);
+                true
+            }
             quadraui::SidebarEvent::Ignored => false,
             _ => true,
         }

--- a/src/core/engine/ext_panel.rs
+++ b/src/core/engine/ext_panel.rs
@@ -42,7 +42,24 @@ impl Engine {
         }
     }
 
-    /// Count visible items in a section (accounting for collapsed tree nodes).
+    /// Whether an item passes the panel's search-input filter.
+    /// Returns true when there is no filter or when the item's text contains
+    /// the filter substring (case-insensitive). Plugins that subscribe to
+    /// `panel_input` and re-emit a filtered `set_items` still work — this is
+    /// a default fallback for panels whose plugins don't intercept.
+    pub(crate) fn ext_panel_filter_matches(
+        &self,
+        panel_name: &str,
+        item: &plugin::ExtPanelItem,
+    ) -> bool {
+        match self.ext_panel_input_text.get(panel_name) {
+            Some(s) if !s.is_empty() => item.text.to_lowercase().contains(&s.to_lowercase()),
+            _ => true,
+        }
+    }
+
+    /// Count visible items in a section (accounting for collapsed tree nodes
+    /// and the panel's search-input filter).
     pub(crate) fn ext_panel_visible_count(
         &self,
         panel_name: &str,
@@ -50,11 +67,15 @@ impl Engine {
     ) -> usize {
         items
             .iter()
-            .filter(|item| self.ext_panel_item_visible(panel_name, item, items))
+            .filter(|item| {
+                self.ext_panel_item_visible(panel_name, item, items)
+                    && self.ext_panel_filter_matches(panel_name, item)
+            })
             .count()
     }
 
-    /// Return the indices of visible items in a section.
+    /// Return the indices of visible items in a section (accounting for
+    /// collapsed tree nodes and the panel's search-input filter).
     pub fn ext_panel_visible_indices(
         &self,
         panel_name: &str,
@@ -63,7 +84,10 @@ impl Engine {
         items
             .iter()
             .enumerate()
-            .filter(|(_, item)| self.ext_panel_item_visible(panel_name, item, items))
+            .filter(|(_, item)| {
+                self.ext_panel_item_visible(panel_name, item, items)
+                    && self.ext_panel_filter_matches(panel_name, item)
+            })
             .map(|(i, _)| i)
             .collect()
     }
@@ -545,6 +569,8 @@ impl Engine {
                 if let Some(text) = self.ext_panel_input_text.get_mut(&panel_name) {
                     text.pop();
                 }
+                self.ext_panel_selected = 0;
+                self.ext_panel_scroll_top = 0;
                 // Fire panel_input on every change for live filtering.
                 let text = self
                     .ext_panel_input_text
@@ -561,6 +587,8 @@ impl Engine {
                             .entry(panel_name.clone())
                             .or_default()
                             .push(ch);
+                        self.ext_panel_selected = 0;
+                        self.ext_panel_scroll_top = 0;
                         // Fire panel_input on every change for live filtering.
                         let text = self
                             .ext_panel_input_text

--- a/src/core/engine/search.rs
+++ b/src/core/engine/search.rs
@@ -1068,6 +1068,12 @@ impl Engine {
                 }
                 true
             }
+            quadraui::SidebarEvent::HeaderActivated { section } => {
+                let mut sys = self.search_sidebar_system.borrow_mut();
+                let collapsed = sys.is_collapsed(section);
+                sys.set_collapsed(section, !collapsed);
+                true
+            }
             quadraui::SidebarEvent::Ignored => false,
             _ => true,
         }

--- a/src/core/engine/source_control.rs
+++ b/src/core/engine/source_control.rs
@@ -1225,6 +1225,12 @@ impl Engine {
                 true
             }
             quadraui::SidebarEvent::RowSelected { .. } => true,
+            quadraui::SidebarEvent::HeaderActivated { section } => {
+                let mut sys = self.sc_sidebar_system.borrow_mut();
+                let collapsed = sys.is_collapsed(section);
+                sys.set_collapsed(section, !collapsed);
+                true
+            }
             quadraui::SidebarEvent::Ignored => false,
             _ => true,
         }

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -1156,9 +1156,16 @@ pub(super) fn handle_mouse(
         // Scroll wheel — sidebar or editor
         MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
             let scroll_up = matches!(ev.kind, MouseEventKind::ScrollUp);
+            // When an extension panel is showing, its surface bounds (registered
+            // by `render_ext_panel`) own the sidebar area — the activity-bar
+            // `active_panel_id` is unchanged from before the ext panel opened,
+            // so without this guard the wheel scrolls whatever the underlying
+            // panel was (#485 was explorer routing).
+            let ext_panel_showing = sidebar.ext_panel_name.is_some();
             if sb_visible
                 && col >= ab_width
                 && col < ab_width + sidebar_width
+                && !ext_panel_showing
                 && engine.active_panel_is(PANEL_EXPLORER)
             {
                 let delta = if scroll_up { -3_isize } else { 3 };
@@ -1168,6 +1175,7 @@ pub(super) fn handle_mouse(
             if sb_visible
                 && col >= ab_width
                 && col < ab_width + sidebar_width
+                && !ext_panel_showing
                 && engine.active_panel_is(PANEL_GIT)
             {
                 let scroll_ev = quadraui::UiEvent::Scroll {
@@ -1181,6 +1189,7 @@ pub(super) fn handle_mouse(
             if sb_visible
                 && col >= ab_width
                 && col < ab_width + sidebar_width
+                && !ext_panel_showing
                 && engine.active_panel_is(PANEL_SEARCH)
             {
                 let scroll_ev = quadraui::UiEvent::Scroll {
@@ -1194,6 +1203,7 @@ pub(super) fn handle_mouse(
             if sb_visible
                 && col >= ab_width
                 && col < ab_width + sidebar_width
+                && !ext_panel_showing
                 && engine.active_panel_is(PANEL_SETTINGS)
             {
                 let content_start = 2_u16;
@@ -2288,9 +2298,12 @@ pub(super) fn handle_mouse(
                     *last_click_pos = (col, row);
                     if is_double {
                         engine.handle_ext_panel_double_click();
+                    } else {
+                        // Single-click toggles sections/expandable items.
+                        // Suppressed on double-click so the second Down doesn't
+                        // un-toggle what the first one just toggled (#484).
+                        engine.handle_ext_panel_key("Return", false, None);
                     }
-                    // Single-click toggles sections/expandable items
-                    engine.handle_ext_panel_key("Return", false, None);
                 }
             }
         } else if engine.active_panel_is(PANEL_EXPLORER) {


### PR DESCRIPTION
## Summary

Three TUI sidebar/ext-panel bugs surfaced during #476 smoke testing, plus one broader bug discovered during smoke-testing this branch:

- **#483 — Search input doesn't filter visible items.** \`engine.ext_panel_input_text\` was written but never consulted. Added \`ext_panel_filter_matches()\` and made \`ext_panel_visible_indices\`/\`_count\` apply it. Selection + scroll reset to top on each input change so navigation stays sensible. Plugins that subscribe to \`panel_input\` and re-emit a filtered \`set_items\` still work — this is just a default.
- **#485 — Scroll wheel doesn't scroll ext panel.** \`active_panel_id\` is unchanged when an ext panel is shown, so the wheel-handler early returns for \`PANEL_EXPLORER\`/\`PANEL_GIT\`/\`PANEL_SEARCH\`/\`PANEL_SETTINGS\` swallowed the event before it could reach the registered \`ext_panel:sb\` scroll surface. Each early return now guarded on \`sidebar.ext_panel_name.is_none()\`; the wheel then flows through \`dispatch_scroll\`, which routes correctly.
- **#484 — Section header click doesn't toggle (defensive).** The original handler always fired \`handle_ext_panel_key(\"Return\", …)\` even when \`is_double\` was true, so a same-position rapid-Down pair toggled twice → net zero. Gated the Return dispatch on \`!is_double\` so the second event only fires the plugin's double-click handler. **Partial fix** — smoke testing revealed only the top section in \`git_insights\` toggles; filed #499 to investigate the remaining cases.
- **Bonus — SidebarSystem section headers (Debug / SC / Search / built-in Extensions).** All four dispatchers caught \`SidebarEvent::HeaderActivated\` under \`_ => true\` but never toggled the section. quadraui's \`SidebarSystem\` owns the \`collapsed\` Vec and renders from it; the host app has to call \`set_collapsed\` in response. Each dispatcher now does. Confirmed working in smoke test.

## Known follow-ups (filed during smoke testing)

- #499 — TUI ext panel: only the top section header toggles on click in \`git_insights\` (Log/Stash still don't).
- #500 — TUI search panel: scrollbar thumb drag stops when the cursor leaves the panel into the editor area (likely needs a \`SidebarSystem::is_dragging()\` exposure in quadraui or a vimcode-side drag-in-flight flag).

## Test plan

- [x] \`cargo build --no-default-features\`
- [x] \`cargo test --no-default-features --lib\` — 1989 passed
- [x] \`cargo clippy -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] Smoke test: \`/\` then typing in an ext panel filters items
- [x] Smoke test: wheel scrolls ext panel (was previously eaten by explorer-scroll early return)
- [x] Smoke test: clicks on Debug / SC / Search / built-in Extensions section headers all toggle correctly

Closes #483, #485. Partial for #484 — leaving open as #499 covers the remaining git_insights case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)