### PR TITLE
fix(picker): breadcrumb symbol click shows correct sibling list (#465)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2814,6 +2814,13 @@ pub struct Engine {
     /// When `Some`, `picker_populate_document_symbols` filters to symbols
     /// whose container matches this value. `Some(None)` = top-level only.
     pub breadcrumb_scoped_parent: Option<Option<String>>,
+    /// When `Some`, the line at which the parent scope starts in the buffer.
+    /// Used as the primary key for finding the parent in the LSP document
+    /// symbol tree, since tree-sitter's name (e.g. `"VsplitLayout"` for an
+    /// `impl X for VsplitLayout` block) doesn't match rust-analyzer's
+    /// `"impl X for VsplitLayout"` container string. Falls back to the
+    /// name-based filter when this is `None`.
+    pub breadcrumb_scoped_parent_line: Option<usize>,
 
     // --- Two-way diff state ---
     /// The pair of windows currently in diff mode, or None when diff is off.
@@ -3678,6 +3685,7 @@ impl Engine {
             breadcrumb_selected: 0,
             breadcrumb_segments: Vec::new(),
             breadcrumb_scoped_parent: None,
+            breadcrumb_scoped_parent_line: None,
             diff_window_pair: None,
             diff_results: HashMap::new(),
             diff_aligned: HashMap::new(),

--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -91,6 +91,7 @@ impl Engine {
         self.picker_items.clear();
         self.picker_preview = None;
         self.breadcrumb_scoped_parent = None;
+        self.breadcrumb_scoped_parent_line = None;
         self.picker_history_index = None;
         self.picker_history_typing_buffer.clear();
 
@@ -220,6 +221,7 @@ impl Engine {
         self.picker_scroll_top = 0;
         self.picker_preview = None;
         self.breadcrumb_scoped_parent = None;
+        self.breadcrumb_scoped_parent_line = None;
     }
 
     /// Rebuild the cached breadcrumb segments from the active group's state.
@@ -307,13 +309,27 @@ impl Engine {
         // Filter to symbols whose container matches this segment's parent,
         // matching VSCode behavior (clicking a function shows sibling functions).
         //
-        // #465: `open_picker` resets `breadcrumb_scoped_parent` to None as part
-        // of its state-clear pass, so the assignment has to happen AFTER the
-        // open call — otherwise the filter is wiped before the async LSP
-        // response can read it, and the populated picker shows all symbols (or
-        // empty if rust-analyzer returns symbols with no `container`).
+        // #465: `open_picker` resets the scope filter as part of its state-clear
+        // pass, so both assignments happen AFTER the open call — otherwise the
+        // filter is wiped before the async LSP response can read it.
+        //
+        // The parent's *line* is recorded alongside its name because tree-sitter
+        // and LSP disagree on naming for impl blocks: tree-sitter's name is the
+        // type being implemented (e.g. `VsplitLayout`), while rust-analyzer's
+        // hierarchical `DocumentSymbol` names the impl block fully (e.g. `impl
+        // WindowGroupLayout for VsplitLayout`) and sets that on children's
+        // `container`. The line uniquely identifies the parent in either form
+        // without depending on name-string compatibility.
+        let parent_line = self
+            .breadcrumb_segments
+            .iter()
+            .take(self.breadcrumb_selected)
+            .rev()
+            .find(|s| s.is_symbol)
+            .and_then(|s| s.symbol_line);
         self.open_picker(PickerSource::CommandCenter);
         self.breadcrumb_scoped_parent = Some(seg.parent_scope.clone());
+        self.breadcrumb_scoped_parent_line = parent_line;
         self.picker_query = "@".to_string();
         self.picker_filter();
         self.picker_load_preview();
@@ -1072,8 +1088,40 @@ impl Engine {
     /// When a filter query is active, the tree is flattened for fuzzy matching.
     pub(crate) fn picker_populate_document_symbols(&mut self, symbols: Vec<lsp::SymbolInfo>) {
         // Apply scoped parent filter if set (from breadcrumb navigation).
+        //
+        // Two filter keys can be set by `breadcrumb_open_scoped`:
+        //  * `breadcrumb_scoped_parent_line` — start line of the parent scope
+        //    in the buffer. Primary key. Set when the click came via the
+        //    breadcrumb bar (where each segment has a line).
+        //  * `breadcrumb_scoped_parent` — parent name. Fallback for callers
+        //    that don't have a line (and the existing test surface).
+        //
+        // Line-based lookup wins when available because tree-sitter and LSP
+        // disagree on naming for impl blocks (#465): tree-sitter returns just
+        // the implemented type (`VsplitLayout`), while rust-analyzer names the
+        // impl `impl WindowGroupLayout for VsplitLayout`. Lines are unique and
+        // language-server-agnostic.
         let scoped = self.breadcrumb_scoped_parent.take();
-        let filtered: Vec<lsp::SymbolInfo> = if let Some(ref parent_filter) = scoped {
+        let scoped_line = self.breadcrumb_scoped_parent_line.take();
+        let filtered: Vec<lsp::SymbolInfo> = if let Some(parent_line) = scoped_line {
+            // Walk the hierarchical tree to find the parent symbol at the given
+            // line, then use its children as the sibling list. Falls through to
+            // name-based filtering if no such symbol is found (defensive).
+            match Self::find_symbol_at_line(&symbols, parent_line) {
+                Some(parent) if !parent.children.is_empty() => parent.children.clone(),
+                Some(parent) => {
+                    // Flat SymbolInformation case: parent has no children, so
+                    // siblings have to be identified via the `container` field
+                    // using the parent's own LSP name (not tree-sitter's).
+                    let parent_name = parent.name.clone();
+                    symbols
+                        .into_iter()
+                        .filter(|s| s.container.as_deref() == Some(parent_name.as_str()))
+                        .collect()
+                }
+                None => symbols, // parent not in LSP response — best-effort: show all
+            }
+        } else if let Some(ref parent_filter) = scoped {
             symbols
                 .into_iter()
                 .filter(|sym| sym.container.as_deref() == parent_filter.as_deref())
@@ -1138,6 +1186,26 @@ impl Engine {
         self.picker_scroll_top = 0;
         self.picker_update_scroll();
         self.picker_load_preview();
+    }
+
+    /// Recursively walk a hierarchical document-symbol tree and return the
+    /// first symbol whose start line matches `target_line`. Used by the
+    /// breadcrumb scope filter to locate the clicked-on parent by line —
+    /// language-server-agnostic, unlike name matching which breaks for impl
+    /// blocks where tree-sitter and LSP disagree on naming (#465).
+    fn find_symbol_at_line(
+        symbols: &[lsp::SymbolInfo],
+        target_line: usize,
+    ) -> Option<&lsp::SymbolInfo> {
+        for sym in symbols {
+            if sym.line as usize == target_line {
+                return Some(sym);
+            }
+            if let Some(found) = Self::find_symbol_at_line(&sym.children, target_line) {
+                return Some(found);
+            }
+        }
+        None
     }
 
     /// Reconstruct a tree from a flat symbol list using the `container` field.

--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -306,8 +306,14 @@ impl Engine {
         // Symbol segment: show siblings at the same level.
         // Filter to symbols whose container matches this segment's parent,
         // matching VSCode behavior (clicking a function shows sibling functions).
-        self.breadcrumb_scoped_parent = Some(seg.parent_scope.clone());
+        //
+        // #465: `open_picker` resets `breadcrumb_scoped_parent` to None as part
+        // of its state-clear pass, so the assignment has to happen AFTER the
+        // open call — otherwise the filter is wiped before the async LSP
+        // response can read it, and the populated picker shows all symbols (or
+        // empty if rust-analyzer returns symbols with no `container`).
         self.open_picker(PickerSource::CommandCenter);
+        self.breadcrumb_scoped_parent = Some(seg.parent_scope.clone());
         self.picker_query = "@".to_string();
         self.picker_filter();
         self.picker_load_preview();

--- a/src/core/engine/picker.rs
+++ b/src/core/engine/picker.rs
@@ -1103,7 +1103,8 @@ impl Engine {
         // language-server-agnostic.
         let scoped = self.breadcrumb_scoped_parent.take();
         let scoped_line = self.breadcrumb_scoped_parent_line.take();
-        let filtered: Vec<lsp::SymbolInfo> = if let Some(parent_line) = scoped_line {
+        let is_scoped = scoped.is_some();
+        let mut filtered: Vec<lsp::SymbolInfo> = if let Some(parent_line) = scoped_line {
             // Walk the hierarchical tree to find the parent symbol at the given
             // line, then use its children as the sibling list. Falls through to
             // name-based filtering if no such symbol is found (defensive).
@@ -1129,6 +1130,17 @@ impl Engine {
         } else {
             symbols
         };
+        // In scoped mode the picker shows ONE level (the siblings of the
+        // clicked segment). Strip nested children so `build_symbol_tree_items`
+        // doesn't recurse and flatten the whole subtree below each sibling —
+        // before this, clicking a top-level `impl` segment expanded every
+        // impl's methods inline and the picker showed all ~92 symbols in the
+        // file instead of just the sibling impls/structs/free functions.
+        if is_scoped {
+            for sym in &mut filtered {
+                sym.children.clear();
+            }
+        }
         let path = self.active_buffer_path().unwrap_or_default();
 
         // Check if the symbols already have hierarchy (DocumentSymbol format)

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -18185,6 +18185,75 @@ fn test_breadcrumb_enter_on_path_opens_file_picker() {
 }
 
 #[test]
+fn test_scoped_filter_hierarchical_impl_block_name_mismatch() {
+    // #465 follow-up: tree-sitter names an `impl X for Y` block as just `Y`,
+    // while rust-analyzer's hierarchical DocumentSymbol names the same block
+    // as `impl X for Y` and sets that on children's `container`. The fix is
+    // to use the parent's *line number* (which both agree on) to find the
+    // parent in the LSP tree, then return its children directly.
+    use crate::core::lsp::{SymbolInfo, SymbolKind};
+    let mut e = engine_with_text("hello");
+    // Simulate state right after clicking `adjust_ratio_at_index_impl` in the
+    // breadcrumb. Tree-sitter gave us:
+    //   - parent_scope = "VsplitLayout" (the impl's type)
+    //   - parent_line  = 600 (the impl_item's start row)
+    e.breadcrumb_scoped_parent = Some(Some("VsplitLayout".to_string()));
+    e.breadcrumb_scoped_parent_line = Some(600);
+
+    // Rust-analyzer's hierarchical response for the same code. Note the
+    // parent's name uses LSP's convention, not tree-sitter's.
+    let symbols = vec![SymbolInfo {
+        name: "impl WindowGroupLayout for VsplitLayout".to_string(),
+        kind: SymbolKind::Class,
+        detail: None,
+        container: None,
+        path: None,
+        line: 600,
+        character: 0,
+        children: vec![
+            SymbolInfo {
+                name: "adjust_ratio_at_index_impl".to_string(),
+                kind: SymbolKind::Method,
+                detail: None,
+                container: Some("impl WindowGroupLayout for VsplitLayout".to_string()),
+                path: None,
+                line: 601,
+                character: 0,
+                children: Vec::new(),
+            },
+            SymbolInfo {
+                name: "other_method".to_string(),
+                kind: SymbolKind::Method,
+                detail: None,
+                container: Some("impl WindowGroupLayout for VsplitLayout".to_string()),
+                path: None,
+                line: 650,
+                character: 0,
+                children: Vec::new(),
+            },
+        ],
+    }];
+    e.picker_populate_document_symbols(symbols);
+    // Pre-fix: name-based filter `container == "VsplitLayout"` matched zero
+    // items because rust-analyzer's container is the full `impl X for Y` form.
+    // Post-fix: line-based lookup finds the impl block at line 600 and uses
+    // its children (the two methods) as the sibling list.
+    let names: Vec<&str> = e
+        .picker_all_items
+        .iter()
+        .map(|i| i.display.as_str())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("adjust_ratio_at_index_impl")),
+        "expected adjust_ratio_at_index_impl in sibling list, got: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n.contains("other_method")),
+        "expected other_method in sibling list, got: {names:?}"
+    );
+}
+
+#[test]
 fn test_breadcrumb_open_scoped_preserves_parent_through_open_picker() {
     // #465: open_picker resets breadcrumb_scoped_parent as part of its
     // state-clear pass. Setting the scope BEFORE calling open_picker meant

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -18185,6 +18185,106 @@ fn test_breadcrumb_enter_on_path_opens_file_picker() {
 }
 
 #[test]
+fn test_scoped_filter_top_level_does_not_flatten_subtree() {
+    // #465 follow-up: when the user clicks the outermost symbol segment
+    // (parent_scope = None) the picker should show only the sibling
+    // top-level items, NOT recurse into their children. Pre-fix the picker
+    // showed every nested symbol in the file because `build_symbol_tree_items`
+    // recursively walked `children` on each filtered item.
+    use crate::core::lsp::{SymbolInfo, SymbolKind};
+    let mut e = engine_with_text("hello");
+    // Simulate state right after clicking the impl block segment at the top
+    // of the symbol breadcrumb chain: parent_scope is None (no enclosing
+    // symbol) so the filter is top-level only.
+    e.breadcrumb_scoped_parent = Some(None);
+    e.breadcrumb_scoped_parent_line = None;
+    // A file with two impl blocks, each with two methods (4 nested + 2
+    // top-level = 6 symbols total).
+    let symbols = vec![
+        SymbolInfo {
+            name: "impl Alpha".to_string(),
+            kind: SymbolKind::Class,
+            detail: None,
+            container: None,
+            path: None,
+            line: 10,
+            character: 0,
+            children: vec![
+                SymbolInfo {
+                    name: "a1".to_string(),
+                    kind: SymbolKind::Method,
+                    detail: None,
+                    container: Some("impl Alpha".to_string()),
+                    path: None,
+                    line: 11,
+                    character: 0,
+                    children: Vec::new(),
+                },
+                SymbolInfo {
+                    name: "a2".to_string(),
+                    kind: SymbolKind::Method,
+                    detail: None,
+                    container: Some("impl Alpha".to_string()),
+                    path: None,
+                    line: 15,
+                    character: 0,
+                    children: Vec::new(),
+                },
+            ],
+        },
+        SymbolInfo {
+            name: "impl Beta".to_string(),
+            kind: SymbolKind::Class,
+            detail: None,
+            container: None,
+            path: None,
+            line: 50,
+            character: 0,
+            children: vec![
+                SymbolInfo {
+                    name: "b1".to_string(),
+                    kind: SymbolKind::Method,
+                    detail: None,
+                    container: Some("impl Beta".to_string()),
+                    path: None,
+                    line: 51,
+                    character: 0,
+                    children: Vec::new(),
+                },
+                SymbolInfo {
+                    name: "b2".to_string(),
+                    kind: SymbolKind::Method,
+                    detail: None,
+                    container: Some("impl Beta".to_string()),
+                    path: None,
+                    line: 55,
+                    character: 0,
+                    children: Vec::new(),
+                },
+            ],
+        },
+    ];
+    e.picker_populate_document_symbols(symbols);
+    let names: Vec<&str> = e
+        .picker_all_items
+        .iter()
+        .map(|i| i.display.as_str())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("impl Alpha")),
+        "expected impl Alpha at top level, got: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n.contains("impl Beta")),
+        "expected impl Beta at top level, got: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains(" a1") || n.contains(" b1")),
+        "nested methods should be hidden in scoped top-level view, got: {names:?}"
+    );
+}
+
+#[test]
 fn test_scoped_filter_hierarchical_impl_block_name_mismatch() {
     // #465 follow-up: tree-sitter names an `impl X for Y` block as just `Y`,
     // while rust-analyzer's hierarchical DocumentSymbol names the same block

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -18185,6 +18185,43 @@ fn test_breadcrumb_enter_on_path_opens_file_picker() {
 }
 
 #[test]
+fn test_breadcrumb_open_scoped_preserves_parent_through_open_picker() {
+    // #465: open_picker resets breadcrumb_scoped_parent as part of its
+    // state-clear pass. Setting the scope BEFORE calling open_picker meant
+    // the filter was wiped before the async LSP response could read it,
+    // and the picker showed all symbols (or empty if rust-analyzer's
+    // DocumentSymbol response had no `container` field set on items).
+    // The fix moves the assignment after open_picker so the filter
+    // survives into picker_populate_document_symbols.
+    let mut e = engine_with_text("hello");
+    e.breadcrumb_segments = vec![
+        BreadcrumbSegmentInfo {
+            label: "Engine".to_string(),
+            is_symbol: true,
+            path_prefix: None,
+            symbol_line: Some(10),
+            parent_scope: None,
+        },
+        BreadcrumbSegmentInfo {
+            label: "handle_key".to_string(),
+            is_symbol: true,
+            path_prefix: None,
+            symbol_line: Some(20),
+            parent_scope: Some("Engine".to_string()),
+        },
+    ];
+    e.breadcrumb_selected = 1; // on "handle_key"
+    e.breadcrumb_open_scoped();
+    assert!(e.picker_open, "scoped picker should open");
+    assert_eq!(e.picker_query, "@");
+    assert_eq!(
+        e.breadcrumb_scoped_parent,
+        Some(Some("Engine".to_string())),
+        "scoped parent must survive open_picker so the async LSP response can filter siblings"
+    );
+}
+
+#[test]
 fn test_scoped_symbol_filtering() {
     let mut e = engine_with_text("hello");
     // Set the scoped parent filter to "Engine"


### PR DESCRIPTION
## Summary

The breadcrumb symbol picker had three compounding bugs that together produced the user-visible \"empty / wrong list\" behavior. Each is fixed in its own commit so the chain is easy to read.

### 1. \`f4e2512\` — assignment order
\`breadcrumb_open_scoped\` set \`breadcrumb_scoped_parent\` *before* calling \`open_picker\`, but \`open_picker\` resets the field as part of its state-clear pass. By the time the async LSP document-symbol response arrived, the scope filter was already wiped. Moving the assignment after the open call lets the filter survive.

### 2. \`c58b48b\` — name-vs-line parent matching
Tree-sitter and rust-analyzer disagree on how to name \`impl X for Y\` blocks. Tree-sitter's \`extract_node_name\` returns just the implemented type (\`Y\`); rust-analyzer's hierarchical \`DocumentSymbol\` uses the full \`impl X for Y\` form and sets that as \`container\` on children. Filtering siblings by \`container == parent_scope\` returned zero for any method inside an impl block. Fix: record the parent's start line at breadcrumb time, walk the hierarchical LSP tree to find the symbol at that line, and use its children directly — language-server-agnostic. Falls back to the name-based filter (existing test surface) when no line is set.

### 3. \`f12501e\` — sibling view shouldn't flatten subtree
\`build_symbol_tree_items\` always recurses into \`.children\`, which is correct for the unscoped @-picker (gives a flattened depth-first walk that the visible-tree pass collapses on demand). For the scoped sibling view it produced \"~92 symbols for the whole file\" when clicking a top-level \`impl\` segment, because every impl's methods got expanded inline. Stripping \`.children\` from the filtered list before handing it off keeps the scoped view at exactly one level.

Closes #465.

## Test plan

- [x] \`cargo build\`, \`cargo clippy -- -D warnings\`, \`cargo fmt --check\`
- [x] \`cargo test --no-default-features\` — 1994 lib + 2086 engine tests pass. 6 TUI snapshot tests fail on \`develop\` independently of this PR (verified by stashing changes).
- [x] Three regression tests added covering each commit's bug
- [x] GTK smoke test (user-driven): cursor at line 430 of \`src/core/window.rs\` (inside \`leaf_count\` method of \`impl GroupLayout\`). Clicking the \`leaf_count\` breadcrumb shows 18 sibling methods. Clicking the \`impl GroupLayout\` breadcrumb shows top-level siblings (other impls / structs / free functions in window.rs). Clicking path segments still opens scoped file picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)