### PR TITLE
#509: TUI+GTK: adopt quadraui::SidebarPanel for SC button-row + sections (consolidate Y-geometry)

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -2680,10 +2680,11 @@ pub struct Engine {
     /// and mouse handling. Both TUI and GTK call `render()` and `handle()`.
     pub sc_sidebar_system: std::rc::Rc<std::cell::RefCell<quadraui::SidebarSystem>>,
     pub sc_sidebar_body_rect: std::cell::Cell<quadraui::Rect>,
-    /// Cached layout of the SC action-button `quadraui::Toolbar` from the
-    /// last paint. Click/hover dispatch reads it verbatim via `hit_test()`
-    /// (#505) — no per-backend button-row arithmetic.
-    pub sc_button_layout: std::cell::RefCell<Option<quadraui::ToolbarLayout>>,
+    /// Cached layout of the SC `quadraui::SidebarPanel` from the last paint.
+    /// Click/hover dispatch reads it via `hit_test()` (#509) — no per-backend
+    /// button-row or section-start arithmetic. `toolbar_layout` inside carries
+    /// the per-button bounds for `sc_button_hit`.
+    pub sc_panel_layout: std::cell::RefCell<Option<quadraui::SidebarPanelLayout>>,
     /// Ahead/behind counts relative to upstream (cached alongside `sc_refresh`).
     pub sc_ahead: u32,
     pub sc_behind: u32,
@@ -3650,7 +3651,7 @@ impl Engine {
                 std::rc::Rc::new(std::cell::RefCell::new(s))
             },
             sc_sidebar_body_rect: std::cell::Cell::new(quadraui::Rect::new(0.0, 0.0, 0.0, 0.0)),
-            sc_button_layout: std::cell::RefCell::new(None),
+            sc_panel_layout: std::cell::RefCell::new(None),
             sc_ahead: 0,
             sc_behind: 0,
             sc_log: Vec::new(),

--- a/src/core/engine/source_control.rs
+++ b/src/core/engine/source_control.rs
@@ -1191,14 +1191,31 @@ impl Engine {
     }
 
     /// Resolve which SC button (if any) sits under absolute point `(x, y)`,
-    /// using the `quadraui::Toolbar` layout cached at paint time (#505).
-    /// Returns `None` for clicks in the bar's empty gutter or off the bar.
+    /// using the `SidebarPanelLayout` cached at paint time (#509).
+    /// Returns `None` for clicks in the toolbar's empty gutter, the content
+    /// area, or outside the panel.
     pub fn sc_button_hit(&self, x: f32, y: f32) -> Option<usize> {
-        let layout = self.sc_button_layout.borrow();
-        match layout.as_ref()?.hit_test(x, y) {
+        let layout = self.sc_panel_layout.borrow();
+        match layout.as_ref()?.toolbar_layout.as_ref()?.hit_test(x, y) {
             quadraui::ToolbarHit::Button(id) => Self::sc_button_index(&id),
             quadraui::ToolbarHit::Empty => None,
         }
+    }
+
+    /// Map a content-local row index (row 0 = first section header) to a
+    /// flat `(index, is_header)` pair for the SC panel sections area (#509).
+    ///
+    /// This is the content-coordinate variant of [`Self::sc_visual_row_to_flat`]:
+    /// callers that receive content-local y from `SidebarPanelLayout::hit_test`
+    /// use this function directly instead of offsetting by 3.
+    pub fn sc_content_row_to_flat(
+        &self,
+        content_row: usize,
+        empty_section_hint: bool,
+    ) -> Option<(usize, bool)> {
+        // content_row 0 == first section header == visual_row 3 in
+        // sc_visual_row_to_flat's coordinate system.
+        self.sc_visual_row_to_flat(content_row + 3, empty_section_hint)
     }
 
     /// Read the active section index and selected item index from the

--- a/src/gtk/draw.rs
+++ b/src/gtk/draw.rs
@@ -2778,32 +2778,32 @@ pub(super) fn draw_source_control_panel(
         y_commit += commit_h;
     }
 
-    // ── Action buttons via quadraui::Toolbar (#505) ────────────────────────
+    // ── Bottom slab: toolbar slot + sections via SidebarPanel (#509) ──────────
+    // Passes the entire remaining area (from just below commit input) to
+    // draw_sc_sidebar_panel. The backend reserves one `line_height` row for
+    // the toolbar slot; content_bounds below receives the sections. No manual
+    // btn_pad / btn_h arithmetic — option (a): tighter layout, single source
+    // of truth in the cached SidebarPanelLayout.
     {
-        let btn_pad = gap; // same gap as after header
-        let btn_y_base = y_commit + btn_pad;
-        let btn_h = line_height;
-        let margin = 4.0;
-        let btn_x = x + margin;
-        let btn_w = w - margin * 2.0;
-
-        // Shared builder paints both backends and caches the layout for
-        // click/hover hit-testing.
-        let btn_rect =
-            quadraui::Rect::new(btn_x as f32, btn_y_base as f32, btn_w as f32, btn_h as f32);
+        let slab_h = (y + h - y_commit).max(0.0);
+        let slab_rect = quadraui::Rect::new(x as f32, y_commit as f32, w as f32, slab_h as f32);
         backend.borrow_mut().enter_frame_scope(cr, layout, |b| {
             b.set_current_theme(super::quadraui_gtk::q_theme(theme));
             b.set_current_line_height(line_height);
-            render::draw_sc_button_toolbar(b, engine, sc, btn_rect);
+            render::draw_sc_sidebar_panel(b, engine, sc, slab_rect);
         });
-
-        y_commit = btn_y_base + btn_h + btn_pad;
     }
 
     // Section rendering — migrated to SidebarSystem (#321).
+    // Read content_bounds from the layout that draw_sc_sidebar_panel just cached.
     let _ = (add_r, add_g, add_b, del_r, del_g, del_b);
-    let sections_h = (y + h - y_commit).max(0.0);
-    let body_rect = quadraui::Rect::new(x as f32, y_commit as f32, w as f32, sections_h as f32);
+    let body_rect = {
+        let l = engine.sc_panel_layout.borrow();
+        l.as_ref().map(|l| l.content_bounds).unwrap_or(
+            // Fallback: old arithmetic for the first frame before layout is cached.
+            quadraui::Rect::new(x as f32, (y_commit + line_height) as f32, w as f32, 0.0),
+        )
+    };
     engine.sc_sidebar_body_rect.set(body_rect);
     render::populate_sc_sidebar_system(engine, theme);
     {
@@ -3553,16 +3553,24 @@ pub(super) fn draw_panel_hover_popup(
 
     // Y position: align with the hovered item row.
     let item_row_y = if hover.panel_name == "source_control" {
-        // SC layout: header(lh) + gap + commit(lh*rows) + gap + buttons(lh) + gap + sections
-        // The flat index maps into the sections area. Use SC-specific geometry.
-        let gap = (line_height * 0.3).round();
+        // SC layout after #509: section_top is read from the cached
+        // SidebarPanelLayout.content_bounds.y so we don't re-derive it.
         let item_height = (line_height * 1.4).round();
-        let commit_rows = screen
+        let section_top = screen
             .source_control
             .as_ref()
-            .map(|sc| sc.commit_message.split('\n').count().max(1))
-            .unwrap_or(1) as f64;
-        let section_top = line_height + gap + commit_rows * line_height + gap + line_height + gap;
+            .and_then(|sc| sc.sc_sections_start_y)
+            .map(|y| y as f64)
+            .unwrap_or_else(|| {
+                // Fallback: recompute from commit_rows (one frame lag is acceptable).
+                let gap = (line_height * 0.3).round();
+                let commit_rows = screen
+                    .source_control
+                    .as_ref()
+                    .map(|sc| sc.commit_message.split('\n').count().max(1))
+                    .unwrap_or(1) as f64;
+                line_height + gap + commit_rows * line_height + line_height
+            });
         // Walk sections to find the accumulated Y offset for the hovered flat_idx.
         // Headers use line_height, items use item_height.
         // Staged + Unstaged always show; Worktrees only when > 1; Log always shows.

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -8025,44 +8025,54 @@ impl App {
                 {
                     let mut engine = self.engine.borrow_mut();
                     engine.sc_set_focus(true);
+                    // Route via cached SidebarPanelLayout (#509).
+                    // Header / commit-input area: identified by panel-local y
+                    // (the panel starts at 0,0 in the drawing area).
                     let gap = (lh * 0.3).round();
                     let commit_rows = engine.sc_commit_message.split('\n').count().max(1);
                     let commit_h = commit_rows as f64 * lh;
                     let header_end = lh;
                     let commit_top = header_end + gap;
                     let commit_bottom = commit_top + commit_h;
-                    let btn_top = commit_bottom + gap;
-                    let btn_bottom = btn_top + lh;
-                    let section_top = btn_bottom + gap;
 
                     if y < header_end {
                         engine.sc_commit_input_active = false;
                     } else if y >= commit_top && y < commit_bottom {
                         engine.sc_commit_input_active = true;
                         engine.sc_commit_cursor = engine.sc_commit_message.len();
-                    } else if y >= btn_top && y < btn_bottom {
-                        engine.sc_commit_input_active = false;
-                        if let Some(idx) = engine.sc_button_hit(x_click as f32, y as f32) {
-                            engine.sc_activate_button(idx);
-                        }
-                    } else if y >= section_top {
-                        engine.sc_commit_input_active = false;
-                        let click_ev = quadraui::UiEvent::MouseDown {
-                            widget: None,
-                            button: quadraui::MouseButton::Left,
-                            position: quadraui::Point::new(x_click as f32, y as f32),
-                            modifiers: quadraui::Modifiers::default(),
-                        };
-                        engine.handle_sc_sidebar_ui_event(click_ev);
-                        if n_press >= 2 {
-                            let double_ev = quadraui::UiEvent::DoubleClick {
-                                widget: None,
-                                position: quadraui::Point::new(x_click as f32, y as f32),
-                            };
-                            engine.handle_sc_sidebar_ui_event(double_ev);
-                        }
                     } else {
+                        // Bottom slab: delegate to SidebarPanelLayout hit_test.
                         engine.sc_commit_input_active = false;
+                        let hit = {
+                            let layout = engine.sc_panel_layout.borrow();
+                            layout
+                                .as_ref()
+                                .map(|l| l.hit_test(x_click as f32, y as f32))
+                        };
+                        match hit {
+                            Some(quadraui::SidebarPanelHit::ToolbarButton(_)) => {
+                                if let Some(idx) = engine.sc_button_hit(x_click as f32, y as f32) {
+                                    engine.sc_activate_button(idx);
+                                }
+                            }
+                            Some(quadraui::SidebarPanelHit::Content { .. }) => {
+                                let click_ev = quadraui::UiEvent::MouseDown {
+                                    widget: None,
+                                    button: quadraui::MouseButton::Left,
+                                    position: quadraui::Point::new(x_click as f32, y as f32),
+                                    modifiers: quadraui::Modifiers::default(),
+                                };
+                                engine.handle_sc_sidebar_ui_event(click_ev);
+                                if n_press >= 2 {
+                                    let double_ev = quadraui::UiEvent::DoubleClick {
+                                        widget: None,
+                                        position: quadraui::Point::new(x_click as f32, y as f32),
+                                    };
+                                    engine.handle_sc_sidebar_ui_event(double_ev);
+                                }
+                            }
+                            _ => {}
+                        }
                     }
                 }
                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
@@ -8071,33 +8081,31 @@ impl App {
                 self.draw_needed.set(true);
             }
             Msg::ScSidebarMotion(mx, my) => {
-                // Determine which button (if any) the mouse is over.
+                // Route via cached SidebarPanelLayout (#509) — no per-frame
+                // button-row or section-top arithmetic.
                 let lh = self.cached_ui_line_height;
                 let mut engine = self.engine.borrow_mut();
-                let gap = (lh * 0.3).round();
-                let commit_rows = engine.sc_commit_message.split('\n').count().max(1);
-                let commit_h = commit_rows as f64 * lh;
-                // Button row Y range: after header + gap + commit + gap
-                let btn_top = lh + gap + commit_h + gap;
-                let btn_bottom = btn_top + lh;
+
+                let hit = if mx < 0.0 {
+                    // Mouse left the panel (leave event sends -1,-1).
+                    None
+                } else {
+                    let layout = engine.sc_panel_layout.borrow();
+                    layout.as_ref().map(|l| l.hit_test(mx as f32, my as f32))
+                };
+
                 let old = engine.sc_button_hovered;
-                if mx < 0.0 || my < btn_top || my >= btn_bottom {
-                    engine.sc_button_hovered = None;
-                } else {
-                    engine.sc_button_hovered = engine.sc_button_hit(mx as f32, my as f32);
-                }
-                if engine.sc_button_hovered != old {
-                    drop(engine);
-                    if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
-                        da.queue_draw();
+                match hit {
+                    Some(quadraui::SidebarPanelHit::ToolbarButton(_))
+                    | Some(quadraui::SidebarPanelHit::ToolbarEmpty) => {
+                        engine.sc_button_hovered = engine.sc_button_hit(mx as f32, my as f32);
+                        engine.dismiss_panel_hover();
                     }
-                } else {
-                    // Panel hover dwell tracking for SC items.
-                    let item_height = (lh * 1.4).round();
-                    let btn_pad = gap;
-                    let section_top = btn_bottom + btn_pad;
-                    if mx >= 0.0 && my >= section_top {
-                        // Accumulator walk matching draw_source_control_panel layout.
+                    Some(quadraui::SidebarPanelHit::Content { y: content_y, .. }) => {
+                        engine.sc_button_hovered = None;
+                        // Walk sections within the content area using content-local y.
+                        // content_y is in pixels relative to content_bounds.y.
+                        let item_height = (lh * 1.4).round();
                         let staged_count = engine
                             .sc_file_statuses
                             .iter()
@@ -8112,11 +8120,12 @@ impl App {
                         let wt_count = engine.sc_worktrees.len();
                         let log_count = engine.sc_log.len();
 
-                        let mut y_off = section_top;
+                        let my_local = content_y as f64;
+                        let mut y_off = 0.0f64;
                         let mut flat_idx = 0usize;
                         let mut hit_flat: Option<usize> = None;
 
-                        // Walk each section: header(lh) + items(item_height) if expanded
+                        // Walk each section: header(lh) + items(item_height) if expanded.
                         struct Section {
                             count: usize,
                             expanded: bool,
@@ -8132,8 +8141,7 @@ impl App {
                             },
                         ];
                         for sec in &sections {
-                            // Header
-                            if my >= y_off && my < y_off + lh {
+                            if my_local >= y_off && my_local < y_off + lh {
                                 hit_flat = Some(flat_idx);
                                 break;
                             }
@@ -8141,7 +8149,7 @@ impl App {
                             flat_idx += 1;
                             if sec.expanded {
                                 for _ in 0..sec.count {
-                                    if my >= y_off && my < y_off + item_height {
+                                    if my_local >= y_off && my_local < y_off + item_height {
                                         hit_flat = Some(flat_idx);
                                         break;
                                     }
@@ -8154,15 +8162,14 @@ impl App {
                             }
                         }
                         if hit_flat.is_none() && show_worktrees {
-                            // Worktrees header
-                            if my >= y_off && my < y_off + lh {
+                            if my_local >= y_off && my_local < y_off + lh {
                                 hit_flat = Some(flat_idx);
                             }
                             y_off += lh;
                             flat_idx += 1;
                             if hit_flat.is_none() && engine.sc_sections_expanded[2] {
                                 for _ in 0..wt_count {
-                                    if my >= y_off && my < y_off + item_height {
+                                    if my_local >= y_off && my_local < y_off + item_height {
                                         hit_flat = Some(flat_idx);
                                         break;
                                     }
@@ -8172,15 +8179,14 @@ impl App {
                             }
                         }
                         if hit_flat.is_none() {
-                            // Log header
-                            if my >= y_off && my < y_off + lh {
+                            if my_local >= y_off && my_local < y_off + lh {
                                 hit_flat = Some(flat_idx);
                             }
                             y_off += lh;
                             flat_idx += 1;
                             if hit_flat.is_none() && engine.sc_sections_expanded[3] {
                                 for _ in 0..log_count {
-                                    if my >= y_off && my < y_off + item_height {
+                                    if my_local >= y_off && my_local < y_off + item_height {
                                         hit_flat = Some(flat_idx);
                                         break;
                                     }
@@ -8189,6 +8195,7 @@ impl App {
                                 }
                             }
                         }
+                        let _ = (y_off, flat_idx); // loop accumulators only
 
                         if let Some(fi) = hit_flat {
                             if engine.panel_hover_mouse_move("source_control", "", fi) {
@@ -8196,14 +8203,24 @@ impl App {
                                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
                                     da.queue_draw();
                                 }
+                                return;
                             }
                         } else {
                             engine.dismiss_panel_hover();
                         }
-                    } else if mx < 0.0 {
-                        // Mouse left the panel. Use delayed dismiss so the overlay's
-                        // motion controller can cancel it if the mouse enters the popup.
+                    }
+                    _ => {
+                        // Outside panel or mouse left — clear button hover and
+                        // dwell tracking.
+                        engine.sc_button_hovered = None;
                         engine.dismiss_panel_hover();
+                    }
+                }
+
+                if engine.sc_button_hovered != old {
+                    drop(engine);
+                    if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
+                        da.queue_draw();
                     }
                 }
             }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1576,6 +1576,10 @@ pub struct SourceControlData {
     pub branch_picker: Option<BranchPickerData>,
     /// SC help dialog visible.
     pub help_open: bool,
+    /// Y coordinate (in native units) where the sections area begins —
+    /// the top of `SidebarPanelLayout.content_bounds` from the last paint
+    /// (#509). TUI: terminal rows. GTK: pixels. `None` until first paint.
+    pub sc_sections_start_y: Option<f32>,
 }
 
 /// Data for the branch picker / create popup in the SC panel.
@@ -6445,6 +6449,11 @@ fn build_source_control_data(engine: &Engine) -> Option<SourceControlData> {
             None
         },
         help_open: engine.sc_help_open,
+        sc_sections_start_y: engine
+            .sc_panel_layout
+            .borrow()
+            .as_ref()
+            .map(|l| l.content_bounds.y),
     })
 }
 
@@ -6507,22 +6516,35 @@ pub fn sc_button_toolbar(sc: &SourceControlData) -> quadraui::Toolbar {
     }
 }
 
-/// Draw the SC action-button toolbar through backend `b` and cache its
-/// layout on `engine` for click/hover dispatch (#505). Both backends call
-/// this inside their frame scope; the only per-backend input is `rect`
-/// (cell units for TUI, pixels for GTK). Keyboard focus → pressed_id,
-/// mouse hover → hovered_id.
-pub fn draw_sc_button_toolbar(
+/// Build the SC `SidebarPanel` — a `quadraui::SidebarPanel` wrapping the
+/// action-button toolbar as its header slot (#509). `toolbar_height: None`
+/// defers to each backend's idiomatic default (1 cell TUI, `line_height` GTK).
+pub fn sc_sidebar_panel(sc: &SourceControlData) -> quadraui::SidebarPanel {
+    use quadraui::{SidebarPanel, WidgetId};
+    SidebarPanel {
+        id: WidgetId::new("sc:panel"),
+        toolbar: Some(sc_button_toolbar(sc)),
+        toolbar_height: None,
+    }
+}
+
+/// Draw the SC bottom slab (toolbar + sections) through backend `b` and
+/// cache the full `SidebarPanelLayout` on `engine` for click/hover dispatch
+/// (#509). `rect` covers the "bottom slab" — from just below the commit input
+/// to the bottom of the panel. Both backends call this inside their frame
+/// scope; section rendering then reads `content_bounds` from the cached
+/// layout. Keyboard focus → pressed_id, mouse hover → hovered_id.
+pub fn draw_sc_sidebar_panel(
     b: &mut dyn quadraui::Backend,
     engine: &Engine,
     sc: &SourceControlData,
     rect: quadraui::Rect,
 ) {
-    let bar = sc_button_toolbar(sc);
+    let panel = sc_sidebar_panel(sc);
     let hovered = sc.button_hovered.and_then(Engine::sc_button_id);
     let pressed = sc.button_focused.and_then(Engine::sc_button_id);
-    let layout = b.draw_toolbar(rect, &bar, hovered.as_ref(), pressed.as_ref());
-    engine.sc_button_layout.replace(Some(layout));
+    let layout = b.draw_sidebar_panel(rect, &panel, hovered.as_ref(), pressed.as_ref());
+    engine.sc_panel_layout.replace(Some(layout));
 }
 
 pub fn source_control_to_tree_view(sc: &SourceControlData, theme: &Theme) -> quadraui::TreeView {
@@ -12750,6 +12772,7 @@ mod tests {
             button_hovered: None,
             branch_picker: None,
             help_open: false,
+            sc_sections_start_y: None,
         }
     }
 
@@ -12844,6 +12867,90 @@ mod tests {
             layout.hit_test(commit.bounds.x + 0.5, commit.bounds.y),
             ToolbarHit::Empty
         );
+    }
+
+    // ─── SC SidebarPanel tests (#509) ────────────────────────────────────────
+
+    #[test]
+    fn test_sc_sidebar_panel_toolbar_slot_reserved_at_top() {
+        use quadraui::{primitives::toolbar::ToolbarItemMeasure, SidebarPanelMeasure};
+
+        let sc = empty_sc_data();
+        let panel = sc_sidebar_panel(&sc);
+        // TUI default: toolbar_height = 1 cell, item_width = 8 cells.
+        let area = quadraui::Rect::new(0.0, 5.0, 60.0, 20.0);
+        let measure = SidebarPanelMeasure::new(1.0, 8.0);
+        let layout = panel.layout(area, measure, |_| ToolbarItemMeasure::new(8.0));
+
+        // Toolbar slot is reserved at the top.
+        let tb = layout.toolbar_bounds.expect("toolbar slot reserved");
+        assert_eq!(tb.y, 5.0, "toolbar slot starts at panel top");
+        assert_eq!(tb.height, 1.0, "TUI default toolbar height = 1 cell");
+        // Content starts immediately below toolbar slot (no padding — option a).
+        assert_eq!(
+            layout.content_bounds.y, 6.0,
+            "content starts at toolbar_y + 1"
+        );
+        assert_eq!(
+            layout.content_bounds.height, 19.0,
+            "content height = panel_height - 1"
+        );
+    }
+
+    #[test]
+    fn test_sc_sidebar_panel_hit_test_resolves_toolbar_button_and_content() {
+        use crate::core::engine::Engine;
+        use quadraui::{
+            primitives::toolbar::ToolbarItemMeasure, SidebarPanelHit, SidebarPanelMeasure,
+        };
+
+        let mut sc = empty_sc_data();
+        sc.commit_message = "feat: fix".into(); // non-empty → Commit enabled
+        let panel = sc_sidebar_panel(&sc);
+        let area = quadraui::Rect::new(0.0, 0.0, 60.0, 10.0);
+        let measure = SidebarPanelMeasure::new(1.0, 8.0);
+        let layout = panel.layout(area, measure, |_| ToolbarItemMeasure::new(8.0));
+
+        // A hit in the toolbar slot (y=0, which is the toolbar row) on a button.
+        let hit = layout.hit_test(0.5, 0.0);
+        match hit {
+            SidebarPanelHit::ToolbarButton(id) => {
+                assert_eq!(
+                    Engine::sc_button_index(&id),
+                    Some(0),
+                    "first button = Commit"
+                );
+            }
+            other => panic!("expected ToolbarButton hit, got {other:?}"),
+        }
+
+        // A hit in the content area (y=2, content starts at y=1) returns content-local coords.
+        let hit = layout.hit_test(5.0, 2.0);
+        match hit {
+            SidebarPanelHit::Content { x, y } => {
+                assert_eq!(x, 5.0);
+                assert_eq!(y, 1.0, "content-local y = abs_y - content_bounds.y = 2-1");
+            }
+            other => panic!("expected Content hit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_sc_sidebar_panel_content_bounds_height() {
+        use quadraui::{primitives::toolbar::ToolbarItemMeasure, SidebarPanelMeasure};
+
+        let sc = empty_sc_data();
+        let panel = sc_sidebar_panel(&sc);
+        // Simulate a 15-row panel starting at y=3 (e.g. after 3 header/commit rows).
+        let area = quadraui::Rect::new(0.0, 3.0, 40.0, 15.0);
+        let measure = SidebarPanelMeasure::new(1.0, 8.0);
+        let layout = panel.layout(area, measure, |_| ToolbarItemMeasure::new(8.0));
+
+        assert_eq!(
+            layout.content_bounds.height, 14.0,
+            "content = panel_height(15) - toolbar_slot(1)"
+        );
+        assert_eq!(layout.content_bounds.y, 4.0, "content starts at y=3+1=4");
     }
 
     // ─── Debug toolbar tests (#510) ──────────────────────────────────────────

--- a/src/tui_main/mouse.rs
+++ b/src/tui_main/mouse.rs
@@ -1639,32 +1639,42 @@ pub(super) fn handle_mouse(
 
     // ── SC button hover (mouse moved) ───────────────────────────────────────
     if matches!(ev.kind, MouseEventKind::Moved) {
-        let menu_rows: u16 = if engine.menu_bar_visible { 1 } else { 0 };
         if sb_visible
             && engine.active_panel_is(PANEL_GIT)
             && col >= ab_width
             && col < ab_width + sidebar_width
         {
-            let sidebar_row = row.saturating_sub(menu_rows);
-            let commit_rows = engine.sc_commit_message.split('\n').count().max(1) as u16;
-            let btn_row = 1 + commit_rows + 1; // header + commit + pad_above
-            if sidebar_row == btn_row {
-                engine.sc_button_hovered = engine.sc_button_hit(col as f32, row as f32);
-            } else {
-                engine.sc_button_hovered = None;
-                // SC item hover dwell tracking (sections area).
-                let section_start = 4 + commit_rows; // btn + pad_below + 1
-                if sidebar_row >= section_start {
-                    let adjusted = sidebar_row - section_start + 3;
+            // Route via cached SidebarPanelLayout (#509) — no per-frame
+            // arithmetic; hit_test uses absolute terminal coordinates.
+            let hit = {
+                let layout = engine.sc_panel_layout.borrow();
+                layout.as_ref().map(|l| l.hit_test(col as f32, row as f32))
+            };
+            match hit {
+                Some(quadraui::SidebarPanelHit::ToolbarButton(_))
+                | Some(quadraui::SidebarPanelHit::ToolbarEmpty) => {
+                    engine.sc_button_hovered = engine.sc_button_hit(col as f32, row as f32);
+                    if !mouse_on_hover_popup {
+                        engine.dismiss_panel_hover();
+                    }
+                }
+                Some(quadraui::SidebarPanelHit::Content { y: content_y, .. }) => {
+                    engine.sc_button_hovered = None;
+                    // content_y is content-local (row 0 = first section row).
+                    let content_row = content_y as usize;
                     if let Some((flat_idx, _is_header)) =
-                        engine.sc_visual_row_to_flat(adjusted as usize, true)
+                        engine.sc_content_row_to_flat(content_row, true)
                     {
                         engine.panel_hover_mouse_move("source_control", "", flat_idx);
                     } else if !mouse_on_hover_popup {
                         engine.dismiss_panel_hover();
                     }
-                } else if !mouse_on_hover_popup {
-                    engine.dismiss_panel_hover();
+                }
+                _ => {
+                    engine.sc_button_hovered = None;
+                    if !mouse_on_hover_popup {
+                        engine.dismiss_panel_hover();
+                    }
                 }
             }
         } else {
@@ -2367,47 +2377,55 @@ pub(super) fn handle_mouse(
             sidebar.has_focus = true;
             engine.sc_set_focus(true);
 
-            // sidebar_row layout:
-            //   0 = header
-            //   1 .. commit_rows = commit input
-            //   1+commit_rows = pad above
-            //   2+commit_rows = button row
-            //   3+commit_rows = pad below
-            //   4+commit_rows .. = sections (rendered by SidebarSystem)
+            // sidebar_row layout after #509 (option a, no padding):
+            //   0               = header
+            //   1 .. commit_end = commit input
+            //   commit_end      = toolbar slot (button row, SidebarPanel)
+            //   commit_end+1 .. = sections (SidebarPanel content area)
             let commit_rows = engine.sc_commit_message.split('\n').count().max(1) as u16;
             let commit_end = 1 + commit_rows;
-            let btn_row = 2 + commit_rows;
-            let section_start = 4 + commit_rows;
+
             if sidebar_row == 0 {
                 engine.sc_commit_input_active = false;
             } else if sidebar_row >= 1 && sidebar_row < commit_end {
                 engine.sc_commit_input_active = true;
                 engine.sc_commit_cursor = engine.sc_commit_message.len();
-            } else if sidebar_row == btn_row {
+            } else {
+                // Route via cached SidebarPanelLayout (#509).
                 engine.sc_commit_input_active = false;
-                if let Some(idx) = engine.sc_button_hit(col as f32, row as f32) {
-                    engine.sc_activate_button(idx);
-                }
-            } else if sidebar_row >= section_start {
-                engine.sc_commit_input_active = false;
-                let click_ev = quadraui::UiEvent::MouseDown {
-                    widget: None,
-                    button: quadraui::MouseButton::Left,
-                    position: quadraui::Point::new(col as f32, row as f32),
-                    modifiers: quadraui::Modifiers::default(),
+                let hit = {
+                    let layout = engine.sc_panel_layout.borrow();
+                    layout.as_ref().map(|l| l.hit_test(col as f32, row as f32))
                 };
-                engine.handle_sc_sidebar_ui_event(click_ev);
-                let now = Instant::now();
-                let is_double = now.duration_since(*last_click_time) < Duration::from_millis(400)
-                    && *last_click_pos == (col, row);
-                *last_click_time = now;
-                *last_click_pos = (col, row);
-                if is_double {
-                    let double_ev = quadraui::UiEvent::DoubleClick {
-                        widget: None,
-                        position: quadraui::Point::new(col as f32, row as f32),
-                    };
-                    engine.handle_sc_sidebar_ui_event(double_ev);
+                match hit {
+                    Some(quadraui::SidebarPanelHit::ToolbarButton(_)) => {
+                        if let Some(idx) = engine.sc_button_hit(col as f32, row as f32) {
+                            engine.sc_activate_button(idx);
+                        }
+                    }
+                    Some(quadraui::SidebarPanelHit::Content { .. }) => {
+                        let click_ev = quadraui::UiEvent::MouseDown {
+                            widget: None,
+                            button: quadraui::MouseButton::Left,
+                            position: quadraui::Point::new(col as f32, row as f32),
+                            modifiers: quadraui::Modifiers::default(),
+                        };
+                        engine.handle_sc_sidebar_ui_event(click_ev);
+                        let now = Instant::now();
+                        let is_double = now.duration_since(*last_click_time)
+                            < Duration::from_millis(400)
+                            && *last_click_pos == (col, row);
+                        *last_click_time = now;
+                        *last_click_pos = (col, row);
+                        if is_double {
+                            let double_ev = quadraui::UiEvent::DoubleClick {
+                                widget: None,
+                                position: quadraui::Point::new(col as f32, row as f32),
+                            };
+                            engine.handle_sc_sidebar_ui_event(double_ev);
+                        }
+                    }
+                    _ => {}
                 }
             }
             return sidebar_width;

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -851,32 +851,38 @@ pub(super) fn render_source_control(
         }
     }
 
-    if area.height < 2 + commit_rows + 3 {
+    if area.height < 1 + commit_rows + 2 {
         return;
     }
 
-    // ── Button row (after commit input, with 1 row padding above and below) ──
+    // ── Bottom slab: toolbar slot + sections via SidebarPanel (#509) ──────────
+    // Passes the entire remaining area (just below commit input) to
+    // draw_sc_sidebar_panel, which reserves one toolbar-height row for the
+    // button row and returns content_bounds for the sections below. No
+    // per-side padding rows — option (a) from the issue: tighter layout,
+    // zero manual arithmetic.
     {
-        let pad_above = area.y + 1 + commit_rows;
-        let btn_y = pad_above + 1;
-        let pad_below = btn_y + 1;
-
-        // Clear padding rows.
-        for px in area.x..area.x + area.width {
-            set_cell(buf, px, pad_above, ' ', dim_fg, row_bg);
-            set_cell(buf, px, pad_below, ' ', dim_fg, row_bg);
-        }
-
-        // Action buttons via quadraui::Toolbar (#505) — shared builder paints
-        // both backends and caches the layout for click/hover hit-testing.
-        let btn_rect = quadraui::Rect::new(area.x as f32, btn_y as f32, area.width as f32, 1.0);
+        let slab_y = area.y + 1 + commit_rows;
+        let slab_h = (area.y + area.height).saturating_sub(slab_y);
+        let slab_rect = quadraui::Rect::new(
+            area.x as f32,
+            slab_y as f32,
+            area.width as f32,
+            slab_h as f32,
+        );
         backend.set_current_theme(super::quadraui_tui::q_theme(theme));
         backend.enter_frame_scope(frame, |b| {
-            render::draw_sc_button_toolbar(b, engine, sc, btn_rect);
+            render::draw_sc_sidebar_panel(b, engine, sc, slab_rect);
         });
     }
 
-    let section_start_y = area.y + 4 + commit_rows; // +2 for padding rows, +1 for btn row, +1 for next
+    // Read section-area origin from the cached layout.
+    let section_start_y = {
+        let l = engine.sc_panel_layout.borrow();
+        l.as_ref()
+            .map(|l| l.content_bounds.y as u16)
+            .unwrap_or(area.y + 2 + commit_rows) // fallback: btn row + 1
+    };
     if section_start_y >= area.y + area.height {
         return;
     }
@@ -1361,7 +1367,16 @@ pub(super) fn render_panel_hover_popup(
 
     // Vertically align with the hovered item.
     let item_row = if ph.panel_name == "source_control" {
-        let section_start: u16 = 5;
+        // Derive section_start from the cached SidebarPanelLayout (#509):
+        // content_bounds.y (absolute terminal row) minus sidebar_y gives the
+        // sidebar-relative row where sections begin. Falls back to 2 (header +
+        // btn, option-a layout) if the layout hasn't been populated yet.
+        let section_start = screen
+            .source_control
+            .as_ref()
+            .and_then(|sc| sc.sc_sections_start_y)
+            .map(|y| (y as u16).saturating_sub(sidebar_y))
+            .unwrap_or(2u16);
         section_start + ph.item_index as u16
     } else {
         ph.item_index as u16 + 1


### PR DESCRIPTION
Closes #509

Automated merge from the coordinator for assignment de6d6dbab05f on issue #509.

Worker branch: `issue-509-tui-gtk-adopt-quadraui-sidebarpanel-for` → `develop`.