### PR TITLE
#494: GTK activity bar keyboard focus path (TUI parity)

### DIFF
--- a/src/core/engine/accessors.rs
+++ b/src/core/engine/accessors.rs
@@ -572,7 +572,7 @@ impl Engine {
             || self.activity_bar_focused
     }
 
-    /// Clear all sidebar panel focus flags at once.
+    /// Clear all sidebar panel focus flags at once, including the activity bar.
     pub fn clear_sidebar_focus(&mut self) {
         self.explorer_has_focus = false;
         self.search_has_focus = false;
@@ -582,6 +582,7 @@ impl Engine {
         self.ai_has_focus = false;
         self.settings_has_focus = false;
         self.ext_panel_has_focus = false;
+        self.activity_bar_focused = false;
     }
 
     /// Returns true if any user-focused modal popup is currently open

--- a/src/core/engine/ext_panel.rs
+++ b/src/core/engine/ext_panel.rs
@@ -239,6 +239,18 @@ impl Engine {
             "q" | "Escape" => {
                 self.ext_panel_has_focus = false;
             }
+            "h" | "Left" => {
+                // Leave this panel and focus the activity bar at the matching row.
+                // Uses the same sorted-index mapping as the activity bar primitive.
+                let mut ext_names: Vec<_> = self.ext_panels.keys().cloned().collect();
+                ext_names.sort();
+                let idx = ext_names
+                    .iter()
+                    .position(|n| self.ext_panel_active.as_deref() == Some(n.as_str()))
+                    .unwrap_or(0);
+                self.ext_panel_has_focus = false;
+                self.activity_bar_focus_in_at(8 + idx as u16);
+            }
             "j" | "Down" => {
                 let max = self.ext_panel_flat_len();
                 if max > 0 && self.ext_panel_selected + 1 < max {

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -16439,6 +16439,7 @@ fn test_clear_sidebar_focus() {
     engine.ai_has_focus = true;
     engine.settings_has_focus = true;
     engine.ext_panel_has_focus = true;
+    engine.activity_bar_focused = true;
     assert!(engine.sidebar_has_focus());
 
     engine.clear_sidebar_focus();
@@ -16451,6 +16452,7 @@ fn test_clear_sidebar_focus() {
     assert!(!engine.ai_has_focus);
     assert!(!engine.settings_has_focus);
     assert!(!engine.ext_panel_has_focus);
+    assert!(!engine.activity_bar_focused);
 }
 
 #[test]

--- a/src/core/engine/tests.rs
+++ b/src/core/engine/tests.rs
@@ -27292,6 +27292,68 @@ fn test_activity_bar_resolve_extension_panels() {
     assert_eq!(resolve_activity_bar_click(9, 30, &ext_names), None);
 }
 
+#[test]
+fn test_ext_panel_h_focuses_activity_bar() {
+    use crate::core::plugin::PanelRegistration;
+    let mut engine = Engine::new();
+    // Register two ext panels (sorted: "alpha", "beta").
+    engine.ext_panels.insert(
+        "beta".to_string(),
+        PanelRegistration {
+            name: "beta".to_string(),
+            title: "Beta".to_string(),
+            icon: 'B',
+            fallback_icon: None,
+            sections: vec![],
+        },
+    );
+    engine.ext_panels.insert(
+        "alpha".to_string(),
+        PanelRegistration {
+            name: "alpha".to_string(),
+            title: "Alpha".to_string(),
+            icon: 'A',
+            fallback_icon: None,
+            sections: vec![],
+        },
+    );
+    // Simulate "beta" ext panel being focused (sorted index 1 → toolbar idx 9).
+    engine.ext_panel_has_focus = true;
+    engine.ext_panel_active = Some("beta".to_string());
+
+    engine.handle_ext_panel_key("h", false, None);
+
+    assert!(!engine.ext_panel_has_focus, "ext_panel_has_focus should be cleared");
+    assert!(engine.activity_bar_focused, "activity_bar_focused should be set");
+    // "beta" is sorted index 1 (["alpha", "beta"]) → toolbar index 9.
+    assert_eq!(engine.activity_bar_selected, 9, "toolbar index should be 8 + sorted_idx");
+}
+
+#[test]
+fn test_ext_panel_left_focuses_activity_bar() {
+    use crate::core::plugin::PanelRegistration;
+    let mut engine = Engine::new();
+    // Register one ext panel (sorted index 0 → toolbar idx 8).
+    engine.ext_panels.insert(
+        "mypanel".to_string(),
+        PanelRegistration {
+            name: "mypanel".to_string(),
+            title: "My Panel".to_string(),
+            icon: 'M',
+            fallback_icon: None,
+            sections: vec![],
+        },
+    );
+    engine.ext_panel_has_focus = true;
+    engine.ext_panel_active = Some("mypanel".to_string());
+
+    engine.handle_ext_panel_key("Left", false, None);
+
+    assert!(!engine.ext_panel_has_focus);
+    assert!(engine.activity_bar_focused);
+    assert_eq!(engine.activity_bar_selected, 8);
+}
+
 // --- Context menu hit regions ---
 
 #[test]

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -9423,12 +9423,17 @@ impl App {
             }
             ExplorerKeyResult::FocusToolbar => {
                 // engine.activity_bar_focus_in_at(1) was already called inside
-                // dispatch_explorer_key. Grab GTK focus on the activity bar DA
-                // so the visual highlight is shown and key events route there.
+                // dispatch_explorer_key. Redraw the activity bar for the
+                // selection highlight; key events route through the editor DA
+                // whose handle_key_press checks activity_bar_focused and
+                // dispatches to handle_activity_bar_key. The activity bar DA
+                // has no EventControllerKey, so grab_focus on it drops keys.
                 self.engine.borrow_mut().explorer_has_focus = false;
                 if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                    da.grab_focus();
                     da.queue_draw();
+                }
+                if let Some(ref da) = *self.drawing_area.borrow() {
+                    da.grab_focus();
                 }
             }
             _ => {}
@@ -9443,18 +9448,29 @@ impl App {
         }
     }
 
-    /// After a sidebar panel processes a key, redirect GTK focus to the
-    /// activity bar DA if the engine just set `activity_bar_focused`, otherwise
-    /// fall back to the normal editor-focus logic.
+    /// After a sidebar panel processes a key, queue a redraw of the activity
+    /// bar if the engine just set `activity_bar_focused`, and in all cases
+    /// give GTK widget focus to the editor DA so its `handle_key_press` can
+    /// route the next key via engine flags (`activity_bar_focused`,
+    /// `ext_panel_has_focus`, …).
     ///
-    /// `fallback_focused` is the "panel still has focus" flag that would
-    /// normally be passed to `focus_editor_if_needed`.
+    /// Why the editor DA, not the activity bar DA?  The activity bar DA has
+    /// no `EventControllerKey`; routing GTK focus there drops subsequent key
+    /// events.  The editor DA's capture-phase controller checks engine focus
+    /// flags and dispatches to `handle_activity_bar_key` when needed — the
+    /// same engine-flag routing that the TUI backend uses.
+    ///
+    /// `fallback_focused` is the "panel still has focus" flag passed through
+    /// to `focus_editor_if_needed` when neither activity-bar nor editor focus
+    /// applies (i.e. the sidebar panel kept focus → don't steal it).
     fn focus_after_sidebar_key(&self, fallback_focused: bool) {
         if self.engine.borrow().activity_bar_focused {
+            // Activity bar has logical focus — redraw it for the keyboard-
+            // selection highlight. Key routing flows through the editor DA.
             if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                da.grab_focus();
                 da.queue_draw();
             }
+            self.focus_editor_if_needed(false);
         } else {
             self.focus_editor_if_needed(fallback_focused);
         }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -5434,7 +5434,8 @@ impl App {
                 let still_focused = engine.ext_panel_has_focus;
                 let has_dialog = engine.dialog.is_some();
                 drop(engine);
-                self.focus_editor_if_needed(still_focused && !has_dialog);
+                // h/Left moves focus to the activity bar; other exits go to the editor.
+                self.focus_after_sidebar_key(still_focused && !has_dialog);
                 if let Some(ref da) = *self.ext_dyn_panel_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -5503,7 +5504,7 @@ impl App {
                 }
                 let still_focused = engine.search_has_focus;
                 drop(engine);
-                self.focus_editor_if_needed(still_focused);
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.search_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -8617,7 +8617,7 @@ impl App {
                     engine.handle_ext_panel_key(mapped, false, unicode);
                     let still_focused = engine.ext_panel_has_focus;
                     drop(engine);
-                    self.focus_editor_if_needed(still_focused);
+                    self.focus_after_sidebar_key(still_focused);
                 }
                 self.sync_plus_register_to_clipboard();
                 if let Some(ref da) = *self.ext_dyn_panel_da_ref.borrow() {

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -576,6 +576,11 @@ fn build_gtk_activity_bar_primitive(
             theme.cursor.g,
             theme.cursor.b,
         )),
+        // Signals to the quadraui GTK backend that this bar owns the
+        // keyboard.  The backend's draw_activity_bar impl records the bar ID
+        // in GtkBackend::focused_activity_bar so window-level key events can
+        // be converted to ActivityBarEvent::KeyPressed (Q#368).
+        is_keyboard_focused: engine.activity_bar_focused,
     }
 }
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -5451,16 +5451,8 @@ impl App {
                 }
                 let still_focused = engine.ext_sidebar_has_focus;
                 let has_dialog = engine.dialog.is_some();
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused && !has_dialog);
-                }
+                self.focus_after_sidebar_key(still_focused && !has_dialog);
                 if let Some(ref da) = *self.ext_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -5476,16 +5468,8 @@ impl App {
                 }
                 let still_focused = engine.settings_has_focus;
                 let has_dialog = engine.dialog.is_some();
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused && !has_dialog);
-                }
+                self.focus_after_sidebar_key(still_focused && !has_dialog);
                 if let Some(ref da) = *self.settings_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -5534,16 +5518,8 @@ impl App {
                     engine.dispatch_sc_sidebar_key_unified(mapped, ctrl, sc_unicode);
                 }
                 let still_focused = engine.sc_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -5573,16 +5549,8 @@ impl App {
                     }
                 }
                 let still_focused = engine.dap_sidebar_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.debug_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -5596,16 +5564,8 @@ impl App {
                     engine.handle_ai_panel_key(&key_name, ctrl, unicode);
                 }
                 let still_focused = engine.ai_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.ai_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -8011,16 +7971,8 @@ impl App {
                     engine.dispatch_dap_sidebar_action_key(mapped);
                 }
                 let still_focused = engine.dap_sidebar_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.debug_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -8320,16 +8272,8 @@ impl App {
                 let (mapped, unicode) = map_gtk_key_with_unicode(key_name.as_str());
                 engine.dispatch_sc_sidebar_key_unified(mapped, ctrl, unicode);
                 let still_focused = engine.sc_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.git_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -8416,16 +8360,8 @@ impl App {
                 engine.dispatch_ext_sidebar_key_unified(mapped, unicode);
                 let still_focused = engine.ext_sidebar_has_focus;
                 let has_dialog = engine.dialog.is_some();
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused && !has_dialog);
-                }
+                self.focus_after_sidebar_key(still_focused && !has_dialog);
                 if let Some(ref da) = *self.ext_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -8493,16 +8429,8 @@ impl App {
                     engine.handle_settings_key(mapped, ctrl, unicode);
                 }
                 let still_focused = engine.settings_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.settings_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -8928,16 +8856,8 @@ impl App {
                 let mut engine = self.engine.borrow_mut();
                 engine.handle_ai_panel_key(&key_name, ctrl, unicode);
                 let still_focused = engine.ai_has_focus;
-                let ab_focused = engine.activity_bar_focused;
                 drop(engine);
-                if ab_focused {
-                    if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
-                        da.grab_focus();
-                        da.queue_draw();
-                    }
-                } else {
-                    self.focus_editor_if_needed(still_focused);
-                }
+                self.focus_after_sidebar_key(still_focused);
                 if let Some(ref da) = *self.ai_sidebar_da_ref.borrow() {
                     da.queue_draw();
                 }
@@ -9519,6 +9439,23 @@ impl App {
     fn queue_explorer_draw(&self) {
         if let Some(ref da) = *self.explorer_sidebar_da_ref.borrow() {
             da.queue_draw();
+        }
+    }
+
+    /// After a sidebar panel processes a key, redirect GTK focus to the
+    /// activity bar DA if the engine just set `activity_bar_focused`, otherwise
+    /// fall back to the normal editor-focus logic.
+    ///
+    /// `fallback_focused` is the "panel still has focus" flag that would
+    /// normally be passed to `focus_editor_if_needed`.
+    fn focus_after_sidebar_key(&self, fallback_focused: bool) {
+        if self.engine.borrow().activity_bar_focused {
+            if let Some(ref da) = *self.activity_bar_da_ref.borrow() {
+                da.grab_focus();
+                da.queue_draw();
+            }
+        } else {
+            self.focus_editor_if_needed(fallback_focused);
         }
     }
 

--- a/src/tui_main/mod.rs
+++ b/src/tui_main/mod.rs
@@ -1987,24 +1987,6 @@ fn event_loop(
 
                     // ── Extension panel (plugin-provided) keyboard handling ─
                     if engine.ext_panel_has_focus && sidebar.ext_panel_name.is_some() {
-                        // h/Left: switch focus to activity bar toolbar.
-                        // (engine.activity_bar_focus_in_at is called inside handle_ext_panel_key)
-                        if matches!(key_event.code, KeyCode::Char('h') | KeyCode::Left)
-                            && !key_event.modifiers.contains(KeyModifiers::CONTROL)
-                        {
-                            // Find the toolbar row index for this ext panel.
-                            let mut ext_names: Vec<_> = engine.ext_panels.keys().cloned().collect();
-                            ext_names.sort();
-                            let idx = ext_names
-                                .iter()
-                                .position(|n| Some(n) == sidebar.ext_panel_name.as_ref())
-                                .unwrap_or(0);
-                            sidebar.has_focus = false;
-                            engine.ext_panel_has_focus = false;
-                            engine.activity_bar_focus_in_at(8 + idx as u16);
-                            needs_redraw = true;
-                            continue;
-                        }
                         // When the input field is active, pass characters as
                         // input text instead of navigation commands.
                         if engine.ext_panel_input_active {
@@ -2026,9 +2008,12 @@ fn event_loop(
                             needs_redraw = true;
                             continue;
                         }
+                        // h/Left: engine sets activity_bar_focused via handle_ext_panel_key.
                         let (key_name, unicode): (&str, Option<char>) = match key_event.code {
                             KeyCode::Char('j') | KeyCode::Down => ("j", None),
                             KeyCode::Char('k') | KeyCode::Up => ("k", None),
+                            KeyCode::Char('h') => ("h", None),
+                            KeyCode::Left => ("Left", None),
                             KeyCode::Char('g') => ("g", None),
                             KeyCode::Char('G') => ("G", None),
                             KeyCode::Tab => ("Tab", None),
@@ -2047,7 +2032,11 @@ fn event_loop(
                             engine.handle_ext_panel_key(&name, ctrl, ch);
                             if !engine.ext_panel_has_focus {
                                 sidebar.has_focus = false;
-                                sidebar.ext_panel_name = None;
+                                // Keep ext_panel_name when focus moved to activity bar
+                                // (the ext panel remains visible while the toolbar cursor shows).
+                                if !engine.activity_bar_focused {
+                                    sidebar.ext_panel_name = None;
+                                }
                             }
                         }
                         needs_redraw = true;

--- a/src/tui_main/panels.rs
+++ b/src/tui_main/panels.rs
@@ -113,6 +113,10 @@ fn build_activity_bar_primitive(
             theme.cursor.g,
             theme.cursor.b,
         )),
+        // Signals to the quadraui TUI backend that this bar owns the
+        // keyboard so it intercepts KeyPressed as ActivityBarEvent::KeyPressed
+        // (Q#368 protocol).
+        is_keyboard_focused: engine.activity_bar_focused,
     }
 }
 


### PR DESCRIPTION
Completes #494 — GTK activity-bar keyboard focus, lifted to the engine for TUI parity.

The keyboard-focus logic now lives in the engine (`handle_ext_panel_key` h/Left → activity bar), with both backends wired through the quadraui #368 `is_keyboard_focused` protocol. The GTK side replaces ~8 copies of the per-panel `grab_focus(activity_bar_da)` block with a single `focus_after_sidebar_key()` helper that routes keys through the editor DA (which owns the key controller) — fixing the root bug where grabbing focus on the activity-bar DA silenced the editor's key handler.

**Provenance:** adversarial review = approve; interactive smoke test = passed (work `485cabf9e482`). This branch is the clean rebase of that approved work onto current `develop`; it supersedes the incomplete earlier cut merged via #519.

**Verified on rebase:** `cargo test --no-default-features` EXIT=0 (incl. new engine tests `test_ext_panel_h_focuses_activity_bar`, `test_ext_panel_left_focuses_activity_bar`); `cargo check --features gui` EXIT=0 against current develop + quadraui #368.